### PR TITLE
remove comment for large payload input

### DIFF
--- a/sdk/src/main/java/com/amazonaws/lambda/durable/DurableExecutor.java
+++ b/sdk/src/main/java/com/amazonaws/lambda/durable/DurableExecutor.java
@@ -46,11 +46,6 @@ public class DurableExecutor {
                         : 0);
 
         // Validate initial operation is an EXECUTION operation
-        // TODO: Double check if very large inputs (close to 6MB) have a null
-        // initialExecutionState.
-        // Potentially, we need to call the backend to fetch it. Give it to the manager,
-        // have it load it from the
-        // if null.
         if (input.initialExecutionState() == null
                 || input.initialExecutionState().operations() == null
                 || input.initialExecutionState().operations().isEmpty()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

https://github.com/aws/aws-durable-execution-sdk-java/issues/73

### Description

Confirmed that the operations field will never be empty. Removing unnecessary comments in code now. 

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
