### PR TITLE
[Bugfix] adding completableFuture docs and minor bug fixes

### DIFF
--- a/docs/adr/003-completable-future-based-coordination.md
+++ b/docs/adr/003-completable-future-based-coordination.md
@@ -1,4 +1,177 @@
 # ADR-003: CompletableFuture-Based Operation Coordination
 
-**Status:** Todo
+**Status:** Review
 **Date:** 2026-02-18
+
+## Context
+
+Currently, the SDK employs a Phaser-based mechanism for coordinating operations. The design is detailed in [ADR-002: Phaser-Based Operation Coordination](002-phaser-based-coordination.md).
+
+With this design, we can:
+ 
+- Register a thread when it begins and deregister it when it completes;
+- Block `DurableFuture::get()` calls until the operation completes;
+- Suspend execution when no registered thread exists.
+
+However, this design has a few issues:
+
+- We allow the Phasers to advance over predefined phase ranges (0 - RUNNING, 1 - COMPLETE). If we received duplicate completion updates from local runner or backend API, the phase could be advanced to 2, 3, and so on.
+- We assume that there is only one party during operation replay, and two parties when receiving an operation state from checkpoint API. We call Phaser `arriveAndAwaitAdvance` once or twice based on this assumption, but it could be incorrect. In complex scenarios, this could lead to a deadlock (not enough arrive calls) or exceeding the phase range (too many arrive calls).
+- The Phaser has higher complexity and cognitive overhead compared to other synchronization mechanisms.
+
+## Decision
+
+We will implement operation coordination using `CompletableFuture`.,
+
+### Threads
+
+Each piece of user code (e.g. the main Lambda function body, a step body, a child context body) runs in its own user thread from the user thread pool. 
+Execution manager tracks active running user threads. 
+When a new step or a new child context is created, a new thread is created and registered in execution manager. 
+When the step or the child context completes, the corresponding thread is deregistered from execution manager.
+When the user code is blocked on `DurableFuture::get()` or another synchronous durable operation (e.g., `wait()`), the caller thread is deregistered from execution manager. 
+When there is no registered thread in execution manager, the durable execution is suspended.
+
+A special SDK thread is created and managed by the SDK to make checkpoint API requests.
+
+### CompletableFuture
+
+The `CompletableFuture` is used to manage the completion of operations. It allows us to track the progress of operations and handle their completion in a more flexible and readable manner.
+
+Each durable operation has a `CompletableFuture` field.
+This field is used by user threads and the SDK thread communicate the completion of operations. 
+
+For example, when a context executes a step, the communication occurs as follows
+
+```mermaid
+sequenceDiagram
+    participant Context as Context Thread
+    participant Future as CompletableFuture
+    participant EM as Execution Manager
+    participant SDK as SDK Thread
+    participant Step as Step Thread
+
+    Note over Context: calling context.stepAsync()
+    Context->>Context: create StepOperation 
+    Context->>Future: create CompletableFuture
+    Note over EM: Step Thread lifecycle in EM
+    Context->>EM: register Step Thread
+    activate Step
+    activate EM
+    Context->>+Step: create Step Thread
+    Note over Context: calling step.get()
+    Context->>Future: check if CompletableFuture is done
+    alt is not done
+    Context->>EM: deregister Context Thread
+    Context->>Future: attach a callback to register context thread when CompletableFuture is done
+    Context->>Future: wait for CompletableFuture to complete
+    Note over Context: (BLOCKED)
+    end
+
+    Note over Step: executing Step logic
+    Step->>Step: execute user function
+    Step->>+SDK: checkpoint SUCCESS
+    SDK->>SDK: call checkpoint API
+    SDK->>SDK: handle checkpoint response
+    SDK->>+Future: complete CompletableFuture
+    alt callback attached
+    Future->>EM: register Context Thread
+    Future->>Context: unblock Context Thread
+    Note over Context: (UNBLOCKED)
+    end
+    Future-->>-SDK: CompletableFuture completed
+    SDK-->>-Step: checkpoint done
+    Context->>Context: retrieve the step result
+    Step->>EM: deregister Step thread
+    deactivate Step
+    deactivate EM
+
+```
+
+|   | Context Thread                                                                                              | Step Thread                                                         | SDK Thread                                                                                                                                                                    |
+|---|-------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1 | create StepOperation (a CompletableFuture is created)                                                       | (not created)                                                       | (idle)                                                                                                                                                                        |
+| 2 | checkpoint START event (synchronously or asynchronously)                                                    | (not created)                                                       | call checkpoint API                                                                                                                                                           |
+| 3 | create and register the Step thread                                                                         | execute user code for the step                                      | (idle)                                                                                                                                                                        |
+| 4 | call `DurableFuture::get()`, deregister the context thread and wait for the `CompletableFuture` to complete | (continue)                                                          | (idle)                                                                                                                                                                        |
+| 5 | (blocked)                                                                                                   | checkpoint the step result and wait for checkpoint call to complete | call checkpoint API, and handle the API response. If it is a terminal response, complete the step operation CompletableFuture, register and unblock the context thread.       |
+| 6 | retrieve the result of the step                                                                             | deregister and terminate the Step thread                            | (idle)                                                                                                                                                                        |        
+
+If the step code completes quickly, an alternative scenario could happen as follows
+
+```mermaid
+sequenceDiagram
+    participant Context as Context Thread
+    participant Future as CompletableFuture
+    participant EM as Execution Manager
+    participant SDK as SDK Thread
+    participant Step as Step Thread
+
+    Note over Context: calling context.stepAsync()
+    Context->>Context: create StepOperation 
+    Context->>Future: create CompletableFuture
+    Note over EM: Step Thread lifecycle in EM
+    Context->>EM: register Step Thread
+    activate EM
+    Context->>Step: create Step Thread
+    activate Step
+    Step->>Step: execute user function
+    Step->>EM: checkpoint SUCCESS
+    EM->>SDK: checkpoint SUCCESS
+    activate SDK
+    SDK->>SDK: call checkpoint API
+    SDK->>SDK: handle checkpoint response
+    SDK->>+Future: complete CompletableFuture
+    Note over Future: no callback attached
+    Future-->>-SDK: CompletableFuture completed
+    SDK-->>Step: checkpoint done
+    deactivate SDK
+    Step->>EM: deregister Step thread
+    deactivate EM
+    deactivate Step
+
+    Note over Context: calling step.get()
+    Context->>Future: check if CompletableFuture is done
+    alt is done
+    Context->>Context: retrieve the step result
+    end
+
+
+```
+
+|   | Context Thread                                                                              | Step Thread                                                         | SDK Thread                                                                                                                     |
+|---|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| 1 | create StepOperation (a CompletableFuture is created)                                       | (not created)                                                       | (idle)                                                                                                                         |
+| 2 | checkpoint START event (synchronously or asynchronously)                                    | (not created)                                                       | call checkpoint API                                                                                                            |
+| 3 | create and register the Step thread                                                         | execute user code for the step and complete quickly                 | (idle)                                                                                                                         |
+| 5 | (do something else or just get starved)                                                     | checkpoint the step result and wait for checkpoint call to complete | call checkpoint API, and handle the API response. If it is a terminal response, complete the Step operation CompletableFuture. |
+| 4 | call `DurableFuture::get()` (non-blocking because `CompletableFuture` is already completed) | deregister and terminate the Step thread                            | (idle)                                                                                                                         |
+| 6 | retrieve the result of the step                                                             | (ended)                                                             | (idle)                                                                                                                         |        
+
+The following two key mechanisms make `CompletableFuture` based solution work properly.
+
+- Strict ordering of `register and unblock the context thread` and `deregister and terminate the Step thread`.
+  - When a step completes, it calls checkpoint API to checkpoint the result and wait for the checkpoint call to complete.
+  - SDK thread receives the checkpoint request, makes the API call, and processes the API response.
+    - If the response contains a terminal operation state (it should for a succeeded or failed step), it will send the response to the `StepOperation` to complete `CompletableFuture`. When completing the future, the attached completion stages will be executed synchronously, which will register any context threads that are waiting for the result of the step.
+  - When SDK thread completes the API request and registers all waiting threads, the step thread continues to deregister itself from execution manager.
+- Synchronized access to `CompletableFuture`.
+  - When a context thread calls `DurableFuture::get()`, it checks if `CompletableFuture` is done. 
+    1. If the future is done, `get()` will return the operation result. Otherwise, the context thread will
+    2. deregister itself from execution manager;
+    3. attach a completion stage to `CompletableFuture` that will re-register the context thread when later the future is completed;
+    4. wait for `CompletableFuture` to complete.
+  - Meantime, `CompletableFuture` can be completed by SDK thread when handling the checkpoint API responses. 
+    - A race condition will occur if this happens when the context thread is between the step `a` and `c`.
+    - To prevent the race condition, all the mutating access to `CompletableFuture` either to complete the future or to attach a completion stage is synchronized.
+
+## Consequences
+
+Enables:
+- Support for complex scenarios which were not supported by Phaser
+- Reduced implementation complexity and improved readability
+- `CompletableFuture` based implementation of `DurableFuture::allOf` and `DurableFuture::anyOf`
+
+Cost:
+- Synchronized access to `CompletableFuture`
+- Obscured ordering of thread registration/deregistration

