### PR TITLE
add custom UA header

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -66,6 +66,15 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/*.prop</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
@@ -2,16 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.LambdaClientBuilder;
 import software.amazon.awssdk.services.lambda.model.GetDurableExecutionStateRequest;
 import software.amazon.lambda.durable.client.DurableExecutionClient;
 import software.amazon.lambda.durable.client.LambdaDurableFunctionsClient;
@@ -63,6 +68,10 @@ public final class DurableConfig {
      * is always set by the Lambda runtime.
      */
     private static final String DEFAULT_REGION = "us-east-1";
+
+    private static final String VERSION_FILE = "/version.prop";
+    private static final String PROJECT_VERSION = getProjectVersion(VERSION_FILE);
+    private static final String USER_AGENT_SUFFIX = "@aws/durable-execution-sdk-java/" + PROJECT_VERSION;
 
     private final DurableExecutionClient durableExecutionClient;
     private final SerDes serDes;
@@ -169,9 +178,9 @@ public final class DurableConfig {
             logger.debug("AWS_REGION not set, defaulting to: {}", region);
         }
 
-        var lambdaClient = LambdaClient.builder()
-                .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
-                .region(Region.of(region))
+        var lambdaClient = addUserAgentSuffix(LambdaClient.builder()
+                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                        .region(Region.of(region)))
                 .build();
 
         try {
@@ -192,6 +201,27 @@ public final class DurableConfig {
 
         logger.debug("Default DurableExecutionClient created for region: {}", region);
         return new LambdaDurableFunctionsClient(lambdaClient);
+    }
+
+    static LambdaClientBuilder addUserAgentSuffix(LambdaClientBuilder builder) {
+        return builder.overrideConfiguration(builder.overrideConfiguration().toBuilder()
+                .putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX, USER_AGENT_SUFFIX)
+                .build());
+    }
+
+    private static String getProjectVersion(String versionFile) {
+        InputStream stream = DurableConfig.class.getResourceAsStream(versionFile);
+        if (stream == null) {
+            return "UNKNOWN";
+        }
+        Properties props = new Properties();
+        try {
+            props.load(stream);
+            stream.close();
+            return (String) props.get("version");
+        } catch (IOException e) {
+            return "UNKNOWN";
+        }
     }
 
     /**
@@ -230,23 +260,23 @@ public final class DurableConfig {
          * <p>Example:
          *
          * <pre>{@code
-         * LambdaClient lambdaClient = LambdaClient.builder()
+         * LambdaClientBuilder lambdaClientBuilder = LambdaClient.builder()
          *     .region(Region.US_WEST_2)
-         *     .credentialsProvider(ProfileCredentialsProvider.create("my-profile"))
-         *     .build();
+         *     .credentialsProvider(ProfileCredentialsProvider.create("my-profile"));
          *
          * DurableConfig.builder()
-         *     .withLambdaClient(lambdaClient)
+         *     .withLambdaClientBuilder(lambdaClientBuilder)
          *     .build();
          * }</pre>
          *
-         * @param lambdaClient Custom LambdaClient instance
+         * @param lambdaClientBuilder Custom LambdaClientBuilder instance
          * @return This builder
          * @throws NullPointerException if lambdaClient is null
          */
