### PR TITLE
[bugfix] remove unncessary policies

### DIFF
--- a/examples/template.yaml
+++ b/examples/template.yaml
@@ -20,13 +20,6 @@ Resources:
       DurableConfig:
         ExecutionTimeout: 300
         RetentionPeriodInDays: 7
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:simple-step-example"
     Metadata:
       Dockerfile: examples/Dockerfile
       DockerContext: ../
@@ -46,12 +39,6 @@ Resources:
         - Statement:
             - Effect: Allow
               Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-                - lambda:InvokeFunction
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:simple-invoke-example"
-            - Effect: Allow
-              Action:
                 - lambda:InvokeFunction
               Resource: '*'
     Metadata:
@@ -69,13 +56,6 @@ Resources:
       DurableConfig:
         ExecutionTimeout: 300
         RetentionPeriodInDays: 7
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:wait-example"
     Metadata:
       Dockerfile: examples/Dockerfile
       DockerContext: ../
@@ -91,13 +71,6 @@ Resources:
       DurableConfig:
         ExecutionTimeout: 300
         RetentionPeriodInDays: 7
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:retry-example"
     Metadata:
       Dockerfile: examples/Dockerfile
       DockerContext: ../
@@ -113,13 +86,6 @@ Resources:
       DurableConfig:
         ExecutionTimeout: 300
         RetentionPeriodInDays: 7
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:wait-at-least-example"
     Metadata:
       Dockerfile: examples/Dockerfile
       DockerContext: ../
@@ -135,13 +101,6 @@ Resources:
       DurableConfig:
         ExecutionTimeout: 300
         RetentionPeriodInDays: 7
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:wait-at-least-in-process-example"
     Metadata:
       Dockerfile: examples/Dockerfile
       DockerContext: ../
@@ -157,13 +116,6 @@ Resources:
       DurableConfig:
         ExecutionTimeout: 300
         RetentionPeriodInDays: 7
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:retry-in-process-example"
     Metadata:
       Dockerfile: examples/Dockerfile
       DockerContext: ../
@@ -179,13 +131,6 @@ Resources:
       DurableConfig:
         ExecutionTimeout: 300
         RetentionPeriodInDays: 7
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:generic-types-example"
     Metadata:
       Dockerfile: examples/Dockerfile
       DockerContext: ../
@@ -201,13 +146,6 @@ Resources:
       DurableConfig:
         ExecutionTimeout: 300
         RetentionPeriodInDays: 7
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:custom-config-example"
     Metadata:
       Dockerfile: examples/Dockerfile
       DockerContext: ../
@@ -223,13 +161,6 @@ Resources:
       DurableConfig:
         ExecutionTimeout: 300
         RetentionPeriodInDays: 7
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:logging-example"
     Metadata:
       Dockerfile: examples/Dockerfile
       DockerContext: ../
@@ -245,13 +176,6 @@ Resources:
       DurableConfig:
         ExecutionTimeout: 300
         RetentionPeriodInDays: 7
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:error-handling-example"
     Metadata:
       Dockerfile: examples/Dockerfile
       DockerContext: ../
@@ -267,13 +191,6 @@ Resources:
       DurableConfig:
         ExecutionTimeout: 300
         RetentionPeriodInDays: 7
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:callback-example"
     Metadata:
       Dockerfile: examples/Dockerfile
       DockerContext: ../
@@ -289,13 +206,6 @@ Resources:
       DurableConfig:
         ExecutionTimeout: 300
         RetentionPeriodInDays: 7
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - lambda:CheckpointDurableExecutions
-                - lambda:GetDurableExecutionState
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:many-async-steps-example"
     Metadata:
       Dockerfile: examples/Dockerfile
       DockerContext: ../


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

- The permission `CheckpointDurableExecutions` doesn't exist. It should have been `CheckpointDurableExecution`.
- The policy is actually not necessary because `AWSLambdaBasicDurableExecutionRolePolicy` will be auto attached with the required permission if `DurableConfig` is specified

### Demo/Screenshots

```
mvn package && \sam build && \sam deploy
...
Successfully created/updated stack - durable-java-sdk-example-app in us-east-2
```

The roles still have the required permissions:

<img width="610" height="448" alt="image" src="https://github.com/user-attachments/assets/21908e0b-e949-4582-8608-38fe029a212a" />


### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable)
