### PR TITLE
Add Dependabot configuration for Maven and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "[maven]"
+    labels:
+      - "dependencies"
+      - "java"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "[github-actions]"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
- Configure daily dependency updates at 09:00 UTC
- Monitor Maven dependencies in root directory
- Monitor GitHub Actions in .github/workflows
- Limit to 5 open PRs per ecosystem
- Add appropriate labels and commit message prefixes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
https://github.com/aws/aws-durable-execution-sdk-java/issues/8

### Description
* Add Dependabot configuration for Maven and GitHub Actions

### Demo/Screenshots

### Checklist

- [x ] I have filled out every section of the PR template
- [ ] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? The workflow should run with the Pull Request.

#### Examples

Has a new example been added for the change? (if applicable)
