### PR TITLE
[refactor] remove redundant InitialExecutionState

### DIFF
--- a/sdk-integration-tests/src/test/java/com/amazonaws/lambda/durable/DurableExecutionCheckpointTest.java
+++ b/sdk-integration-tests/src/test/java/com/amazonaws/lambda/durable/DurableExecutionCheckpointTest.java
@@ -33,7 +33,9 @@ class DurableExecutionCheckpointTest {
         var input = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token1",
-                new DurableExecutionInput.InitialExecutionState(List.of(executionOp), null));
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(executionOp))
+                        .build());
 
         var largeString = "x".repeat(7 * 1024 * 1024); // 7MB string
 
@@ -67,7 +69,9 @@ class DurableExecutionCheckpointTest {
         var input = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token1",
-                new DurableExecutionInput.InitialExecutionState(List.of(executionOp), null));
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(executionOp))
+                        .build());
 
         var smallResult = "Small result";
 

--- a/sdk-testing/src/main/java/com/amazonaws/lambda/durable/testing/LocalDurableTestRunner.java
+++ b/sdk-testing/src/main/java/com/amazonaws/lambda/durable/testing/LocalDurableTestRunner.java
@@ -14,6 +14,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
+import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
 import software.amazon.awssdk.services.lambda.model.ExecutionDetails;
 import software.amazon.awssdk.services.lambda.model.Operation;
@@ -268,7 +269,7 @@ public class LocalDurableTestRunner<I, O> {
         return new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "test-token",
-                new DurableExecutionInput.InitialExecutionState(allOps, null));
+                CheckpointUpdatedExecutionState.builder().operations(allOps).build());
     }
 
     private Context mockLambdaContext() {

--- a/sdk/src/main/java/com/amazonaws/lambda/durable/model/DurableExecutionInput.java
+++ b/sdk/src/main/java/com/amazonaws/lambda/durable/model/DurableExecutionInput.java
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazonaws.lambda.durable.model;
 
-import java.util.List;
-import software.amazon.awssdk.services.lambda.model.Operation;
+import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 
 public record DurableExecutionInput(
-        String durableExecutionArn, String checkpointToken, InitialExecutionState initialExecutionState) {
-    public record InitialExecutionState(List<Operation> operations, String nextMarker) {}
-}
+        String durableExecutionArn, String checkpointToken, CheckpointUpdatedExecutionState initialExecutionState) {}

--- a/sdk/src/main/java/com/amazonaws/lambda/durable/serde/AwsSdkV2Module.java
+++ b/sdk/src/main/java/com/amazonaws/lambda/durable/serde/AwsSdkV2Module.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
 import software.amazon.awssdk.services.lambda.model.Operation;
 
