### PR TITLE
[feat: invoke] add Cloud runner support for invoke operation

### DIFF
--- a/examples/src/test/java/com/amazonaws/lambda/durable/examples/CloudBasedIntegrationTest.java
+++ b/examples/src/test/java/com/amazonaws/lambda/durable/examples/CloudBasedIntegrationTest.java
@@ -69,6 +69,19 @@ class CloudBasedIntegrationTest {
     }
 
     @Test
+    void testSimpleInvokeExample() {
+        var runner = CloudDurableTestRunner.create(arn("simple-invoke-example"), Map.class, String.class);
+        var result = runner.run(Map.of("message", "test"));
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertNotNull(result.getResult(String.class));
+
+        var createGreetingOp = runner.getOperation("invoke-greeting1");
+        assertNotNull(createGreetingOp);
+        assertEquals("invoke-greeting1", createGreetingOp.getName());
+    }
+
+    @Test
     void testRetryExample() {
         var runner = CloudDurableTestRunner.create(arn("retry-example"), String.class, String.class);
         var result = runner.run("{}");


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

#18 

### Description

- added cloud runner support for chained invoke operation
- added chained invoke operation case to Cloud runner test suite

### Demo/Screenshots

```
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 120.9 s -- in com.amazonaws.lambda.durable.examples.CloudBasedIntegrationTest
```

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? Added a new case

#### Examples

Has a new example been added for the change? (if applicable) N/A
