### PR TITLE
fix/mavenurl

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -15,6 +15,13 @@
 
     <name>AWS Lambda Durable Execution SDK Examples</name>
     <description>Example applications using the AWS Lambda Durable Execution SDK</description>
+    <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
+
+    <scm>
+        <connection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</connection>
+        <developerConnection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</developerConnection>
+        <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
+    </scm>
 
     <dependencies>
         <!-- Local SDK dependency -->

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <name>AWS Lambda Durable Execution SDK Parent</name>
     <description>Parent POM for AWS Lambda Durable Execution SDK and Examples</description>
-    <url>https://github.com/aws/aws-lambda-java-durable-execution-sdk</url>
+    <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
 
     <licenses>
         <license>
@@ -33,7 +33,9 @@
     </developers>
 
     <scm>
-        <url>https://github.com/aws/aws-lambda-java-durable-execution-sdk.git</url>
+        <connection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</connection>
+        <developerConnection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</developerConnection>
+        <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
     </scm>
 
     <modules>

--- a/sdk-integration-tests/pom.xml
+++ b/sdk-integration-tests/pom.xml
@@ -15,6 +15,13 @@
 
     <name>AWS Lambda Durable Execution SDK Integration Tests</name>
     <description>Integration tests for AWS Lambda Durable Execution SDK</description>
+    <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
+
+    <scm>
+        <connection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</connection>
+        <developerConnection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</developerConnection>
+        <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
+    </scm>
 
     <dependencies>
         <dependency>

--- a/sdk-testing/pom.xml
+++ b/sdk-testing/pom.xml
@@ -15,6 +15,13 @@
 
     <name>AWS Lambda Durable Execution SDK Testing Utilities</name>
     <description>Testing utilities for AWS Lambda Durable Execution SDK</description>
+    <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
+
+    <scm>
+        <connection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</connection>
+        <developerConnection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</developerConnection>
+        <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
+    </scm>
 
     <dependencies>
         <!-- SDK dependency -->

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -15,6 +15,13 @@
 
     <name>AWS Lambda Durable Execution SDK for Java</name>
     <description>Java SDK for AWS Lambda Durable Functions</description>
+    <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
+
+    <scm>
+        <connection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</connection>
+        <developerConnection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</developerConnection>
+        <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
+    </scm>
 
     <dependencies>
         <!-- AWS Lambda Java Core -->


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

**Fix maven url in pom**
- We only set urls in parent POM before, flatten-pom-plugin will automatically append the artifact name in the URL, causing the url on maven to break.
- I added <url> and <scm> field in child pom so that it will not be overriden by the plugin.
- This fix will take effect when next release is published to maven.
- For the url used in <scm> section, please refer to: https://maven.apache.org/pom.html#scm

### Demo/Screenshots

N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

`mvn clean install`

Manually verified that in the `.flattened-pom.xml`, we are using

```
    <url>https://github.com/aws/aws-durable-execution-sdk-java</url>

    <scm>
        <connection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</connection>
        <developerConnection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</developerConnection>
        <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
    </scm>
```

#### Unit Tests

N/A

#### Integration Tests

N/A

#### Examples

N/A