@@ -24,7 +25,8 @@ public class AwsSdkV2Module extends SimpleModule {
      *
      * <p>See https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-serialization-changes.html
      */
-    private static final List<Class<?>> SDK_CLASSES = List.of(Operation.class, ErrorObject.class);
+    private static final List<Class<?>> SDK_CLASSES =
+            List.of(Operation.class, ErrorObject.class, CheckpointUpdatedExecutionState.class);
 
     public AwsSdkV2Module() {
         super("AwsSdkV2Module");

--- a/sdk/src/test/java/com/amazonaws/lambda/durable/DurableContextTest.java
+++ b/sdk/src/test/java/com/amazonaws/lambda/durable/DurableContextTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.amazonaws.lambda.durable.execution.ExecutionManager;
 import com.amazonaws.lambda.durable.execution.SuspendExecutionException;
-import com.amazonaws.lambda.durable.model.DurableExecutionInput.InitialExecutionState;
 import com.amazonaws.lambda.durable.retry.RetryStrategies;
 import java.time.Duration;
 import java.util.List;
@@ -26,7 +25,9 @@ class DurableContextTest {
 
     private DurableContext createTestContext(List<Operation> initialOperations) {
         var client = TestUtils.createMockClient();
-        var initialExecutionState = new InitialExecutionState(initialOperations, null);
+        var initialExecutionState = CheckpointUpdatedExecutionState.builder()
+                .operations(initialOperations)
+                .build();
         var executionManager = new ExecutionManager(
                 "arn:aws:lambda:us-east-1:123456789012:function:test:$LATEST/durable-execution/"
                         + "349beff4-a89d-4bc8-a56f-af7a8af67a5f/20dae574-53da-37a1-bfd5-b0e2e6ec715d",

--- a/sdk/src/test/java/com/amazonaws/lambda/durable/DurableExecutionTest.java
+++ b/sdk/src/test/java/com/amazonaws/lambda/durable/DurableExecutionTest.java
@@ -14,6 +14,7 @@ import com.amazonaws.lambda.durable.model.ExecutionStatus;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.ExecutionDetails;
 import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
@@ -42,7 +43,9 @@ class DurableExecutionTest {
         var input = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token1",
-                new DurableExecutionInput.InitialExecutionState(List.of(executionOp), null));
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(executionOp))
+                        .build());
 
         var output = DurableExecutor.execute(
                 input,
@@ -70,7 +73,9 @@ class DurableExecutionTest {
         var input = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token1",
-                new DurableExecutionInput.InitialExecutionState(List.of(executionOp), null));
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(executionOp))
+                        .build());
 
         var output = DurableExecutor.execute(
                 input,
@@ -101,7 +106,9 @@ class DurableExecutionTest {
         var input = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token1",
-                new DurableExecutionInput.InitialExecutionState(List.of(executionOp), null));
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(executionOp))
+                        .build());
 
         var output = DurableExecutor.execute(
                 input,
@@ -140,7 +147,9 @@ class DurableExecutionTest {
         var input = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token2",
-                new DurableExecutionInput.InitialExecutionState(List.of(executionOp, completedStep), null));
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(executionOp, completedStep))
+                        .build());
 
         var output = DurableExecutor.execute(
                 input,
@@ -158,7 +167,7 @@ class DurableExecutionTest {
         var input = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token1",
-                new DurableExecutionInput.InitialExecutionState(List.of(), null));
+                CheckpointUpdatedExecutionState.builder().operations(List.of()).build());
 
         var exception = assertThrows(
                 IllegalStateException.class,
@@ -180,7 +189,9 @@ class DurableExecutionTest {
         var input = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token1",
-                new DurableExecutionInput.InitialExecutionState(List.of(stepOp), null));
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(stepOp))
+                        .build());
 
         var exception = assertThrows(
                 IllegalStateException.class,
@@ -201,7 +212,9 @@ class DurableExecutionTest {
         var input = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token1",
-                new DurableExecutionInput.InitialExecutionState(List.of(executionOp), null));
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(executionOp))
+                        .build());
 
         var result = DurableExecutor.execute(
                 input, null, String.class, (userInput, ctx) -> "result", configWithMockClient());
@@ -232,7 +245,9 @@ class DurableExecutionTest {
         var input1 = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token1",
-                new DurableExecutionInput.InitialExecutionState(List.of(executionOp), null));
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(executionOp))
+                        .build());
 
         // Execute first handler
         var output1 = DurableExecutor.execute(
@@ -258,7 +273,9 @@ class DurableExecutionTest {
         var input2 = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token2",
-                new DurableExecutionInput.InitialExecutionState(List.of(executionOp2), null));
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(executionOp2))
+                        .build());
 
         // Execute second handler using the same config (and thus same executor)
         var output2 = DurableExecutor.execute(

--- a/sdk/src/test/java/com/amazonaws/lambda/durable/DurableExecutionWrapperTest.java
+++ b/sdk/src/test/java/com/amazonaws/lambda/durable/DurableExecutionWrapperTest.java
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazonaws.lambda.durable;
 
-import static java.util.List.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -12,7 +11,9 @@ import com.amazonaws.lambda.durable.model.DurableExecutionOutput;
 import com.amazonaws.lambda.durable.model.ExecutionStatus;
 import com.amazonaws.lambda.durable.serde.JacksonSerDes;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.ExecutionDetails;
 import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
@@ -71,7 +72,9 @@ class DurableExecutionWrapperTest {
         var input = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token-1",
-                new DurableExecutionInput.InitialExecutionState(of(executionOp), null));
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(executionOp))
+                        .build());
 
         // Execute
         var output = handler.handleRequest(input, null);
