### PR TITLE
[Refactor]: minor code cleanup and improvements

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/BaseContext.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/BaseContext.java
@@ -4,15 +4,20 @@ package software.amazon.lambda.durable;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import software.amazon.lambda.durable.execution.ExecutionManager;
+import software.amazon.lambda.durable.execution.SuspendExecutionException;
+import software.amazon.lambda.durable.execution.ThreadContext;
+import software.amazon.lambda.durable.execution.ThreadType;
 import software.amazon.lambda.durable.logging.DurableLogger;
 
 public abstract class BaseContext implements AutoCloseable {
-    protected final ExecutionManager executionManager;
+    private final ExecutionManager executionManager;
     private final DurableConfig durableConfig;
     private final Context lambdaContext;
     private final ExecutionContext executionContext;
     private final String contextId;
     private final String contextName;
+    private final ThreadType threadType;
+
     private boolean isReplaying;
 
     /** Creates a new BaseContext instance. */
@@ -21,7 +26,8 @@ public abstract class BaseContext implements AutoCloseable {
             DurableConfig durableConfig,
             Context lambdaContext,
             String contextId,
-            String contextName) {
+            String contextName,
+            ThreadType threadType) {
         this.executionManager = executionManager;
         this.durableConfig = durableConfig;
         this.lambdaContext = lambdaContext;
@@ -29,6 +35,10 @@ public abstract class BaseContext implements AutoCloseable {
         this.contextName = contextName;
         this.executionContext = new ExecutionContext(executionManager.getDurableExecutionArn());
         this.isReplaying = executionManager.hasOperationsForContext(contextId);
+        this.threadType = threadType;
+
+        // write the thread id and type to thread local
+        executionManager.setCurrentThreadContext(new ThreadContext(contextId, threadType));
     }
 
     // =============== accessors ================
@@ -95,5 +105,23 @@ public abstract class BaseContext implements AutoCloseable {
      */
     void setExecutionMode() {
         this.isReplaying = false;
+    }
+
+    public void close() {
+        // this is called in the user thread, after the context's user code has completed
+        if (getContextId() != null) {
+            // if this is a child context or a step context, we need to
+            // deregister the context's thread from the execution manager
+            try {
+                executionManager.deregisterActiveThread(getContextId());
+            } catch (SuspendExecutionException e) {
+                // Expected when this is the last active thread. Must catch here because:
+                // 1/ This runs in a worker thread detached from handlerFuture
+                // 2/ Uncaught exception would prevent stepAsync().get() from resume
+                // Suspension/Termination is already signaled via
+                // suspendExecutionFuture/terminateExecutionFuture
+                // before the throw.
+            }
+        }
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableContext.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableContext.java
@@ -15,6 +15,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.LoggerFactory;
 import software.amazon.lambda.durable.execution.ExecutionManager;
+import software.amazon.lambda.durable.execution.ThreadType;
 import software.amazon.lambda.durable.logging.DurableLogger;
 import software.amazon.lambda.durable.model.OperationSubType;
 import software.amazon.lambda.durable.operation.CallbackOperation;
@@ -39,7 +40,7 @@ public class DurableContext extends BaseContext {
             Context lambdaContext,
             String contextId,
             String contextName) {
-        super(executionManager, durableConfig, lambdaContext, contextId, contextName);
+        super(executionManager, durableConfig, lambdaContext, contextId, contextName, ThreadType.CONTEXT);
         this.operationCounter = new AtomicInteger(0);
     }
 
@@ -66,7 +67,7 @@ public class DurableContext extends BaseContext {
      */
     public DurableContext createChildContext(String childContextId, String childContextName) {
         return new DurableContext(
-                executionManager, getDurableConfig(), getLambdaContext(), childContextId, childContextName);
+                getExecutionManager(), getDurableConfig(), getLambdaContext(), childContextId, childContextName);
     }
 
     /**
@@ -77,7 +78,12 @@ public class DurableContext extends BaseContext {
      */
     public StepContext createStepContext(String stepOperationId, String stepOperationName, int attempt) {
         return new StepContext(
-                executionManager, getDurableConfig(), getLambdaContext(), stepOperationId, stepOperationName, attempt);
+                getExecutionManager(),
+                getDurableConfig(),
+                getLambdaContext(),
+                stepOperationId,
+                stepOperationName,
+                attempt);
     }
 
     // ========== step methods ==========
@@ -170,18 +176,19 @@ public class DurableContext extends BaseContext {
 
     // ========== wait methods ==========
 
-    public Void wait(String waitName, Duration duration) {
-        return waitAsync(waitName, duration).get(); // Block (will throw SuspendExecutionException if needed)
+    public Void wait(String name, Duration duration) {
+        // Block (will throw SuspendExecutionException if there is no active thread)
+        return waitAsync(name, duration).get();
     }
 
-    public DurableFuture<Void> waitAsync(String waitName, Duration duration) {
+    public DurableFuture<Void> waitAsync(String name, Duration duration) {
         ParameterValidator.validateDuration(duration, "Wait duration");
-        ParameterValidator.validateOperationName(waitName);
+        ParameterValidator.validateOperationName(name);
 
         var operationId = nextOperationId();
 
         // Create and start wait operation
-        var operation = new WaitOperation(operationId, waitName, duration, this);
+        var operation = new WaitOperation(operationId, name, duration, this);
 
         operation.execute(); // Checkpoint the wait
         return operation;
@@ -444,6 +451,7 @@ public class DurableContext extends BaseContext {
         if (logger != null) {
             logger.close();
         }
+        super.close();
     }
 
     /**

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableExecutor.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableExecutor.java
@@ -19,8 +19,6 @@ import software.amazon.lambda.durable.exception.IllegalDurableOperationException
 import software.amazon.lambda.durable.exception.UnrecoverableDurableExecutionException;
 import software.amazon.lambda.durable.execution.ExecutionManager;
 import software.amazon.lambda.durable.execution.SuspendExecutionException;
-import software.amazon.lambda.durable.execution.ThreadContext;
-import software.amazon.lambda.durable.execution.ThreadType;
 import software.amazon.lambda.durable.model.DurableExecutionInput;
 import software.amazon.lambda.durable.model.DurableExecutionOutput;
 import software.amazon.lambda.durable.serde.SerDes;
@@ -46,8 +44,6 @@ public class DurableExecutor {
                                 executionManager.getExecutionOperation(), config.getSerDes(), inputType);
                         // use try-with-resources to clear logger properties
                         try (var context = DurableContext.createRootContext(executionManager, config, lambdaContext)) {
-                            // Create context in the executor thread so it detects the correct thread name
-                            executionManager.setCurrentThreadContext(new ThreadContext(null, ThreadType.CONTEXT));
                             return handler.apply(userInput, context);
                         }
                     },

--- a/sdk/src/main/java/software/amazon/lambda/durable/StepContext.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/StepContext.java
@@ -5,6 +5,7 @@ package software.amazon.lambda.durable;
 import com.amazonaws.services.lambda.runtime.Context;
 import org.slf4j.LoggerFactory;
 import software.amazon.lambda.durable.execution.ExecutionManager;
+import software.amazon.lambda.durable.execution.ThreadType;
 import software.amazon.lambda.durable.logging.DurableLogger;
 
 public class StepContext extends BaseContext {
@@ -26,7 +27,7 @@ public class StepContext extends BaseContext {
             String stepOperationId,
             String stepOperationName,
             int attempt) {
-        super(executionManager, durableConfig, lambdaContext, stepOperationId, stepOperationName);
+        super(executionManager, durableConfig, lambdaContext, stepOperationId, stepOperationName, ThreadType.STEP);
         this.attempt = attempt;
     }
 
@@ -54,5 +55,6 @@ public class StepContext extends BaseContext {
         if (logger != null) {
             logger.close();
         }
+        super.close();
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -81,11 +81,6 @@ public abstract class BaseDurableOperation<T> implements DurableFuture<T> {
         return operationId;
     }
 
-    /** Gets the unique thread id */
-    protected String getThreadId() {
-        return getOperationId() + "-" + getType().name().toLowerCase();
-    }
-
     /** Gets the operation name (maybe null). */
     public String getName() {
         return name;
@@ -186,7 +181,7 @@ public abstract class BaseDurableOperation<T> implements DurableFuture<T> {
                 completionFuture.thenRun(() -> registerActiveThread(threadContext.threadId()));
 
                 // Deregister the current thread to allow suspension
-                deregisterActiveThread(threadContext.threadId());
+                executionManager.deregisterActiveThread(threadContext.threadId());
             }
         }
 
@@ -245,20 +240,12 @@ public abstract class BaseDurableOperation<T> implements DurableFuture<T> {
     }
 
     // advanced thread and context control
-    protected void deregisterActiveThread(String threadId) {
-        executionManager.deregisterActiveThread(threadId);
-    }
-
     protected void registerActiveThread(String threadId) {
         executionManager.registerActiveThread(threadId);
     }
 
     protected ThreadContext getCurrentThreadContext() {
         return executionManager.getCurrentThreadContext();
-    }
-
-    protected void setCurrentThreadContext(ThreadContext threadContext) {
-        executionManager.setCurrentThreadContext(threadContext);
     }
 
     // polling and checkpointing

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
@@ -26,8 +26,6 @@ import software.amazon.lambda.durable.exception.StepFailedException;
 import software.amazon.lambda.durable.exception.StepInterruptedException;
 import software.amazon.lambda.durable.exception.UnrecoverableDurableExecutionException;
 import software.amazon.lambda.durable.execution.SuspendExecutionException;
-import software.amazon.lambda.durable.execution.ThreadContext;
-import software.amazon.lambda.durable.execution.ThreadType;
 import software.amazon.lambda.durable.model.OperationSubType;
 import software.amazon.lambda.durable.serde.SerDes;
 import software.amazon.lambda.durable.util.ExceptionHelper;
@@ -96,7 +94,9 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
     private void executeChildContext() {
         // The operationId is already globally unique (prefixed by parent context path via
         // DurableContext.nextOperationId), so we use it directly as the contextId.
-        // E.g., root child context "1", nested child context "1-2", deeply nested "1-2-1".
+        // E.g., first level child context "hash(1)",
+        //       second level child context "hash(hash(1)-2)",
+        //       third level child context "hash(hash(hash(1)-2)-1)".
         var contextId = getOperationId();
 
         // Thread registration is intentionally split across two threads:
@@ -107,35 +107,34 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
         // registerActiveThread is idempotent (no-op if already registered).
         registerActiveThread(contextId);
 
-        CompletableFuture.runAsync(
-                () -> {
-                    setCurrentThreadContext(new ThreadContext(contextId, ThreadType.CONTEXT));
-                    // use a try-with-resources to clear logger properties
-                    try (var childContext = getContext().createChildContext(contextId, getName())) {
-                        try {
-                            T result = function.apply(childContext);
+        Runnable userHandler = () -> {
+            // use a try-with-resources to
+            // - add thread id/type to thread local when the step starts
+            // - clear logger properties when the step finishes
+            try (var childContext = getContext().createChildContext(contextId, getName())) {
+                try {
+                    T result = function.apply(childContext);
 
-                            if (replayChildContext) {
-                                // Replaying a SUCCEEDED child with replayChildren=true — skip checkpointing.
-                                // Advance the phaser so get() doesn't block waiting for a checkpoint response.
-                                this.reconstructedResult = result;
-                                markAlreadyCompleted();
-                                return;
-                            }
+                    handleChildContextSuccess(result);
+                } catch (Throwable e) {
+                    handleChildContextFailure(e);
+                }
+            }
+        };
 
-                            checkpointSuccess(result);
-                        } catch (Throwable e) {
-                            handleChildContextFailure(e);
-                        } finally {
-                            try {
-                                deregisterActiveThread(contextId);
-                            } catch (SuspendExecutionException e) {
-                                // Expected when this is the last active thread — suspension already signaled
-                            }
-                        }
-                    }
-                },
-                userExecutor);
+        // Execute user provided child context code in user-configured executor
+        CompletableFuture.runAsync(userHandler, userExecutor);
+    }
+
+    private void handleChildContextSuccess(T result) {
+        if (replayChildContext) {
+            // Replaying a SUCCEEDED child with replayChildren=true — skip checkpointing.
+            // Mark the completableFuture completed so get() doesn't block waiting for a checkpoint response.
+            this.reconstructedResult = result;
+            markAlreadyCompleted();
+        } else {
+            checkpointSuccess(result);
+        }
     }
 
     private void checkpointSuccess(T result) {

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
@@ -22,8 +22,6 @@ import software.amazon.lambda.durable.exception.StepFailedException;
 import software.amazon.lambda.durable.exception.StepInterruptedException;
 import software.amazon.lambda.durable.exception.UnrecoverableDurableExecutionException;
 import software.amazon.lambda.durable.execution.SuspendExecutionException;
-import software.amazon.lambda.durable.execution.ThreadContext;
-import software.amazon.lambda.durable.execution.ThreadType;
 import software.amazon.lambda.durable.util.ExceptionHelper;
 
 public class StepOperation<T> extends BaseDurableOperation<T> {
@@ -87,66 +85,58 @@ public class StepOperation<T> extends BaseDurableOperation<T> {
     }
 
     private void executeStepLogic(int attempt) {
-        var stepThreadId = getThreadId();
+        // Register step thread as active BEFORE executor runs (prevents suspension when handler deregisters).
+        // The thread local ThreadContext is set inside the executor since that's where the step actually runs
+        registerActiveThread(getOperationId());
 
-        // Register step thread as active BEFORE executor runs (prevents suspension when handler deregisters)
-        // thread local ThreadContext is set inside the executor since that's where the step actually runs
-        registerActiveThread(stepThreadId);
+        Runnable userHandler = () -> {
+            // use a try-with-resources to
+            // - add thread id/type to thread local when the step starts
+            // - clear logger properties when the step finishes
+            try (StepContext stepContext = getContext().createStepContext(getOperationId(), getName(), attempt)) {
+                try {
+                    checkpointStarted();
 
-        // Execute user code in customer-configured executor
-        CompletableFuture.runAsync(
-                () -> {
-                    // Set thread local ThreadContext on the executor thread
-                    setCurrentThreadContext(new ThreadContext(stepThreadId, ThreadType.STEP));
+                    // Execute the function
+                    T result = function.apply(stepContext);
 
-                    // use a try-with-resources to clear logger properties
-                    try (StepContext stepContext =
-                            getContext().createStepContext(getOperationId(), getName(), attempt)) {
-                        try {
-                            // Check if we need to send START
-                            var existing = getOperation();
-                            if (existing == null || existing.status() != OperationStatus.STARTED) {
-                                var startUpdate = OperationUpdate.builder().action(OperationAction.START);
+                    handleStepSucceeded(result);
+                } catch (Throwable e) {
+                    handleStepFailure(e, attempt);
+                }
+            }
+        };
 
-                                if (config.semantics() == StepSemantics.AT_MOST_ONCE_PER_RETRY) {
-                                    // AT_MOST_ONCE: await START checkpoint before executing user code
-                                    sendOperationUpdate(startUpdate);
-                                } else {
-                                    // AT_LEAST_ONCE: fire-and-forget START checkpoint
-                                    sendOperationUpdateAsync(startUpdate);
-                                }
-                            }
+        // Execute user provided step code in user-configured executor
+        CompletableFuture.runAsync(userHandler, userExecutor);
+    }
 
-                            // Execute the function
-                            T result = function.apply(stepContext);
+    private void checkpointStarted() {
+        // Check if we need to send START
+        var existing = getOperation();
+        if (existing == null || existing.status() != OperationStatus.STARTED) {
+            var startUpdate = OperationUpdate.builder().action(OperationAction.START);
 
-                            // Send SUCCEED
-                            var successUpdate = OperationUpdate.builder()
-                                    .action(OperationAction.SUCCEED)
-                                    .payload(serializeResult(result));
+            if (config.semantics() == StepSemantics.AT_MOST_ONCE_PER_RETRY) {
+                // AT_MOST_ONCE: await START checkpoint before executing user code
+                sendOperationUpdate(startUpdate);
+            } else {
+                // AT_LEAST_ONCE: fire-and-forget START checkpoint
+                sendOperationUpdateAsync(startUpdate);
+            }
+        }
+    }
 
-                            // sendOperationUpdate must be synchronous here. When waiting for the return of this call,
-                            // the
-                            // context
-                            // threads waiting for the result of this step operation will be wakened up and registered.
-                            sendOperationUpdate(successUpdate);
-                        } catch (Throwable e) {
-                            handleStepFailure(e, attempt);
-                        } finally {
-                            try {
-                                deregisterActiveThread(stepThreadId);
-                            } catch (SuspendExecutionException e) {
-                                // Expected when this is the last active thread. Must catch here because:
-                                // 1/ This runs in a worker thread detached from handlerFuture
-                                // 2/ Uncaught exception would prevent stepAsync().get() from resume
-                                // Suspension/Termination is already signaled via
-                                // suspendExecutionFuture/terminateExecutionFuture
-                                // before the throw.
-                            }
-                        }
-                    }
-                },
-                userExecutor);
+    private void handleStepSucceeded(T result) {
+        // Send SUCCEED
+        var successUpdate =
+                OperationUpdate.builder().action(OperationAction.SUCCEED).payload(serializeResult(result));
+
+        // sendOperationUpdate must be synchronous here. When waiting for the return of this call,
+        // the
+        // context
+        // threads waiting for the result of this step operation will be wakened up and registered.
+        sendOperationUpdate(successUpdate);
     }
 
     private void handleStepFailure(Throwable exception, int attempt) {

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitOperation.java
@@ -16,7 +16,6 @@ import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.TypeToken;
 import software.amazon.lambda.durable.serde.NoopSerDes;
 import software.amazon.lambda.durable.serde.SerDes;
-import software.amazon.lambda.durable.validation.ParameterValidator;
 
 public class WaitOperation extends BaseDurableOperation<Void> {
 
@@ -27,7 +26,6 @@ public class WaitOperation extends BaseDurableOperation<Void> {
 
     public WaitOperation(String operationId, String name, Duration duration, DurableContext durableContext) {
         super(operationId, name, OperationType.WAIT, TypeToken.get(Void.class), NOOP_SER_DES, durableContext);
-        ParameterValidator.validateDuration(duration, "Wait duration");
         this.duration = duration;
     }
 

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/WaitOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/WaitOperationTest.java
@@ -4,8 +4,6 @@ package software.amazon.lambda.durable.operation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,35 +30,6 @@ class WaitOperationTest {
         executionManager = mock(ExecutionManager.class);
         durableContext = mock(DurableContext.class);
         when(durableContext.getExecutionManager()).thenReturn(executionManager);
-    }
-
-    @Test
-    void constructor_withNullDuration_shouldThrow() {
-        var exception = assertThrows(
-                IllegalArgumentException.class,
-                () -> new WaitOperation(OPERATION_ID, OPERATION_NAME, null, durableContext));
-
-        assertEquals("Wait duration cannot be null", exception.getMessage());
-    }
-
-    @Test
-    void constructor_withZeroDuration_shouldThrow() {
-        var exception = assertThrows(
-                IllegalArgumentException.class,
-                () -> new WaitOperation(OPERATION_ID, OPERATION_NAME, Duration.ofSeconds(0), durableContext));
-
-        assertTrue(exception.getMessage().contains("Wait duration"));
-        assertTrue(exception.getMessage().contains("at least 1 second"));
-    }
-
-    @Test
-    void constructor_withSubSecondDuration_shouldThrow() {
-        var exception = assertThrows(
-                IllegalArgumentException.class,
-                () -> new WaitOperation(OPERATION_ID, OPERATION_NAME, Duration.ofMillis(500), durableContext));
-
-        assertTrue(exception.getMessage().contains("Wait duration"));
-        assertTrue(exception.getMessage().contains("at least 1 second"));
     }
 
     @Test


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

- removed `-step` suffix from the thread id for Step to be consistent with the thread id for ChildContext 
- moved thread local registration to a central place `BaseContext::constructor`
- moved active thread deregistration to a central place `BaseContext::close`
- split big methods in `StepOperation` and `ChildContextOperation` into smaller methods
- removed the proxy methods (setCurrentThreadContext, deregisterActiveThread) that are unused or used only once
- removed wait duration validation in WaitOperation (already validated in DurableContext)
- added more comments to Step and ChildContext code
- renamed `waitName` parameter to `name` to be consistent with the other operations

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Updated

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
