### PR TITLE
[feat: invoke]fix Cloud runner case for invoke operation

### DIFF
--- a/examples/src/test/java/com/amazonaws/lambda/durable/examples/CloudBasedIntegrationTest.java
+++ b/examples/src/test/java/com/amazonaws/lambda/durable/examples/CloudBasedIntegrationTest.java
@@ -76,9 +76,13 @@ class CloudBasedIntegrationTest {
         assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
         assertNotNull(result.getResult(String.class));
 
-        var createGreetingOp = runner.getOperation("invoke-greeting1");
+        var createGreetingOp = runner.getOperation("call-greeting1");
         assertNotNull(createGreetingOp);
-        assertEquals("invoke-greeting1", createGreetingOp.getName());
+        assertEquals("call-greeting1", createGreetingOp.getName());
+
+        var createGreetingOp2 = runner.getOperation("call-greeting2");
+        assertNotNull(createGreetingOp);
+        assertEquals("call-greeting2", createGreetingOp2.getName());
     }
 
     @Test


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

Found a local commit which should have been included in the previous PR #44 

### Demo/Screenshots

```
mvn test -Dtest=CloudBasedIntegrationTest -Dtest.cloud.enabled=true -Dtest.aws.region=us-east-2 -Dtest.aws.account=xxxxxx

[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 162.0 s -- in com.amazonaws.lambda.durable.examples.CloudBasedIntegrationTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
```
### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? Updated

#### Examples

Has a new example been added for the change? (if applicable) N/A