@@ -105,7 +108,9 @@ class DurableExecutionWrapperTest {
         var input = new DurableExecutionInput(
                 "arn:aws:lambda:us-east-1:123456789012:function:test",
                 "token-1",
-                new DurableExecutionInput.InitialExecutionState(of(executionOp), null));
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(executionOp))
+                        .build());
 
         var output = handler.handleRequest(input, null);
 

--- a/sdk/src/test/java/com/amazonaws/lambda/durable/ReplayValidationTest.java
+++ b/sdk/src/test/java/com/amazonaws/lambda/durable/ReplayValidationTest.java
@@ -8,11 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.amazonaws.lambda.durable.exception.NonDeterministicExecutionException;
 import com.amazonaws.lambda.durable.execution.ExecutionManager;
-import com.amazonaws.lambda.durable.model.DurableExecutionInput.InitialExecutionState;
 import java.time.Duration;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.awssdk.services.lambda.model.OperationType;
@@ -29,7 +29,8 @@ class ReplayValidationTest {
                 .build();
         var operations = Stream.concat(Stream.of(executionOp), initialOperations.stream())
                 .toList();
-        var initialExecutionState = new InitialExecutionState(operations, null);
+        var initialExecutionState =
+                CheckpointUpdatedExecutionState.builder().operations(operations).build();
         var executionManager = new ExecutionManager(
                 "arn:aws:lambda:us-east-1:123456789012:function:test", "test-token", initialExecutionState, client);
         return new DurableContext(executionManager, DurableConfig.builder().build(), null);

--- a/sdk/src/test/java/com/amazonaws/lambda/durable/execution/ExecutionManagerTest.java
+++ b/sdk/src/test/java/com/amazonaws/lambda/durable/execution/ExecutionManagerTest.java
@@ -5,9 +5,9 @@ package com.amazonaws.lambda.durable.execution;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.amazonaws.lambda.durable.TestUtils;
-import com.amazonaws.lambda.durable.model.DurableExecutionInput.InitialExecutionState;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.awssdk.services.lambda.model.OperationType;
@@ -16,7 +16,8 @@ class ExecutionManagerTest {
 
     private ExecutionManager createManager(List<Operation> operations) {
         var client = TestUtils.createMockClient();
-        var initialState = new InitialExecutionState(operations, null);
+        var initialState =
+                CheckpointUpdatedExecutionState.builder().operations(operations).build();
         return new ExecutionManager(
                 "arn:aws:lambda:us-east-1:123456789012:function:test", "test-token", initialState, client);
     }

--- a/sdk/src/test/java/com/amazonaws/lambda/durable/operation/CallbackOperationTest.java
+++ b/sdk/src/test/java/com/amazonaws/lambda/durable/operation/CallbackOperationTest.java
@@ -13,7 +13,6 @@ import com.amazonaws.lambda.durable.exception.IllegalDurableOperationException;
 import com.amazonaws.lambda.durable.exception.SerDesException;
 import com.amazonaws.lambda.durable.execution.ExecutionManager;
 import com.amazonaws.lambda.durable.execution.ThreadType;
-import com.amazonaws.lambda.durable.model.DurableExecutionInput.InitialExecutionState;
 import com.amazonaws.lambda.durable.serde.JacksonSerDes;
 import com.amazonaws.lambda.durable.serde.SerDes;
 import java.time.Duration;
@@ -60,7 +59,9 @@ class CallbackOperationTest {
 
     private ExecutionManager createExecutionManager(List<Operation> initialOperations) {
         var client = TestUtils.createMockClient();
-        var initialState = new InitialExecutionState(initialOperations, null);
+        var initialState = CheckpointUpdatedExecutionState.builder()
+                .operations(initialOperations)
+                .build();
         var executionManager = new ExecutionManager(
                 "arn:aws:lambda:us-east-1:123456789012:function:test", "test-token", initialState, client);
         executionManager.setCurrentContext("Root", ThreadType.CONTEXT);


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

- removed the redundant `InitialExecutionState` class. Lambda API already provided a class   `                CheckpointUpdatedExecutionState` for the same purpose.
- updated fetchAllPages to work with CheckpointUpdatedExecutionState from the invoke payload as well as the getExecutionState response

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? updated

#### Integration Tests

Have integration tests been written for these changes? updated

#### Examples

Has a new example been added for the change? (if applicable) N/A
