### PR TITLE
[bugfix] fix a broken unit test testCombinedSyncAsyncWait

### DIFF
--- a/sdk/src/test/java/com/amazonaws/lambda/durable/DurableContextTest.java
+++ b/sdk/src/test/java/com/amazonaws/lambda/durable/DurableContextTest.java
@@ -145,6 +145,11 @@ class DurableContextTest {
         var asyncFuture = context.stepAsync("async-step", Integer.class, () -> 42);
         assertEquals(42, asyncFuture.get());
 
+        // Receiving results from `get` calls doesn't mean the step threads have been deregistered.So we wait for 500ms
+        // to make sure the above step threads have been deregistered. Otherwise, the wait call will be stuck forever
+        // and SuspendExecutionException will be thrown from the step thread
+        Thread.sleep(500);
+
         // Wait should suspend (throw exception)
         assertThrows(SuspendExecutionException.class, () -> {
             context.wait(Duration.ofSeconds(30));


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fixes: #105 

### Description


The case `testCombinedSyncAsyncWait` sometimes gets stuck because

1. The step calls `sendOperationUpdate` to send the result
2. The context thread calling `step.get()` is resumed and it receives the result
3. The context thread calls `wait` but it doesn't throw  SuspendExecutionException because the step thread is still running
4. The step calls `deregisterActiveThreadAndUnsetCurrentContext` to deregister itself and throws SuspendExecutionException

In this case `SuspendExecutionException` is still thrown but it's not from the expected place (`wait` call) and `wait` call will be stuck forever.

A quick fix: add a delay before we call `wait`


### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Updated

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable)
