### PR TITLE
[Test]: add a small checkpoint delay for ManyAsyncStepsExample

### DIFF
--- a/examples/src/main/java/software/amazon/lambda/durable/examples/ManyAsyncStepsExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/ManyAsyncStepsExample.java
@@ -4,6 +4,7 @@ package software.amazon.lambda.durable.examples;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableFuture;
 import software.amazon.lambda.durable.DurableHandler;
@@ -53,6 +54,13 @@ public class ManyAsyncStepsExample extends DurableHandler<ManyAsyncStepsExample.
         // Wait 10 seconds to test replay
         context.wait("post-compute-wait", Duration.ofSeconds(10));
 
-        return String.format("Completed %d async steps. Sum: %d, Time: %dms", STEP_COUNT, totalSum, executionTimeMs);
+        return String.format(
+                "Completed %d async steps. Sum: %d, Replay Time: %dms", STEP_COUNT, totalSum, executionTimeMs);
+    }
+
+    @Override
+    protected DurableConfig createConfiguration() {
+        // add a small checkpoint delay to allow checkpoint batching
+        return DurableConfig.builder().withCheckpointDelay(Duration.ofMillis(1)).build();
     }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

#143 

### Description

- Added a small checkpoint delay for ManyAsyncStepsExample to allow checkpoint batching
- Updated the output string of ManyAsyncStepsExample to make it clear it's replay time (not execution time).

### Demo/Screenshots

<img width="582" height="254" alt="image" src="https://github.com/user-attachments/assets/a7175516-f516-411c-9e9d-fdcfeae2f46e" />


### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) Updated