-        public Builder withLambdaClient(LambdaClient lambdaClient) {
-            Objects.requireNonNull(lambdaClient, "LambdaClient cannot be null");
-            this.durableExecutionClient = new LambdaDurableFunctionsClient(lambdaClient);
+        public Builder withLambdaClientBuilder(LambdaClientBuilder lambdaClientBuilder) {
+            Objects.requireNonNull(lambdaClientBuilder, "LambdaClient cannot be null");
+            this.durableExecutionClient = new LambdaDurableFunctionsClient(
+                    addUserAgentSuffix(lambdaClientBuilder).build());
             return this;
         }
 
@@ -255,7 +285,7 @@ public final class DurableConfig {
          *
          * <p><b>Note:</b> This method is primarily intended for testing with mock clients (e.g.,
          * {@code LocalMemoryExecutionClient}). For production use with a custom AWS SDK client, prefer
-         * {@link #withLambdaClient(LambdaClient)}.
+         * {@link #withLambdaClientBuilder(LambdaClientBuilder)}.
          *
          * @param durableExecutionClient Custom DurableExecutionClient instance
          * @return This builder

--- a/sdk/src/main/resources/version.prop
+++ b/sdk/src/main/resources/version.prop
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
@@ -9,11 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.lambda.durable.client.DurableExecutionClient;
 import software.amazon.lambda.durable.client.LambdaDurableFunctionsClient;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
@@ -230,5 +233,65 @@ class DurableConfigTest {
         assertNotNull(config.getDurableExecutionClient());
         assertInstanceOf(LambdaDurableFunctionsClient.class, config.getDurableExecutionClient());
         assertNotNull(config.getExecutorService());
+    }
+
+    @Test
+    void testBuilder_WithLambdaClientBuilder_CreatesLambdaDurableFunctionsClient() {
+        var lambdaClientBuilder = LambdaClient.builder()
+                .region(software.amazon.awssdk.regions.Region.US_WEST_2)
+                .credentialsProvider(software.amazon.awssdk.auth.credentials.StaticCredentialsProvider.create(
+                        software.amazon.awssdk.auth.credentials.AwsBasicCredentials.create("test", "test")));
+
+        var config = DurableConfig.builder()
+                .withLambdaClientBuilder(lambdaClientBuilder)
+                .build();
+
+        assertNotNull(config.getDurableExecutionClient());
+        assertInstanceOf(LambdaDurableFunctionsClient.class, config.getDurableExecutionClient());
+    }
+
+    @Test
+    void testBuilder_WithLambdaClientBuilder_NullThrowsException() {
+        var builder = DurableConfig.builder();
+
+        var exception = assertThrows(NullPointerException.class, () -> builder.withLambdaClientBuilder(null));
+
+        assertEquals("LambdaClient cannot be null", exception.getMessage());
+    }
+
+    @Test
+    void testAddUserAgentSuffix_SetsUserAgentOnBuilder() {
+        var lambdaClientBuilder = LambdaClient.builder();
+
+        var result = DurableConfig.addUserAgentSuffix(lambdaClientBuilder);
+
+        var overrideConfig = result.overrideConfiguration();
+        var userAgentSuffix = overrideConfig.advancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX);
+        assertTrue(userAgentSuffix.isPresent(), "USER_AGENT_SUFFIX should be set");
+        assertTrue(
+                userAgentSuffix.get().contains("@aws/durable-execution-sdk-java/"),
+                "User agent suffix should contain SDK identifier, got: " + userAgentSuffix.get());
+    }
+
+    @Test
+    void testAddUserAgentSuffix_PreservesExistingConfiguration() {
+        var lambdaClientBuilder =
+                LambdaClient.builder().overrideConfiguration(c -> c.putHeader("X-Custom-Header", "test-value"));
+
+        var result = DurableConfig.addUserAgentSuffix(lambdaClientBuilder);
+
+        var overrideConfig = result.overrideConfiguration();
+        var userAgentSuffix = overrideConfig.advancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX);
+        assertTrue(userAgentSuffix.isPresent());
+        assertTrue(userAgentSuffix.get().contains("@aws/durable-execution-sdk-java/"));
+    }
+
+    @Test
+    void testAddUserAgentSuffix_ReturnsSameBuilderInstance() {
+        var lambdaClientBuilder = LambdaClient.builder();
+
+        var result = DurableConfig.addUserAgentSuffix(lambdaClientBuilder);
+
+        assertSame(lambdaClientBuilder, result);
     }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fixes #144 

### Description

- add a java sdk tag with version to user agent

### Demo/Screenshots

```
UserAgent=aws-sdk-java/2.42.6 md/io#sync md/http#Apache ua/2.1 api/Lambda#2.42.x os/Linux#5.10.247-280.992.amzn2.aarch64 lang/java#17.0.18 md/OpenJDK_64-Bit_Server_VM#17.0.18+8-LTS md/vendor#Amazon.com_Inc. md/en_US exec-env/AWS_Lambda_java17 m/D,g @aws/durable-execution-sdk-java/0.6.0-SNAPSHOT
```

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Yes

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
