### PR TITLE
[refactor] split execute method

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -100,8 +100,23 @@ public abstract class BaseDurableOperation<T> implements DurableFuture<T> {
         return operationType;
     }
 
-    /** Starts the operation. Returns immediately after starting background work or checkpointing. Does not block. */
-    public abstract void execute();
+    /** Starts the operation, processes the operation updates from backend. Does not block. */
+    public void execute() {
+        var existing = getOperation();
+
+        if (existing != null) {
+            validateReplay(existing);
+            replay(existing);
+        } else {
+            start();
+        }
+    }
+
+    /** Starts the operation. */
+    protected abstract void start();
+
+    /** Replays the operation. */
+    protected abstract void replay(Operation existing);
 
     /**
      * Gets the Operation from ExecutionManager and update the replay state from REPLAY to EXECUTE if operation is not

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/CallbackOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/CallbackOperation.java
@@ -3,6 +3,7 @@
 package software.amazon.lambda.durable.operation;
 
 import software.amazon.awssdk.services.lambda.model.CallbackOptions;
+import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationAction;
 import software.amazon.awssdk.services.lambda.model.OperationType;
 import software.amazon.awssdk.services.lambda.model.OperationUpdate;
@@ -34,44 +35,40 @@ public class CallbackOperation<T> extends BaseDurableOperation<T> implements Dur
         return callbackId;
     }
 
+    /** Starts the operation. */
     @Override
