### PR TITLE
Change operation IDs to hashed values

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/IntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/IntegrationTest.java
@@ -110,12 +110,12 @@ class IntegrationTest {
 
         assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
         assertEquals(3, result.getSucceededOperations().size());
-        assertEquals("Step 1 done", result.getSucceededOperations().get(0).getStepResult(String.class));
+        assertEquals("Step 1 done", result.getOperation("step1").getStepResult(String.class));
         assertEquals(OperationType.WAIT, result.getSucceededOperations().get(1).getType());
         assertEquals(
                 OperationStatus.SUCCEEDED,
                 result.getSucceededOperations().get(1).getStatus());
-        assertEquals("Step 2 done", result.getSucceededOperations().get(2).getStepResult(String.class));
+        assertEquals("Step 2 done", result.getOperation("step2").getStepResult(String.class));
         assertEquals("Step 1 done + Step 2 done", result.getResult(TestOutput.class).result);
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableContext.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableContext.java
@@ -3,7 +3,11 @@
 package software.amazon.lambda.durable;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.HexFormat;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -327,12 +331,20 @@ public class DurableContext extends BaseContext {
     }
 
     /**
-     * Get the next operationId. For root contexts, returns sequential IDs like "1", "2", "3". For child contexts,
-     * prefixes with the contextId to ensure global uniqueness, e.g. "1-1", "1-2" for operations inside child context
-     * "1". This matches the JavaScript SDK's stepPrefix convention and prevents ID collisions in checkpoint batches.
+     * Get the next operationId. Returns a globally unique operation ID by hashing a sequential operation counter. For
+     * root contexts, the counter value is hashed directly (e.g. "1", "2", "3"). For child contexts, the values are
+     * prefixed with the parent hashed contextId (e.g. "<hash>-1", "<hash>-2" inside parent context <hash>). This
+     * matches the JavaScript SDK's stepPrefix convention and prevents ID collisions in checkpoint batches.
      */
     private String nextOperationId() {
         var counter = String.valueOf(operationCounter.incrementAndGet());
-        return getContextId() != null ? getContextId() + "-" + counter : counter;
+        var rawId = getContextId() != null ? getContextId() + "-" + counter : counter;
+        try {
+            var messageDigest = MessageDigest.getInstance("SHA-256");
+            var hash = messageDigest.digest(rawId.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("failed to get next operation id, SHA-256 not available", e);
+        }
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableContextTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableContextTest.java
@@ -24,9 +24,9 @@ class DurableContextTest {
             .type(OperationType.EXECUTION)
             .status(OperationStatus.STARTED)
             .build();
-    private static final String OPERATION_ID1 = "1";
-    private static final String OPERATION_ID2 = "2";
-    private static final String OPERATION_ID3 = "3";
+    private static final String OPERATION_ID1 = TestUtils.hashOperationId("1");
+    private static final String OPERATION_ID2 = TestUtils.hashOperationId("2");
+    private static final String OPERATION_ID3 = TestUtils.hashOperationId("3");
 
     private DurableContext createTestContext() {
         return createTestContext(List.of());

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableExecutionTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableExecutionTest.java
@@ -23,6 +23,9 @@ import software.amazon.lambda.durable.model.ExecutionStatus;
 
 class DurableExecutionTest {
 
+    private static final String OPERATION_ID0 = TestUtils.hashOperationId("0");
+    private static final String OPERATION_ID1 = TestUtils.hashOperationId("1");
+
     private DurableConfig configWithMockClient() {
         return DurableConfig.builder()
                 .withDurableExecutionClient(TestUtils.createMockClient())
@@ -32,7 +35,7 @@ class DurableExecutionTest {
     @Test
     void testExecuteSuccess() {
         var executionOp = Operation.builder()
-                .id("0")
+                .id(OPERATION_ID0)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -62,7 +65,7 @@ class DurableExecutionTest {
     @Test
     void testExecutePending() {
         var executionOp = Operation.builder()
-                .id("0")
+                .id(OPERATION_ID0)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -95,7 +98,7 @@ class DurableExecutionTest {
     @Test
     void testExecuteFailure() {
         var executionOp = Operation.builder()
-                .id("0")
+                .id(OPERATION_ID0)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -128,7 +131,7 @@ class DurableExecutionTest {
     @Test
     void testExecuteReplay() {
         var executionOp = Operation.builder()
-                .id("0")
+                .id(OPERATION_ID0)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -137,7 +140,7 @@ class DurableExecutionTest {
                 .build();
 
         var completedStep = Operation.builder()
-                .id("1")
+                .id(OPERATION_ID1)
                 .name("step1")
                 .type(OperationType.STEP)
                 .status(OperationStatus.SUCCEEDED)
@@ -180,7 +183,7 @@ class DurableExecutionTest {
     @Test
     void testValidationWrongFirstOperation() {
         var stepOp = Operation.builder()
-                .id("1")
+                .id(OPERATION_ID1)
                 .type(OperationType.STEP)
                 .status(OperationStatus.SUCCEEDED)
                 .stepDetails(StepDetails.builder().result("\"result\"").build())
@@ -204,7 +207,7 @@ class DurableExecutionTest {
     @Test
     void testValidationMissingExecutionDetails() {
         var executionOp = Operation.builder()
-                .id("0")
+                .id(OPERATION_ID0)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .build();
@@ -234,7 +237,7 @@ class DurableExecutionTest {
         assertFalse(sharedExecutor.isShutdown(), "Executor should not be shutdown initially");
 
         var executionOp = Operation.builder()
-                .id("0")
+                .id(OPERATION_ID0)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -262,7 +265,7 @@ class DurableExecutionTest {
 
         // Create second input with different execution operation
         var executionOp2 = Operation.builder()
-                .id("0")
+                .id(OPERATION_ID0)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()

--- a/sdk/src/test/java/software/amazon/lambda/durable/ReplayValidationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/ReplayValidationTest.java
@@ -24,7 +24,7 @@ import software.amazon.lambda.durable.model.DurableExecutionInput;
 class ReplayValidationTest {
     public static final String EXECUTION_NAME = "exec-name";
     public static final String INVOCATION_ID = "invocation-id";
-    public static final String OPERATION_ID1 = "1";
+    public static final String OPERATION_ID1 = TestUtils.hashOperationId("1");
 
     private DurableContext createTestContext(List<Operation> initialOperations) {
         var client = TestUtils.createMockClient();

--- a/sdk/src/test/java/software/amazon/lambda/durable/TestUtils.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/TestUtils.java
@@ -5,7 +5,11 @@ package software.amazon.lambda.durable;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.UUID;
 import software.amazon.awssdk.services.lambda.model.*;
@@ -60,5 +64,15 @@ public class TestUtils {
                     .build();
         });
         return client;
+    }
+
+    public static String hashOperationId(String rawId) {
+        try {
+            var messageDigest = MessageDigest.getInstance("SHA-256");
+            var hash = messageDigest.digest(rawId.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new AssertionError("SHA-256 not available", e);
+        }
     }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

https://github.com/aws/aws-durable-execution-sdk-java/issues/83

### Description

Operation IDs are now hashed (using `SHA-256`), to allow for more levels of child contexts without the possibility of going over the 64 character limit for IDs.

Also updated all unit tests that check for a specific operation ID to check for the hashed value.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

Existing unit tests have been updated.

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
