### PR TITLE
[bug]: Configure concurrency for e2e-tests workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,6 +23,10 @@ on:
       - 'examples/**'
       - 'pom.xml'
 
+concurrency:
+  group: e2e-tests
+  cancel-in-progress: false
+
 # permission can be added at job level or workflow level
 permissions:
   id-token: write # This is required for requesting the JWT


### PR DESCRIPTION
Add concurrency settings to e2e tests workflow

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

#139 

### Description

Followed the instructions here: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency

This might be further improved to use per job concurrency control

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable)