-    public void execute() {
-        var existing = getOperation();
+    protected void start() {
+        // First execution: checkpoint and get callback ID
+        var update = OperationUpdate.builder().action(OperationAction.START).callbackOptions(buildCallbackOptions());
 
-        if (existing != null) {
-            validateReplay(existing);
-        }
+        sendOperationUpdate(update);
 
-        if (existing != null && existing.callbackDetails() != null) {
-            // Replay: use existing callback ID
-            callbackId = existing.callbackDetails().callbackId();
+        // Get the callback ID from the updated operation
+        var op = getOperation();
+        callbackId = op.callbackDetails().callbackId();
 
-            switch (existing.status()) {
-                case SUCCEEDED, FAILED, TIMED_OUT -> {
-                    // Terminal state - complete the operation immediately
-                    markAlreadyCompleted();
-                    return;
-                }
-                case STARTED -> {
-                    // Still waiting - continue to polling
-                }
-                default ->
-                    terminateExecutionWithIllegalDurableOperationException(
-                            "Unexpected callback status: " + existing.status());
+        pollForOperationUpdates();
+    }
+
+    /** Replays the operation. */
+    @Override
+    protected void replay(Operation existing) {
+        // Replay: use existing callback ID
+        callbackId = existing.callbackDetails().callbackId();
+
+        switch (existing.status()) {
+            case SUCCEEDED, FAILED, TIMED_OUT -> {
+                // Terminal state - complete the operation immediately
+                markAlreadyCompleted();
+                return;
             }
-        } else {
-            // First execution: checkpoint and get callback ID
-            var update =
-                    OperationUpdate.builder().action(OperationAction.START).callbackOptions(buildCallbackOptions());
-
-            sendOperationUpdate(update);
-
-            // Get the callback ID from the updated operation
-            var op = getOperation();
-            callbackId = op.callbackDetails().callbackId();
+            case STARTED -> {
+                // Still waiting - continue to polling
+            }
+            default ->
+                terminateExecutionWithIllegalDurableOperationException(
+                        "Unexpected callback status: " + existing.status());
         }
-
-        // Start polling for callback completion (delay first poll to allow suspension)
         pollForOperationUpdates();
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import software.amazon.awssdk.services.lambda.model.ContextOptions;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
+import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationAction;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.awssdk.services.lambda.model.OperationType;
@@ -51,34 +52,34 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
         this.userExecutor = getContext().getDurableConfig().getExecutorService();
     }
 
+    /** Starts the operation. */
     @Override
-    public void execute() {
-        var existing = getOperation();
+    protected void start() {
+        // First execution: fire-and-forget START checkpoint, then run
+        sendOperationUpdateAsync(
+                OperationUpdate.builder().action(OperationAction.START).subType(RUN_IN_CHILD_CONTEXT.getValue()));
+        executeChildContext();
+    }
 
-        if (existing != null) {
-            validateReplay(existing);
-            switch (existing.status()) {
-                case SUCCEEDED -> {
-                    if (existing.contextDetails() != null
-                            && Boolean.TRUE.equals(existing.contextDetails().replayChildren())) {
-                        // Large result: re-execute child context to reconstruct result
-                        replayChildContext = true;
-                        executeChildContext();
-                    } else {
-                        markAlreadyCompleted();
-                    }
+    /** Replays the operation. */
+    @Override
+    protected void replay(Operation existing) {
+        switch (existing.status()) {
+            case SUCCEEDED -> {
+                if (existing.contextDetails() != null
+                        && Boolean.TRUE.equals(existing.contextDetails().replayChildren())) {
+                    // Large result: re-execute child context to reconstruct result
+                    replayChildContext = true;
+                    executeChildContext();
+                } else {
+                    markAlreadyCompleted();
                 }
-                case FAILED -> markAlreadyCompleted();
-                case STARTED -> executeChildContext();
-                default ->
-                    terminateExecutionWithIllegalDurableOperationException(
-                            "Unexpected child context status: " + existing.status());
             }
-        } else {
-            // First execution: fire-and-forget START checkpoint, then run
-            sendOperationUpdateAsync(
-                    OperationUpdate.builder().action(OperationAction.START).subType(RUN_IN_CHILD_CONTEXT.getValue()));
-            executeChildContext();
+            case FAILED -> markAlreadyCompleted();
+            case STARTED -> executeChildContext();
+            default ->
+                terminateExecutionWithIllegalDurableOperationException(
+                        "Unexpected child context status: " + existing.status());
         }
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/InvokeOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/InvokeOperation.java
@@ -3,6 +3,7 @@
 package software.amazon.lambda.durable.operation;
 
 import software.amazon.awssdk.services.lambda.model.ChainedInvokeOptions;
+import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationAction;
 import software.amazon.awssdk.services.lambda.model.OperationType;
 import software.amazon.awssdk.services.lambda.model.OperationUpdate;
@@ -37,25 +38,23 @@ public class InvokeOperation<T, U> extends BaseDurableOperation<T> {
         this.payloadSerDes = config.payloadSerDes() != null ? config.payloadSerDes() : config.serDes();
     }
 
-    /** Starts the operation. Returns immediately after starting background work or checkpointing. Does not block. */
+    /** Starts the operation. */
     @Override
-    public void execute() {
-        var existing = getOperation();
-        if (existing == null) {
-            // first execution
-            startInvocation();
-            pollForOperationUpdates();
-        } else {
-            validateReplay(existing);
-            // replay
-            switch (existing.status()) {
-                // The result isn't ready. Need to wait more
-                case STARTED -> pollForOperationUpdates();
-                case SUCCEEDED, FAILED, TIMED_OUT, STOPPED -> markAlreadyCompleted();
-                default ->
-                    terminateExecutionWithIllegalDurableOperationException(
-                            "Unexpected invoke status: " + existing.statusAsString());
-            }
+    protected void start() {
+        startInvocation();
+        pollForOperationUpdates();
+    }
+
+    /** Replays the operation. */
+    @Override
+    protected void replay(Operation existing) {
+        switch (existing.status()) {
+            // The result isn't ready. Need to wait more
+            case STARTED -> pollForOperationUpdates();
+            case SUCCEEDED, FAILED, TIMED_OUT, STOPPED -> markAlreadyCompleted();
+            default ->
+                terminateExecutionWithIllegalDurableOperationException(
+                        "Unexpected invoke status: " + existing.statusAsString());
         }
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
+import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationAction;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.awssdk.services.lambda.model.OperationType;
@@ -45,39 +46,35 @@ public class StepOperation<T> extends BaseDurableOperation<T> {
         this.userExecutor = durableContext.getDurableConfig().getExecutorService();
     }
 
+    /** Starts the operation. */
     @Override
-    public void execute() {
-        var existing = getOperation();
+    protected void start() {
+        executeStepLogic(0);
+    }
 
-        if (existing != null) {
-            validateReplay(existing);
-            // This means we are in a replay scenario
-            switch (existing.status()) {
-                case SUCCEEDED, FAILED -> markAlreadyCompleted();
-                case STARTED -> {
-                    var attempt = existing.stepDetails().attempt() != null
-                            ? existing.stepDetails().attempt()
-                            : 0;
-                    if (config.semantics() == StepSemantics.AT_MOST_ONCE_PER_RETRY) {
-                        // AT_MOST_ONCE: treat as interrupted, go through retry logic
-                        handleStepFailure(new StepInterruptedException(existing), attempt + 1);
-                    } else {
-                        // AT_LEAST_ONCE: re-execute the step
-                        executeStepLogic(attempt);
-                    }
+    /** Replays the operation. */
+    @Override
+    protected void replay(Operation existing) {
+        switch (existing.status()) {
+            case SUCCEEDED, FAILED -> markAlreadyCompleted();
+            case STARTED -> {
+                var attempt = existing.stepDetails().attempt() != null
+                        ? existing.stepDetails().attempt()
+                        : 0;
+                if (config.semantics() == StepSemantics.AT_MOST_ONCE_PER_RETRY) {
+                    // AT_MOST_ONCE: treat as interrupted, go through retry logic
+                    handleStepFailure(new StepInterruptedException(existing), attempt + 1);
+                } else {
+                    // AT_LEAST_ONCE: re-execute the step
+                    executeStepLogic(attempt);
                 }
-                // Step is pending retry - Start polling for PENDING -> READY transition
-                case PENDING ->
-                    pollReadyAndExecuteStepLogic(existing.stepDetails().attempt());
-                // Execute with current attempt
-                case READY -> executeStepLogic(existing.stepDetails().attempt());
-                default ->
-                    terminateExecutionWithIllegalDurableOperationException(
-                            "Unexpected step status: " + existing.status());
             }
-        } else {
-            // First execution
-            executeStepLogic(0);
+            // Step is pending retry - Start polling for PENDING -> READY transition
+            case PENDING -> pollReadyAndExecuteStepLogic(existing.stepDetails().attempt());
+            // Execute with current attempt
+            case READY -> executeStepLogic(existing.stepDetails().attempt());
+            default ->
+                terminateExecutionWithIllegalDurableOperationException("Unexpected step status: " + existing.status());
         }
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitOperation.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationAction;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.awssdk.services.lambda.model.OperationType;
@@ -30,36 +31,40 @@ public class WaitOperation extends BaseDurableOperation<Void> {
         this.duration = duration;
     }
 
+    /** Starts the operation. */
     @Override
-    public void execute() {
-        var existing = getOperation();
+    protected void start() {
         Duration remainingWaitTime = duration;
 
-        if (existing != null) {
-            validateReplay(existing);
-            if (existing.status() == OperationStatus.SUCCEEDED) {
-                // Wait already completed
-                markAlreadyCompleted();
-                return;
-            }
-            // Replay - calculate remaining time from scheduledEndTimestamp
-            // TODO: if the checkpoint is slow remaining wait time might be off. Track
-            // endTimestamp instead and move calculation in front of polling start.
-            if (existing.waitDetails() != null && existing.waitDetails().scheduledEndTimestamp() != null) {
-                remainingWaitTime =
-                        Duration.between(Instant.now(), existing.waitDetails().scheduledEndTimestamp());
-            }
-        } else {
-            // First execution - checkpoint with full duration
-            var update = OperationUpdate.builder()
-                    .action(OperationAction.START)
-                    .waitOptions(WaitOptions.builder()
-                            .waitSeconds((int) duration.toSeconds())
-                            .build());
+        // First execution - checkpoint with full duration
+        var update = OperationUpdate.builder()
+                .action(OperationAction.START)
+                .waitOptions(WaitOptions.builder()
+                        .waitSeconds((int) duration.toSeconds())
+                        .build());
 
-            sendOperationUpdate(update);
+        sendOperationUpdate(update);
+        logger.debug("Remaining wait time: {} seconds", remainingWaitTime.getSeconds());
+        pollForOperationUpdates(remainingWaitTime);
+    }
+
+    /** Replays the operation. */
+    @Override
+    protected void replay(Operation existing) {
+        Duration remainingWaitTime = duration;
+
+        if (existing.status() == OperationStatus.SUCCEEDED) {
+            // Wait already completed
+            markAlreadyCompleted();
+            return;
         }
-
+        // Replay - calculate remaining time from scheduledEndTimestamp
+        // TODO: if the checkpoint is slow remaining wait time might be off. Track
+        // endTimestamp instead and move calculation in front of polling start.
+        if (existing.waitDetails() != null && existing.waitDetails().scheduledEndTimestamp() != null) {
+            remainingWaitTime =
+                    Duration.between(Instant.now(), existing.waitDetails().scheduledEndTimestamp());
+        }
         logger.debug("Remaining wait time: {} seconds", remainingWaitTime.getSeconds());
         pollForOperationUpdates(remainingWaitTime);
     }

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/BaseDurableOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/BaseDurableOperationTest.java
@@ -68,7 +68,10 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {}
+                    protected void start() {}
+
+                    @Override
+                    protected void replay(Operation existing) {}
 
                     @Override
                     public String get() {
@@ -90,10 +93,13 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {
+                    protected void start() {
                         markAlreadyCompleted();
                         assertThrows(IllegalDurableOperationException.class, this::waitForOperationCompletion);
                     }
+
+                    @Override
+                    protected void replay(Operation existing) {}
 
                     @Override
                     public String get() {
@@ -112,7 +118,10 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {}
+                    protected void start() {}
+
+                    @Override
+                    protected void replay(Operation existing) {}
 
                     @Override
                     public String get() {
@@ -142,10 +151,13 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {
+                    protected void start() {
                         markAlreadyCompleted();
                         waitForOperationCompletion();
                     }
+
+                    @Override
+                    protected void replay(Operation existing) {}
 
                     @Override
                     public String get() {
@@ -164,11 +176,14 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {
+                    protected void start() {
                         markAlreadyCompleted();
                         // completion future should be complete
                         assertTrue(this.isOperationCompleted());
                     }
+
+                    @Override
+                    protected void replay(Operation existing) {}
 
                     @Override
                     public String get() {
@@ -189,9 +204,12 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {
+                    protected void start() {
                         validateReplay(getOperation());
                     }
+
+                    @Override
+                    protected void replay(Operation existing) {}
 
                     @Override
                     public String get() {
@@ -214,9 +232,12 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {
+                    protected void start() {
                         validateReplay(getOperation());
                     }
+
+                    @Override
+                    protected void replay(Operation existing) {}
 
                     @Override
                     public String get() {
@@ -235,9 +256,12 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {
+                    protected void start() {
                         validateReplay(getOperation());
                     }
+
+                    @Override
+                    protected void replay(Operation existing) {}
 
                     @Override
                     public String get() {
@@ -259,9 +283,12 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {
+                    protected void start() {
                         validateReplay(getOperation());
                     }
+
+                    @Override
+                    protected void replay(Operation existing) {}
 
                     @Override
                     public String get() {
@@ -277,7 +304,10 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {}
+                    protected void start() {}
+
+                    @Override
+                    protected void replay(Operation existing) {}
 
                     @Override
                     public String get() {
@@ -296,7 +326,10 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {}
+                    protected void start() {}
+
+                    @Override
+                    protected void replay(Operation existing) {}
 
                     @Override
                     public String get() {
@@ -320,7 +353,10 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {
+                    protected void start() {}
+
+                    @Override
+                    protected void replay(Operation existing) {
                         pollForOperationUpdates();
                     }
 
@@ -342,7 +378,10 @@ class BaseDurableOperationTest {
                 new BaseDurableOperation<>(
                         OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, RESULT_TYPE, SER_DES, durableContext) {
                     @Override
-                    public void execute() {
+                    protected void start() {}
+
+                    @Override
+                    protected void replay(Operation existing) {
                         sendOperationUpdate(update);
                     }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

#87 

### Description

Split BaseDurableOperation::execute() into 2 separate methods start() and replay() so that
- start() for initial execution of the operation
- replay() for when the operation is replayed
- more shared logic moved to the base class BaseDurableOperation

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Updated

#### Integration Tests

Have integration tests been written for these changes? Not impacted

#### Examples

Has a new example been added for the change? (if applicable) Not impacted
