### PR TITLE
feat: add executionContext object on context

### DIFF
--- a/sdk/src/main/java/com/amazonaws/lambda/durable/DurableContext.java
+++ b/sdk/src/main/java/com/amazonaws/lambda/durable/DurableContext.java
@@ -27,6 +27,7 @@ public class DurableContext {
     private final Context lambdaContext;
     private final AtomicInteger operationCounter;
     private final DurableLogger logger;
+    private final ExecutionContext executionContext;
 
     DurableContext(
             ExecutionManager executionManager,
@@ -38,6 +39,7 @@ public class DurableContext {
         this.serDes = serDes;
         this.lambdaContext = lambdaContext;
         this.operationCounter = new AtomicInteger(0);
+        this.executionContext = new ExecutionContext(executionManager.getDurableExecutionArn());
 
         var requestId = lambdaContext != null ? lambdaContext.getAwsRequestId() : null;
         this.logger = new DurableLogger(
@@ -152,6 +154,19 @@ public class DurableContext {
 
     public DurableLogger getLogger() {
         return logger;
+    }
+
+    /**
+     * Returns metadata about the current durable execution.
+     *
+     * <p>The execution context provides information that remains constant throughout the execution lifecycle, such as
+     * the durable execution ARN. This is useful for tracking execution progress, correlating logs, and referencing
+     * this execution in external systems.
+     *
+     * @return the execution context
+     */
+    public ExecutionContext getExecutionContext() {
+        return executionContext;
     }
 
     // ========== createCallback methods ==========

--- a/sdk/src/main/java/com/amazonaws/lambda/durable/ExecutionContext.java
+++ b/sdk/src/main/java/com/amazonaws/lambda/durable/ExecutionContext.java
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazonaws.lambda.durable;
+
+/**
+ * Provides metadata about the current durable execution.
+ *
+ * <p>This context contains information about the execution environment that remains constant throughout the execution
+ * lifecycle. Access it via {@link DurableContext#getExecutionContext()}.
+ */
+public class ExecutionContext {
+    private final String durableExecutionArn;
+
+    ExecutionContext(String durableExecutionArn) {
+        this.durableExecutionArn = durableExecutionArn;
+    }
+
+    /**
+     * Returns the ARN of the current durable execution.
+     *
+     * <p>The durable execution ARN uniquely identifies this execution instance and remains constant across all
+     * invocations and replays. Use this ARN to:
+     *
+     * <ul>
+     *   <li>Track execution progress in external systems
+     *   <li>Correlate logs and metrics across invocations
+     *   <li>Reference this execution when calling Lambda APIs
+     * </ul>
+     *
+     * <p>Example ARN format: {@code
+     * arn:aws:lambda:us-east-1:123456789012:function:my-function:$LATEST/durable-execution/349beff4-a89d-4bc8-a56f-af7a8af67a5f/20dae574-53da-37a1-bfd5-b0e2e6ec715d}
+     *
+     * @return the durable execution ARN
+     */
+    public String getDurableExecutionArn() {
+        return durableExecutionArn;
+    }
+}

--- a/sdk/src/test/java/com/amazonaws/lambda/durable/DurableContextTest.java
+++ b/sdk/src/test/java/com/amazonaws/lambda/durable/DurableContextTest.java
@@ -32,7 +32,8 @@ class DurableContextTest {
         var executor = Executors.newCachedThreadPool();
         var initialExecutionState = new InitialExecutionState(initialOperations, null);
         var executionManager = new ExecutionManager(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                "arn:aws:lambda:us-east-1:123456789012:function:test:$LATEST/durable-execution/"
+                        + "349beff4-a89d-4bc8-a56f-af7a8af67a5f/20dae574-53da-37a1-bfd5-b0e2e6ec715d",
                 "test-token",
                 initialExecutionState,
                 client,
@@ -47,6 +48,20 @@ class DurableContextTest {
 
         assertNotNull(context);
         assertNull(context.getLambdaContext());
+    }
+
+    @Test
+    void testGetExecutionContext() {
+        var context = createTestContext();
+
+        var executionContext = context.getExecutionContext();
+
+        assertNotNull(executionContext);
+        assertNotNull(executionContext.getDurableExecutionArn());
+        assertEquals(
+                "arn:aws:lambda:us-east-1:123456789012:function:test:$LATEST/durable-execution/"
+                        + "349beff4-a89d-4bc8-a56f-af7a8af67a5f/20dae574-53da-37a1-bfd5-b0e2e6ec715d",
+                executionContext.getDurableExecutionArn());
     }
 
     @Test

--- a/sdk/src/test/java/com/amazonaws/lambda/durable/ExecutionContextTest.java
+++ b/sdk/src/test/java/com/amazonaws/lambda/durable/ExecutionContextTest.java
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazonaws.lambda.durable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class ExecutionContextTest {
+
+    @Test
+    void constructorSetsArn() {
+        var arn = "arn:aws:lambda:us-east-1:123456789012:function:my-function:$LATEST/durable-execution/"
+                + "349beff4-a89d-4bc8-a56f-af7a8af67a5f/20dae574-53da-37a1-bfd5-b0e2e6ec715d";
+        var context = new ExecutionContext(arn);
+
+        assertEquals(arn, context.getDurableExecutionArn());
+    }
+
+    @Test
+    void getDurableExecutionArnReturnsCorrectValue() {
+        var arn = "arn:aws:lambda:eu-west-1:987654321098:function:test-fn:$LATEST/durable-execution/"
+                + "a1b2c3d4-e5f6-7890-abcd-ef1234567890/b2c3d4e5-f6a7-8901-bcde-f12345678901";
+        var context = new ExecutionContext(arn);
+
+        assertNotNull(context.getDurableExecutionArn());
+        assertEquals(arn, context.getDurableExecutionArn());
+    }
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
https://github.com/aws/aws-durable-execution-sdk-java/issues/28

### Description
Following after https://github.com/aws/aws-durable-execution-sdk-js/pull/430, adding an `executionContext` object on the `context` with an accessor for the durable execution arn.

### Demo/Screenshots

### Checklist

- [X] I have filled out every section of the PR template
- [X] I have thoroughly tested this change

### Testing

#### Unit Tests
Yes

#### Integration Tests
No

#### Examples
No