--- a/sdk-integration-tests/src/test/java/com/amazonaws/lambda/durable/ChildContextIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/com/amazonaws/lambda/durable/ChildContextIntegrationTest.java
@@ -221,7 +221,7 @@ class ChildContextIntegrationTest {
         runner.advanceTime();
 
         // Second run - should complete
-        var result2 = runner.run("test");
+        var result2 = runner.runUntilComplete("test");
         assertEquals(ExecutionStatus.SUCCEEDED, result2.getStatus());
         assertEquals("done", result2.getResult(String.class));
     }

--- a/sdk/src/main/java/com/amazonaws/lambda/durable/DurableContext.java
+++ b/sdk/src/main/java/com/amazonaws/lambda/durable/DurableContext.java
@@ -3,6 +3,7 @@
 package com.amazonaws.lambda.durable;
 
 import com.amazonaws.lambda.durable.execution.ExecutionManager;
+import com.amazonaws.lambda.durable.execution.ThreadContext;
 import com.amazonaws.lambda.durable.execution.ThreadType;
 import com.amazonaws.lambda.durable.logging.DurableLogger;
 import com.amazonaws.lambda.durable.operation.CallbackOperation;
@@ -64,8 +65,8 @@ public class DurableContext {
     static DurableContext createRootContext(
             ExecutionManager executionManager, DurableConfig durableConfig, Context lambdaContext) {
         var ctx = new DurableContext(executionManager, durableConfig, lambdaContext, null);
-        executionManager.registerActiveThread(ROOT_CONTEXT, ThreadType.CONTEXT);
-        executionManager.setCurrentContext(ROOT_CONTEXT, ThreadType.CONTEXT);
+        executionManager.registerActiveThread(ROOT_CONTEXT);
+        executionManager.setCurrentThreadContext(new ThreadContext(ROOT_CONTEXT, ThreadType.CONTEXT));
         return ctx;
     }
 

--- a/sdk/src/main/java/com/amazonaws/lambda/durable/execution/ExecutionManager.java
+++ b/sdk/src/main/java/com/amazonaws/lambda/durable/execution/ExecutionManager.java
@@ -8,9 +8,11 @@ import com.amazonaws.lambda.durable.operation.BaseDurableOperation;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -55,8 +57,8 @@ public class ExecutionManager {
     // ===== Thread Coordination =====
     private final Map<String, BaseDurableOperation<?>> registeredOperations =
             Collections.synchronizedMap(new HashMap<>());
-    private final Map<String, ThreadType> activeThreads = Collections.synchronizedMap(new HashMap<>());
-    private static final ThreadLocal<OperationContext> currentContext = new ThreadLocal<>();
+    private final Set<String> activeThreads = Collections.synchronizedSet(new HashSet<>());
+    private static final ThreadLocal<ThreadContext> currentThreadContext = new ThreadLocal<>();
     private final CompletableFuture<Void> executionExceptionFuture = new CompletableFuture<>();
 
     // ===== Checkpoint Batching =====
@@ -143,53 +145,47 @@ public class ExecutionManager {
     }
 
     // ===== Thread Coordination =====
+    /** Sets the current thread's ThreadContext (threadId and threadType). Called when a user thread is started. */
+    public void setCurrentThreadContext(ThreadContext threadContext) {
+        currentThreadContext.set(threadContext);
+    }
+
+    /** Returns the current thread's ThreadContext (threadId and threadType), or null if not set. */
+    public ThreadContext getCurrentThreadContext() {
+        return currentThreadContext.get();
+    }
+
     /**
-     * Registers a thread as active without setting the thread local OperationContext. Use this when registration must
-     * happen on a different thread than execution. Call setCurrentContext() on the execution thread to set the local
-     * OperationContext.
+     * Registers a thread as active.
      *
-     * @see OperationContext
+     * @see ThreadContext
      */
-    public void registerActiveThread(String threadId, ThreadType threadType) {
-        if (activeThreads.containsKey(threadId)) {
-            logger.trace("Thread '{}' ({}) already registered as active", threadId, threadType);
+    public void registerActiveThread(String threadId) {
+        if (activeThreads.contains(threadId)) {
+            logger.trace("Thread '{}' already registered as active", threadId);
             return;
         }
-        activeThreads.put(threadId, threadType);
-        logger.trace(
-                "Registered thread '{}' ({}) as active (no context). Active threads: {}",
-                threadId,
-                threadType,
-                activeThreads.size());
+        activeThreads.add(threadId);
+        logger.trace("Registered thread '{}' as active. Active threads: {}", threadId, activeThreads.size());
     }
 
     /**
-     * Sets the current thread's context. Use after registerActiveThreadWithoutContext() when the execution thread is
-     * different from the registration thread.
+     * Mark a thread as inactive. If no threads remain, suspends the execution.
+     *
+     * @param threadId the thread ID to deregister
      */
-    public void setCurrentContext(String contextId, ThreadType threadType) {
-        currentContext.set(new OperationContext(contextId, threadType));
-    }
-
-    /** Returns the current thread's context, or null if not set. */
-    public OperationContext getCurrentContext() {
-        return currentContext.get();
-    }
-
-    public void deregisterActiveThreadAndUnsetCurrentContext(String threadId) {
+    public void deregisterActiveThread(String threadId) {
         // Skip if already suspended
         if (executionExceptionFuture.isDone()) {
             return;
         }
 
-        if (!activeThreads.containsKey(threadId)) {
+        boolean removed = activeThreads.remove(threadId);
+        if (removed) {
+            logger.trace("Deregistered thread '{}' Active threads: {}", threadId, activeThreads.size());
+        } else {
             logger.warn("Thread '{}' not active, cannot deregister", threadId);
-            return;
         }
-
-        ThreadType type = activeThreads.remove(threadId);
-        currentContext.remove();
-        logger.trace("Deregistered thread '{}' ({}). Active threads: {}", threadId, type, activeThreads.size());
 
         if (activeThreads.isEmpty()) {
             logger.info("No active threads remaining - suspending execution");
@@ -225,7 +221,7 @@ public class ExecutionManager {
         checkpointBatcher.shutdown();
     }
 
-    private boolean isTerminalStatus(OperationStatus status) {
+    public static boolean isTerminalStatus(OperationStatus status) {
         return status == OperationStatus.SUCCEEDED
                 || status == OperationStatus.FAILED
                 || status == OperationStatus.CANCELLED

--- a/sdk/src/main/java/com/amazonaws/lambda/durable/execution/ThreadContext.java
+++ b/sdk/src/main/java/com/amazonaws/lambda/durable/execution/ThreadContext.java
@@ -3,4 +3,4 @@
 package com.amazonaws.lambda.durable.execution;
 
 /** Holds the current thread's execution context. */
-public record OperationContext(String contextId, ThreadType threadType) {}
+public record ThreadContext(String threadId, ThreadType threadType) {}

--- a/sdk/src/test/java/com/amazonaws/lambda/durable/operation/CallbackOperationTest.java
+++ b/sdk/src/test/java/com/amazonaws/lambda/durable/operation/CallbackOperationTest.java
@@ -10,9 +10,9 @@ import com.amazonaws.lambda.durable.TestUtils;
 import com.amazonaws.lambda.durable.TypeToken;
 import com.amazonaws.lambda.durable.exception.CallbackFailedException;
 import com.amazonaws.lambda.durable.exception.CallbackTimeoutException;
-import com.amazonaws.lambda.durable.exception.IllegalDurableOperationException;
 import com.amazonaws.lambda.durable.exception.SerDesException;
 import com.amazonaws.lambda.durable.execution.ExecutionManager;
+import com.amazonaws.lambda.durable.execution.ThreadContext;
 import com.amazonaws.lambda.durable.execution.ThreadType;
 import com.amazonaws.lambda.durable.serde.JacksonSerDes;
 import com.amazonaws.lambda.durable.serde.SerDes;
@@ -23,6 +23,10 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.*;
 
 class CallbackOperationTest {
+
+    private static final String OPERATION_ID = "1";
+    private static final String EXECUTION_OPERATION_ID = "0";
+    private static final String OPERATION_NAME = "approval";
 
     /** Custom SerDes that tracks deserialization calls. */
     static class TrackingSerDes implements SerDes {
@@ -68,14 +72,14 @@ class CallbackOperationTest {
                 "test-token",
                 initialState,
                 DurableConfig.builder().withDurableExecutionClient(client).build());
-        executionManager.setCurrentContext("Root", ThreadType.CONTEXT);
+        executionManager.setCurrentThreadContext(new ThreadContext("Root", ThreadType.CONTEXT));
         return executionManager;
     }
 
     @Test
     void executeCreatesCheckpointAndGetsCallbackId() {
         var executionOp = Operation.builder()
-                .id("0")
+                .id(EXECUTION_OPERATION_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .build();
@@ -83,8 +87,8 @@ class CallbackOperationTest {
         var serDes = new JacksonSerDes();
 
         var operation = new CallbackOperation<>(
-                "1",
-                "approval",
+                OPERATION_ID,
+                OPERATION_NAME,
                 TypeToken.get(String.class),
                 CallbackConfig.builder().serDes(serDes).build(),
                 executionManager);
@@ -96,7 +100,7 @@ class CallbackOperationTest {
     @Test
     void executeWithConfigSetsOptions() {
         var executionOp = Operation.builder()
-                .id("0")
+                .id(EXECUTION_OPERATION_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .build();
@@ -108,7 +112,8 @@ class CallbackOperationTest {
                 .serDes(serDes)
                 .build();
 
-        var operation = new CallbackOperation<>("1", "approval", TypeToken.get(String.class), config, executionManager);
+        var operation = new CallbackOperation<>(
+                OPERATION_ID, OPERATION_NAME, TypeToken.get(String.class), config, executionManager);
         operation.execute();
 
         assertNotNull(operation.callbackId());
@@ -117,8 +122,8 @@ class CallbackOperationTest {
     @Test
     void replayReturnsExistingCallbackIdWhenSucceeded() {
         var existingCallback = Operation.builder()
-                .id("1")
-                .name("approval")
+                .id(OPERATION_ID)
+                .name(OPERATION_NAME)
                 .type(OperationType.CALLBACK)
                 .status(OperationStatus.SUCCEEDED)
                 .callbackDetails(CallbackDetails.builder()
@@ -130,8 +135,8 @@ class CallbackOperationTest {
         var serDes = new JacksonSerDes();
 
         var operation = new CallbackOperation<>(
-                "1",
-                "approval",
+                OPERATION_ID,
+                OPERATION_NAME,
                 TypeToken.get(String.class),
                 CallbackConfig.builder().serDes(serDes).build(),
                 executionManager);
@@ -143,8 +148,8 @@ class CallbackOperationTest {
     @Test
     void getReturnsDeserializedResultWhenSucceeded() {
         var existingCallback = Operation.builder()
-                .id("1")
-                .name("approval")
+                .id(OPERATION_ID)
+                .name(OPERATION_NAME)
                 .type(OperationType.CALLBACK)
                 .status(OperationStatus.SUCCEEDED)
                 .callbackDetails(CallbackDetails.builder()
@@ -156,8 +161,8 @@ class CallbackOperationTest {
         var serDes = new JacksonSerDes();
 
         var operation = new CallbackOperation<>(
-                "1",
-                "approval",
+                OPERATION_ID,
+                OPERATION_NAME,
                 TypeToken.get(String.class),
                 CallbackConfig.builder().serDes(serDes).build(),
                 executionManager);
@@ -170,8 +175,8 @@ class CallbackOperationTest {
     @Test
     void getThrowsCallbackExceptionWhenFailed() {
         var existingCallback = Operation.builder()
-                .id("1")
-                .name("approval")
+                .id(OPERATION_ID)
+                .name(OPERATION_NAME)
                 .type(OperationType.CALLBACK)
                 .status(OperationStatus.FAILED)
                 .callbackDetails(CallbackDetails.builder()
@@ -186,8 +191,8 @@ class CallbackOperationTest {
         var serDes = new JacksonSerDes();
 
         var operation = new CallbackOperation<>(
-                "1",
-                "approval",
+                OPERATION_ID,
+                OPERATION_NAME,
                 TypeToken.get(String.class),
                 CallbackConfig.builder().serDes(serDes).build(),
                 executionManager);
@@ -200,8 +205,8 @@ class CallbackOperationTest {
     @Test
     void getThrowsCallbackTimeoutExceptionWhenTimedOut() {
         var existingCallback = Operation.builder()
-                .id("1")
-                .name("approval")
+                .id(OPERATION_ID)
+                .name(OPERATION_NAME)
                 .type(OperationType.CALLBACK)
                 .status(OperationStatus.TIMED_OUT)
                 .callbackDetails(
@@ -211,8 +216,8 @@ class CallbackOperationTest {
         var serDes = new JacksonSerDes();
 
         var operation = new CallbackOperation<>(
-                "1",
-                "approval",
+                OPERATION_ID,
+                OPERATION_NAME,
                 TypeToken.get(String.class),
                 CallbackConfig.builder().serDes(serDes).build(),
                 executionManager);
@@ -227,8 +232,8 @@ class CallbackOperationTest {
         var customSerDes = new TrackingSerDes();
 
         var existingCallback = Operation.builder()
-                .id("1")
-                .name("approval")
+                .id(OPERATION_ID)
+                .name(OPERATION_NAME)
                 .type(OperationType.CALLBACK)
                 .status(OperationStatus.SUCCEEDED)
                 .callbackDetails(CallbackDetails.builder()
@@ -239,7 +244,8 @@ class CallbackOperationTest {
         var executionManager = createExecutionManager(List.of(existingCallback));
 
         var config = CallbackConfig.builder().serDes(customSerDes).build();
-        var operation = new CallbackOperation<>("1", "approval", TypeToken.get(String.class), config, executionManager);
+        var operation = new CallbackOperation<>(
+                OPERATION_ID, OPERATION_NAME, TypeToken.get(String.class), config, executionManager);
         operation.execute();
         var result = operation.get();
 
@@ -253,8 +259,8 @@ class CallbackOperationTest {
         var customSerDes = new TrackingSerDes();
 
         var existingCallback = Operation.builder()
-                .id("1")
-                .name("approval")
+                .id(OPERATION_ID)
+                .name(OPERATION_NAME)
                 .type(OperationType.CALLBACK)
                 .status(OperationStatus.SUCCEEDED)
                 .callbackDetails(CallbackDetails.builder()
@@ -265,8 +271,8 @@ class CallbackOperationTest {
         var executionManager = createExecutionManager(List.of(existingCallback));
 
         var operation = new CallbackOperation<>(
-                "1",
-                "approval",
+                OPERATION_ID,
+                OPERATION_NAME,
                 TypeToken.get(String.class),
                 CallbackConfig.builder().serDes(customSerDes).build(),
                 executionManager);
@@ -283,8 +289,8 @@ class CallbackOperationTest {
         var customSerDes = new TrackingSerDes();
 
         var existingCallback = Operation.builder()
-                .id("1")
-                .name("approval")
+                .id(OPERATION_ID)
+                .name(OPERATION_NAME)
                 .type(OperationType.CALLBACK)
                 .status(OperationStatus.SUCCEEDED)
                 .callbackDetails(CallbackDetails.builder()
@@ -295,7 +301,8 @@ class CallbackOperationTest {
         var executionManager = createExecutionManager(List.of(existingCallback));
 
         var config = CallbackConfig.builder().serDes(customSerDes).build();
-        var operation = new CallbackOperation<>("1", "approval", TypeToken.get(String.class), config, executionManager);
+        var operation = new CallbackOperation<>(
+                OPERATION_ID, OPERATION_NAME, TypeToken.get(String.class), config, executionManager);
         operation.execute();
         var result = operation.get();
 
@@ -309,8 +316,8 @@ class CallbackOperationTest {
         var failingSerDes = new FailingSerDes();
 
         var existingCallback = Operation.builder()
-                .id("1")
-                .name("approval")
+                .id(OPERATION_ID)
+                .name(OPERATION_NAME)
                 .type(OperationType.CALLBACK)
                 .status(OperationStatus.SUCCEEDED)
                 .callbackDetails(CallbackDetails.builder()
@@ -321,8 +328,8 @@ class CallbackOperationTest {
         var executionManager = createExecutionManager(List.of(existingCallback));
 
         var operation = new CallbackOperation<>(
-                "1",
-                "approval",
+                OPERATION_ID,
+                OPERATION_NAME,
                 TypeToken.get(String.class),
                 CallbackConfig.builder().serDes(failingSerDes).build(),
                 executionManager);
@@ -330,34 +337,5 @@ class CallbackOperationTest {
 
         var exception = assertThrows(SerDesException.class, operation::get);
         assertEquals("Invalid base64 encoding", exception.getMessage());
-    }
-
-    @Test
-    void getThrowsExceptionWhenCalledWithinStep() {
-        var existingCallback = Operation.builder()
-                .id("1")
-                .name("approval")
-                .type(OperationType.CALLBACK)
-                .status(OperationStatus.SUCCEEDED)
-                .callbackDetails(CallbackDetails.builder()
-                        .callbackId("test-callback-123")
-                        .result("invalid-data")
-                        .build())
-                .build();
-        var executionManager = createExecutionManager(List.of(existingCallback));
-        executionManager.setCurrentContext("Root", ThreadType.STEP);
-
-        var operation = new CallbackOperation<>(
-                "1",
-                "approval",
-                TypeToken.get(String.class),
-                CallbackConfig.builder().serDes(new JacksonSerDes()).build(),
-                executionManager);
-        operation.execute();
-
-        var exception = assertThrows(IllegalDurableOperationException.class, operation::get);
-        assertEquals(
-                "Nested CALLBACK operation is not supported on approval from within a Step execution.",
-                exception.getMessage());
     }
 }

--- a/sdk/src/test/java/com/amazonaws/lambda/durable/operation/ChildContextOperationTest.java
+++ b/sdk/src/test/java/com/amazonaws/lambda/durable/operation/ChildContextOperationTest.java
@@ -10,7 +10,7 @@ import com.amazonaws.lambda.durable.TypeToken;
 import com.amazonaws.lambda.durable.exception.ChildContextFailedException;
 import com.amazonaws.lambda.durable.exception.NonDeterministicExecutionException;
 import com.amazonaws.lambda.durable.execution.ExecutionManager;
-import com.amazonaws.lambda.durable.execution.OperationContext;
+import com.amazonaws.lambda.durable.execution.ThreadContext;
 import com.amazonaws.lambda.durable.execution.ThreadType;
 import com.amazonaws.lambda.durable.serde.JacksonSerDes;
 import java.util.List;
@@ -30,7 +30,7 @@ class ChildContextOperationTest {
 
     private ExecutionManager createMockExecutionManager() {
         var executionManager = mock(ExecutionManager.class);
-        when(executionManager.getCurrentContext()).thenReturn(new OperationContext("Root", ThreadType.CONTEXT));
+        when(executionManager.getCurrentThreadContext()).thenReturn(new ThreadContext("Root", ThreadType.CONTEXT));
         return executionManager;
     }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fix #97  

Follow-up actions on previous PR #103 

### Description

- Added more comments to CompletableFuture related code
- Added a new design doc ADR-003 for CompletableFuture based operation coordination
- Removed duplicate method `isTerminalStatus`
- Fixed a bug in ChildContextOperation that doesn't handle `SuspendExecutionException` properly, causing flaky test cases
- Fixed minor issues with runners
   - Added handling of errors in `CloudDurableTestRunner`
   - Fixed LocalDurableTestRunner gets stuck when skipTimer is true 
- Replaced some magic values in test cases with constants
- simplified thread local and active thread management
   - removed unset/reset thread local object from `waitForOperationCompletion`. Thread local object is set when the thread is started and it is recycled when the thread is terminated. 
   - removed thread type from active thread tracker. Only thread id is needed to track active threads.
   - renamed some methods to better reflect the purpose and avoid confusion. `Context` is renamed to `ThreadContext` to reflect that it's stored in thread local.




### Demo/Screenshots




### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Yes

#### Integration Tests

Have integration tests been written for these changes? Yes

#### Examples

Has a new example been added for the change? (if applicable) Yes
