### PR TITLE
[bugfix] fix the race condition in waitForOperationCompletion

### DIFF
--- a/sdk/src/main/java/com/amazonaws/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/com/amazonaws/lambda/durable/operation/BaseDurableOperation.java
@@ -137,14 +137,15 @@ public abstract class BaseDurableOperation<T> implements DurableFuture<T> {
 
         validateCurrentThreadType();
 
+        // register to prevent the state from advancing
+        phaser.register();
+
         // If we are in a replay where the operation is already complete (SUCCEEDED /
         // FAILED), the Phaser will be
         // advanced in .execute() already and we don't block but return the result
         // immediately.
         if (phaser.getPhase() == ExecutionPhase.RUNNING.getValue()) {
             // Operation not done yet
-            phaser.register();
-
             var context = executionManager.getCurrentContext();
             // Deregister current context - allows suspension
             logger.debug(
@@ -162,6 +163,9 @@ public abstract class BaseDurableOperation<T> implements DurableFuture<T> {
             setCurrentContext(context.contextId(), context.threadType());
 
             // Complete phase 1
+            phaser.arriveAndDeregister();
+        } else {
+            // The phaser is already completed. Deregister now.
             phaser.arriveAndDeregister();
         }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

#72 

### Description

The bug is in the following lines:

```
if (phaser.getPhase() == ExecutionPhase.RUNNING.getValue()) {
    // Operation not done yet
    phaser.register();
```

After checking the phaser status (is RUNNING) and before a new party is registered, the phaser could have changed its status (advanced to the next phase). This is a typical [TOCTOU bug](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use)

This bug is reproduced with an additional delay between them:

```
if (phaser.getPhase() == ExecutionPhase.RUNNING.getValue()) {
    try {
        Thread.sleep(2000);
    } catch (InterruptedException ignored) {
    }
    // Operation not done yet
    phaser.register();
```
With the delay, some test cases will hang forever because the phaser of the operation is registered but never notified (arrived).


The proposed fix here is first calling `register` to lock the phase state, then check the state and deregister immediately if it's completed

```
phaser.register();
if (phaser.getPhase() != ExecutionPhase.RUNNING.getValue()) {
    phaser.deregister();
} else {
    ...
}
```

### Demo/Screenshots

added 2 seconds delays in different places in `waitForOperationCompletion` and the tests always succeeded (but slower)

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Unable to cover the race condition in a unit test

#### Integration Tests

Have integration tests been written for these changes? Existing integration tests should run smoother than before

#### Examples

Has a new example been added for the change? (if applicable)
