### PR TITLE
Improvement: improve polling mechanism

### DIFF
--- a/examples/src/main/java/software/amazon/lambda/durable/examples/CustomPollingExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/CustomPollingExample.java
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableConfig;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.InvokeConfig;
+import software.amazon.lambda.durable.retry.JitterStrategy;
+import software.amazon.lambda.durable.retry.PollingStrategies;
+
+/**
+ * Example demonstrating custom polling strategy configuration.
+ *
+ * <p>The polling strategy controls how the SDK polls for async operation results. By default, the SDK uses exponential
+ * backoff (1s base, 2x rate, full jitter). This example shows how to customize the polling behavior.
+ *
+ * <p>This example configures:
+ *
+ * <ul>
+ *   <li>Exponential backoff with 500ms base interval
+ *   <li>1.5x backoff rate for gentler growth
+ *   <li>Half jitter to balance between consistency and thundering herd avoidance
+ * </ul>
+ */
+public class CustomPollingExample extends DurableHandler<GreetingRequest, String> {
+
+    @Override
+    protected DurableConfig createConfiguration() {
+        return DurableConfig.builder()
+                .withPollingStrategy(PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(500), 1.5, JitterStrategy.HALF, Duration.ofSeconds(5)))
+                .build();
+    }
+
+    @Override
+    public String handleRequest(GreetingRequest input, DurableContext context) {
+        context.getLogger().info("Starting workflow with input: {}", input);
+
+        // Step 1: low case the input
+        var lowered = context.stepAsync("validate", String.class, () -> {
+            try {
+                // prevent the execution from suspension
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return input.getName().toLowerCase();
+        });
+
+        // Step 2: Invoke async
+        var future = context.invokeAsync(
+                "call-greeting",
+                "simple-step-example" + input.getName() + ":$LATEST",
+                input,
+                String.class,
+                InvokeConfig.builder().build());
+        // because we are sleeping 5 seconds in the first async step, the function will not be suspened. The invoke
+        // function will have to poll for completion.
+        return future.get() + lowered.get();
+    }
+}

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/CustomPollingExampleTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/CustomPollingExampleTest.java
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
+
+class CustomPollingExampleTest {
+
+    @Test
+    void testCustomPollingExample() {
+        var handler = new CustomPollingExample();
+        var runner = LocalDurableTestRunner.create(GreetingRequest.class, handler);
+
+        // First run: executes validate step, then pending at wait
+        var input = new GreetingRequest("world");
+        var output1 = runner.run(input);
+
+        assertEquals(ExecutionStatus.PENDING, output1.getStatus());
+
+        // Second run:
+        runner.completeChainedInvoke("call-greeting", "\"hello\"");
+        var output2 = runner.run(input);
+
+        assertEquals(ExecutionStatus.SUCCEEDED, output2.getStatus());
+        assertEquals("helloworld", output2.getResult(String.class));
+    }
+}

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
@@ -155,6 +155,9 @@ public class LocalDurableTestRunner<I, O> {
                     .withDurableExecutionClient(storage)
                     .withSerDes(customerConfig.getSerDes())
                     .withExecutorService(customerConfig.getExecutorService())
+                    .withPollingStrategy(customerConfig.getPollingStrategy())
+                    .withCheckpointDelay(customerConfig.getCheckpointDelay())
+                    .withLoggerConfig(customerConfig.getLoggerConfig())
                     .build();
         } else {
             // Fallback to default config with in-memory client

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
@@ -21,6 +21,8 @@ import software.amazon.awssdk.services.lambda.model.GetDurableExecutionStateRequ
 import software.amazon.lambda.durable.client.DurableExecutionClient;
 import software.amazon.lambda.durable.client.LambdaDurableFunctionsClient;
 import software.amazon.lambda.durable.logging.LoggerConfig;
+import software.amazon.lambda.durable.retry.PollingStrategies;
+import software.amazon.lambda.durable.retry.PollingStrategy;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
 import software.amazon.lambda.durable.serde.SerDes;
 
@@ -77,7 +79,7 @@ public final class DurableConfig {
     private final SerDes serDes;
     private final ExecutorService executorService;
     private final LoggerConfig loggerConfig;
-    private final Duration pollingInterval;
+    private final PollingStrategy pollingStrategy;
     private final Duration checkpointDelay;
 
     private DurableConfig(Builder builder) {
@@ -87,7 +89,8 @@ public final class DurableConfig {
         this.serDes = builder.serDes != null ? builder.serDes : new JacksonSerDes();
         this.executorService = builder.executorService != null ? builder.executorService : createDefaultExecutor();
         this.loggerConfig = builder.loggerConfig != null ? builder.loggerConfig : LoggerConfig.defaults();
-        this.pollingInterval = builder.pollingInterval != null ? builder.pollingInterval : Duration.ofMillis(1000);
+        this.pollingStrategy =
+                builder.pollingStrategy != null ? builder.pollingStrategy : PollingStrategies.Presets.DEFAULT;
         this.checkpointDelay = builder.checkpointDelay != null ? builder.checkpointDelay : Duration.ofSeconds(0);
     }
 
@@ -146,12 +149,12 @@ public final class DurableConfig {
     }
 
     /**
-     * Gets the configured polling interval.
+     * Gets the polling strategy.
      *
-     * @return polling interval in Duration.
+     * @return PollingStrategy instance (never null)
      */
-    public Duration getPollingInterval() {
-        return pollingInterval;
+    public PollingStrategy getPollingStrategy() {
+        return pollingStrategy;
     }
 
     /**
@@ -248,7 +251,7 @@ public final class DurableConfig {
         private SerDes serDes;
         private ExecutorService executorService;
         private LoggerConfig loggerConfig;
-        private Duration pollingInterval;
+        private PollingStrategy pollingStrategy;
         private Duration checkpointDelay;
 
         private Builder() {}
@@ -336,14 +339,14 @@ public final class DurableConfig {
         }
 
         /**
-         * Sets how often the SDK polls updates from backend.
+         * Sets the polling strategy. If not set, defaults to 1 second with full jitter and 2x backoff.
          *
-         * @param duration the polling interval in Duration
+         * @param pollingStrategy Custom PollingStrategy instance
          * @return This builder
          */
-        public Builder withPollingInterval(Duration duration) {
+        public Builder withPollingStrategy(PollingStrategy pollingStrategy) {
             // No validation - polling intervals can be less than 1 second (e.g., 200ms with backoff)
-            this.pollingInterval = duration;
+            this.pollingStrategy = pollingStrategy;
             return this;
         }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/CheckpointBatcher.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/CheckpointBatcher.java
@@ -17,6 +17,8 @@ import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionSt
 import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationUpdate;
 import software.amazon.lambda.durable.DurableConfig;
+import software.amazon.lambda.durable.retry.PollingStrategies;
+import software.amazon.lambda.durable.retry.PollingStrategy;
 
 /**
  * Package-private checkpoint manager for batching and queueing checkpoint API calls.
@@ -57,11 +59,16 @@ class CheckpointBatcher {
 
     /** Polls for updates of the specified operation with preconfigured intervals */
     CompletableFuture<Operation> pollForUpdate(String operationId) {
-        return pollForUpdate(operationId, config.getPollingInterval());
+        return pollForUpdate(operationId, config.getPollingStrategy());
     }
 
     /** Polls for updates of the specified operation with specified delay */
     CompletableFuture<Operation> pollForUpdate(String operationId, Duration delay) {
+        return pollForUpdate(operationId, PollingStrategies.fixedDelay(delay));
+    }
+
+    /** Polls for updates of the specified operation with specified polling strategy */
+    CompletableFuture<Operation> pollForUpdate(String operationId, PollingStrategy pollingStrategy) {
         logger.debug("Polling request received: operation id {}", operationId);
         var future = new CompletableFuture<Operation>();
         synchronized (pollingFutures) {
@@ -70,17 +77,20 @@ class CheckpointBatcher {
                     .computeIfAbsent(operationId, k -> Collections.synchronizedList(new ArrayList<>()))
                     .add(future);
         }
-        pollForUpdateInternal(future, delay);
+        pollForUpdateInternal(future, 0, pollingStrategy);
         return future;
     }
 
-    private CompletableFuture<Void> pollForUpdateInternal(CompletableFuture<Operation> future, Duration delay) {
-        return checkpointApiRequestBatcher.submit(null, delay).thenCompose(v -> {
-            if (future.isDone()) {
-                return CompletableFuture.completedFuture(null);
-            }
-            return pollForUpdateInternal(future, delay);
-        });
+    private CompletableFuture<Void> pollForUpdateInternal(
+            CompletableFuture<Operation> future, int attempt, PollingStrategy pollingStrategy) {
+        return checkpointApiRequestBatcher
+                .submit(null, pollingStrategy.computeDelay(attempt))
+                .thenCompose(v -> {
+                    if (future.isDone()) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    return pollForUpdateInternal(future, attempt + 1, pollingStrategy);
+                });
     }
 
     /** Cancels all polling futures and waits for all pending checkpoint requests to complete */

--- a/sdk/src/main/java/software/amazon/lambda/durable/retry/JitterStrategy.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/retry/JitterStrategy.java
@@ -13,17 +13,32 @@ public enum JitterStrategy {
     /**
      * No jitter - use exact calculated delay. This provides predictable timing but may cause thundering herd issues.
      */
-    NONE,
-
+    NONE {
+        @Override
+        public double apply(double baseDelay) {
+            return baseDelay;
+        }
+    },
     /**
      * Full jitter - random delay between 0 and calculated delay. This provides maximum spread but may result in very
      * short delays.
      */
-    FULL,
-
+    FULL {
+        @Override
+        public double apply(double baseDelay) {
+            return Math.random() * baseDelay;
+        }
+    },
     /**
      * Half jitter - random delay between 50% and 100% of calculated delay. This provides good spread while maintaining
      * reasonable minimum delays.
      */
-    HALF
+    HALF {
+        @Override
+        public double apply(double baseDelay) {
+            return baseDelay / 2 + Math.random() * (baseDelay / 2);
+        }
+    };
+
+    public abstract double apply(double baseDelay);
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/retry/PollingStrategies.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/retry/PollingStrategies.java
@@ -1,0 +1,70 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.retry;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/** Factory class for creating common polling strategies. */
+public class PollingStrategies {
+
+    /** Preset polling strategies for common use cases. */
+    public static class Presets {
+
+        /**
+         * Default polling strategy: - Base interval: 1 second - Backoff rate: 2x - Jitter: FULL - Max interval 10
+         * second
+         */
+        public static final PollingStrategy DEFAULT =
+                exponentialBackoff(Duration.ofMillis(1000), 2.0, JitterStrategy.FULL, Duration.ofSeconds(10));
+    }
+
+    /**
+     * Creates an exponential backoff polling strategy.
+     *
+     * <p>The delay calculation follows the formula: delay = jitter(baseInterval × backoffRate^attempt)
+     *
+     * @param baseInterval Base delay before first poll
+     * @param backoffRate Multiplier for exponential backoff (must be positive)
+     * @param jitter Jitter strategy to apply to delays
+     * @param maxInterval Maximum delay between polls
+     * @return PollingStrategy implementing exponential backoff with jitter
+     */
+    public static PollingStrategy exponentialBackoff(
+            Duration baseInterval, double backoffRate, JitterStrategy jitter, Duration maxInterval) {
+        Objects.requireNonNull(jitter, "jitter must not be null");
+        Objects.requireNonNull(baseInterval, "base interval must not be null");
+        Objects.requireNonNull(maxInterval, "max interval must not be null");
+        if (backoffRate <= 0) {
+            throw new IllegalArgumentException("backoffRate must be positive");
+        }
+
+        if (baseInterval.isNegative() || baseInterval.isZero()) {
+            throw new IllegalArgumentException("baseInterval must be positive");
+        }
+
+        if (maxInterval.isNegative() || maxInterval.isZero()) {
+            throw new IllegalArgumentException("maxInterval must be positive");
+        }
+
+        return (attempt) -> {
+            double delayMs = baseInterval.toMillis() * Math.pow(backoffRate, attempt);
+            delayMs = Math.min(jitter.apply(delayMs), maxInterval.toMillis());
+            return Duration.ofMillis(Math.round(delayMs));
+        };
+    }
+
+    /**
+     * Creates a fixed-delay polling strategy that uses the same interval for every attempt.
+     *
+     * @param interval Fixed delay between polls
+     * @return PollingStrategy with fixed delay
+     */
+    public static PollingStrategy fixedDelay(Duration interval) {
+        Objects.requireNonNull(interval, "interval must not be null");
+        if (interval.isNegative() || interval.isZero()) {
+            throw new IllegalArgumentException("interval must be positive");
+        }
+        return (attempt) -> interval;
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/retry/PollingStrategy.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/retry/PollingStrategy.java
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.retry;
+
+import java.time.Duration;
+
+/** Functional interface for computing polling delays between attempts. */
+@FunctionalInterface
+public interface PollingStrategy {
+
+    /**
+     * Computes the delay before the next polling attempt.
+     *
+     * @param attempt The current attempt number (0-based)
+     * @return Duration to wait before the next poll
+     */
+    Duration computeDelay(int attempt);
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/retry/RetryStrategies.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/retry/RetryStrategies.java
@@ -69,12 +69,7 @@ public class RetryStrategies {
             double baseDelay = Math.min(initialDelaySeconds * Math.pow(backoffRate, attemptNumber), maxDelaySeconds);
 
             // Apply jitter
-            double delayWithJitter =
-                    switch (jitter) {
-                        case NONE -> baseDelay;
-                        case FULL -> Math.random() * baseDelay;
-                        case HALF -> baseDelay / 2 + Math.random() * (baseDelay / 2);
-                    };
+            double delayWithJitter = jitter.apply(baseDelay);
 
             // Round to nearest second, minimum 1
             // Same rounding logic as TS SDK: https://tinyurl.com/4ntxsefu

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,8 @@ import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.lambda.durable.client.DurableExecutionClient;
 import software.amazon.lambda.durable.client.LambdaDurableFunctionsClient;
+import software.amazon.lambda.durable.retry.JitterStrategy;
+import software.amazon.lambda.durable.retry.PollingStrategies;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
 import software.amazon.lambda.durable.serde.SerDes;
 
@@ -293,5 +296,92 @@ class DurableConfigTest {
         var result = DurableConfig.addUserAgentSuffix(lambdaClientBuilder);
 
         assertSame(lambdaClientBuilder, result);
+    }
+
+    // --- Polling strategy tests ---
+
+    @Test
+    void testDefaultConfig_PollingStrategyDefaults() {
+        var config = DurableConfig.defaultConfig();
+
+        assertNotNull(config.getPollingStrategy());
+        assertSame(PollingStrategies.Presets.DEFAULT, config.getPollingStrategy());
+        assertEquals(Duration.ofSeconds(0), config.getCheckpointDelay());
+    }
+
+    @Test
+    void testBuilder_WithCustomPollingStrategy() {
+        var customStrategy = PollingStrategies.exponentialBackoff(
+                Duration.ofMillis(500), 3.0, JitterStrategy.NONE, Duration.ofSeconds(10));
+        var config = DurableConfig.builder()
+                .withDurableExecutionClient(mockClient)
+                .withPollingStrategy(customStrategy)
+                .build();
+
+        assertSame(customStrategy, config.getPollingStrategy());
+    }
+
+    @Test
+    void testBuilder_WithFixedDelayPollingStrategy() {
+        var fixedStrategy = PollingStrategies.fixedDelay(Duration.ofMillis(200));
+        var config = DurableConfig.builder()
+                .withDurableExecutionClient(mockClient)
+                .withPollingStrategy(fixedStrategy)
+                .build();
+
+        assertSame(fixedStrategy, config.getPollingStrategy());
+    }
+
+    @Test
+    void testBuilder_WithPollingStrategyNull_UsesDefault() {
+        var config = DurableConfig.builder()
+                .withDurableExecutionClient(mockClient)
+                .withPollingStrategy(null)
+                .build();
+
+        assertSame(PollingStrategies.Presets.DEFAULT, config.getPollingStrategy());
+    }
+
+    @Test
+    void testBuilder_WithCustomCheckpointDelay() {
+        var config = DurableConfig.builder()
+                .withDurableExecutionClient(mockClient)
+                .withCheckpointDelay(Duration.ofSeconds(5))
+                .build();
+
+        assertEquals(Duration.ofSeconds(5), config.getCheckpointDelay());
+    }
+
+    @Test
+    void testBuilder_WithPollingStrategyAndCheckpointDelay() {
+        var customStrategy = PollingStrategies.exponentialBackoff(
+                Duration.ofMillis(200), 1.5, JitterStrategy.HALF, Duration.ofSeconds(10));
+        var config = DurableConfig.builder()
+                .withDurableExecutionClient(mockClient)
+                .withPollingStrategy(customStrategy)
+                .withCheckpointDelay(Duration.ofSeconds(2))
+                .build();
+
+        assertSame(customStrategy, config.getPollingStrategy());
+        assertEquals(Duration.ofSeconds(2), config.getCheckpointDelay());
+    }
+
+    @Test
+    void testBuilder_FluentAPI_PollingMethods() {
+        var builder = DurableConfig.builder();
+        var strategy = PollingStrategies.Presets.DEFAULT;
+
+        assertSame(builder, builder.withPollingStrategy(strategy));
+        assertSame(builder, builder.withCheckpointDelay(Duration.ofSeconds(1)));
+    }
+
+    @Test
+    void testBuilder_CheckpointDelayNull_UsesDefault() {
+        var config = DurableConfig.builder()
+                .withDurableExecutionClient(mockClient)
+                .withCheckpointDelay(null)
+                .build();
+
+        assertEquals(Duration.ofSeconds(0), config.getCheckpointDelay());
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/execution/CheckpointBatcherTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/execution/CheckpointBatcherTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.CheckpointDurableExecutionResponse;
@@ -23,6 +24,8 @@ import software.amazon.awssdk.services.lambda.model.OperationType;
 import software.amazon.awssdk.services.lambda.model.OperationUpdate;
 import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.client.DurableExecutionClient;
+import software.amazon.lambda.durable.retry.JitterStrategy;
+import software.amazon.lambda.durable.retry.PollingStrategies;
 
 class CheckpointBatcherTest {
 
@@ -37,7 +40,8 @@ class CheckpointBatcherTest {
         config = DurableConfig.builder()
                 .withDurableExecutionClient(client)
                 .withCheckpointDelay(Duration.ofMillis(50))
-                .withPollingInterval(Duration.ofMillis(50))
+                .withPollingStrategy(PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(50), 2.0, JitterStrategy.FULL, Duration.ofSeconds(10)))
                 .build();
 
         callbackOperations = new ArrayList<>();
@@ -299,5 +303,313 @@ class CheckpointBatcherTest {
             // Should only contain non-null update
             return list.stream().noneMatch(u -> u == null);
         }));
+    }
+
+    // --- Polling backoff and jitter tests ---
+
+    @Test
+    void pollForUpdate_withBackoffAndNoJitter_completesWhenOperationReturned() throws Exception {
+        var backoffConfig = DurableConfig.builder()
+                .withDurableExecutionClient(client)
+                .withPollingStrategy(PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(10), 2.0, JitterStrategy.NONE, Duration.ofSeconds(10)))
+                .withCheckpointDelay(Duration.ofMillis(50))
+                .build();
+        var backoffBatcher = new CheckpointBatcher(backoffConfig, "arn:test", "token-1", callbackOperations::addAll);
+
+        var operation = Operation.builder()
+                .id("op-1")
+                .type(OperationType.STEP)
+                .status(OperationStatus.SUCCEEDED)
+                .build();
+
+        when(client.checkpoint(anyString(), anyString(), anyList()))
+                .thenReturn(CheckpointDurableExecutionResponse.builder()
+                        .checkpointToken("token-2")
+                        .newExecutionState(CheckpointUpdatedExecutionState.builder()
+                                .operations(List.of(operation))
+                                .build())
+                        .build());
+
+        var future = backoffBatcher.pollForUpdate("op-1");
+        var result = future.get(500, TimeUnit.MILLISECONDS);
+
+        assertEquals(operation, result);
+    }
+
+    @Test
+    void pollForUpdate_withBackoff_pollsMultipleTimesBeforeCompletion() throws Exception {
+        var backoffConfig = DurableConfig.builder()
+                .withDurableExecutionClient(client)
+                .withPollingStrategy(PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(10), 1.5, JitterStrategy.NONE, Duration.ofSeconds(10)))
+                .withCheckpointDelay(Duration.ofMillis(50))
+                .build();
+        var backoffBatcher = new CheckpointBatcher(backoffConfig, "arn:test", "token-1", callbackOperations::addAll);
+
+        var operation = Operation.builder()
+                .id("op-1")
+                .type(OperationType.STEP)
+                .status(OperationStatus.SUCCEEDED)
+                .build();
+
+        var callCount = new AtomicInteger(0);
+        when(client.checkpoint(anyString(), anyString(), anyList())).thenAnswer(invocation -> {
+            int count = callCount.incrementAndGet();
+            // Return the operation on the 3rd call
+            if (count >= 3) {
+                return CheckpointDurableExecutionResponse.builder()
+                        .checkpointToken("token-2")
+                        .newExecutionState(CheckpointUpdatedExecutionState.builder()
+                                .operations(List.of(operation))
+                                .build())
+                        .build();
+            }
+            return CheckpointDurableExecutionResponse.builder()
+                    .checkpointToken("token-1")
+                    .build();
+        });
+
+        var future = backoffBatcher.pollForUpdate("op-1");
+        var result = future.get(1000, TimeUnit.MILLISECONDS);
+
+        assertEquals(operation, result);
+        assertTrue(callCount.get() >= 3, "Expected at least 3 checkpoint calls, got " + callCount.get());
+    }
+
+    @Test
+    void pollForUpdate_withCustomDelay_ignoresBackoffConfig() throws Exception {
+        var backoffConfig = DurableConfig.builder()
+                .withDurableExecutionClient(client)
+                .withPollingStrategy(PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(10), 100.0, JitterStrategy.NONE, Duration.ofSeconds(10)))
+                .withCheckpointDelay(Duration.ofMillis(50))
+                .build();
+        var backoffBatcher = new CheckpointBatcher(backoffConfig, "arn:test", "token-1", callbackOperations::addAll);
+
+        var operation = Operation.builder()
+                .id("op-1")
+                .type(OperationType.STEP)
+                .status(OperationStatus.SUCCEEDED)
+                .build();
+
+        var callCount = new AtomicInteger(0);
+        when(client.checkpoint(anyString(), anyString(), anyList())).thenAnswer(invocation -> {
+            int count = callCount.incrementAndGet();
+            if (count >= 3) {
+                return CheckpointDurableExecutionResponse.builder()
+                        .checkpointToken("token-2")
+                        .newExecutionState(CheckpointUpdatedExecutionState.builder()
+                                .operations(List.of(operation))
+                                .build())
+                        .build();
+            }
+            return CheckpointDurableExecutionResponse.builder()
+                    .checkpointToken("token-1")
+                    .build();
+        });
+
+        // Use explicit delay (fixed interval) — should NOT apply backoff
+        var future = backoffBatcher.pollForUpdate("op-1", Duration.ofMillis(20));
+        var result = future.get(1000, TimeUnit.MILLISECONDS);
+
+        assertEquals(operation, result);
+        // With fixed interval of 20ms, should complete quickly despite backoffRate=100
+        assertTrue(callCount.get() >= 3);
+    }
+
+    @Test
+    void pollForUpdate_withFullJitter_completesWhenOperationReturned() throws Exception {
+        var jitterConfig = DurableConfig.builder()
+                .withDurableExecutionClient(client)
+                .withPollingStrategy(PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(10), 2.0, JitterStrategy.FULL, Duration.ofSeconds(10)))
+                .withCheckpointDelay(Duration.ofMillis(50))
+                .build();
+        var jitterBatcher = new CheckpointBatcher(jitterConfig, "arn:test", "token-1", callbackOperations::addAll);
+
+        var operation = Operation.builder()
+                .id("op-1")
+                .type(OperationType.STEP)
+                .status(OperationStatus.SUCCEEDED)
+                .build();
+
+        when(client.checkpoint(anyString(), anyString(), anyList()))
+                .thenReturn(CheckpointDurableExecutionResponse.builder()
+                        .checkpointToken("token-2")
+                        .newExecutionState(CheckpointUpdatedExecutionState.builder()
+                                .operations(List.of(operation))
+                                .build())
+                        .build());
+
+        var future = jitterBatcher.pollForUpdate("op-1");
+        var result = future.get(500, TimeUnit.MILLISECONDS);
+
+        assertEquals(operation, result);
+    }
+
+    @Test
+    void pollForUpdate_withHalfJitter_completesWhenOperationReturned() throws Exception {
+        var jitterConfig = DurableConfig.builder()
+                .withDurableExecutionClient(client)
+                .withPollingStrategy(PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(10), 2.0, JitterStrategy.HALF, Duration.ofSeconds(10)))
+                .withCheckpointDelay(Duration.ofMillis(50))
+                .build();
+        var jitterBatcher = new CheckpointBatcher(jitterConfig, "arn:test", "token-1", callbackOperations::addAll);
+
+        var operation = Operation.builder()
+                .id("op-1")
+                .type(OperationType.STEP)
+                .status(OperationStatus.SUCCEEDED)
+                .build();
+
+        when(client.checkpoint(anyString(), anyString(), anyList()))
+                .thenReturn(CheckpointDurableExecutionResponse.builder()
+                        .checkpointToken("token-2")
+                        .newExecutionState(CheckpointUpdatedExecutionState.builder()
+                                .operations(List.of(operation))
+                                .build())
+                        .build());
+
+        var future = jitterBatcher.pollForUpdate("op-1");
+        var result = future.get(500, TimeUnit.MILLISECONDS);
+
+        assertEquals(operation, result);
+    }
+
+    @Test
+    void pollForUpdate_defaultConfig_appliesBackoffAndJitter() throws Exception {
+        // Default config: pollingInterval=1000ms, backoffRate=2.0, jitter=FULL
+        // Use small interval to keep test fast
+        var operation = Operation.builder()
+                .id("op-1")
+                .type(OperationType.STEP)
+                .status(OperationStatus.SUCCEEDED)
+                .build();
+
+        when(client.checkpoint(anyString(), anyString(), anyList()))
+                .thenReturn(CheckpointDurableExecutionResponse.builder()
+                        .checkpointToken("token-2")
+                        .newExecutionState(CheckpointUpdatedExecutionState.builder()
+                                .operations(List.of(operation))
+                                .build())
+                        .build());
+
+        // setUp() batcher uses pollingInterval=50ms, backoffRate=2.0 (default), jitter=FULL (default)
+        var future = batcher.pollForUpdate("op-1");
+        var result = future.get(500, TimeUnit.MILLISECONDS);
+
+        assertEquals(operation, result);
+    }
+
+    @Test
+    void pollForUpdate_withBackoff_delayGrowsAcrossAttempts() throws Exception {
+        // Use NONE jitter so delays are deterministic: base * backoffRate^attempt
+        // base=10ms, rate=2.0 → attempt 0: 10ms, attempt 1: 20ms, attempt 2: 40ms
+        var backoffConfig = DurableConfig.builder()
+                .withDurableExecutionClient(client)
+                .withPollingStrategy(PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(10), 2.0, JitterStrategy.NONE, Duration.ofSeconds(10)))
+                .withCheckpointDelay(Duration.ofMillis(50))
+                .build();
+        var backoffBatcher = new CheckpointBatcher(backoffConfig, "arn:test", "token-1", callbackOperations::addAll);
+
+        var operation = Operation.builder()
+                .id("op-1")
+                .type(OperationType.STEP)
+                .status(OperationStatus.SUCCEEDED)
+                .build();
+
+        var callCount = new AtomicInteger(0);
+        var callTimestamps = new ArrayList<Long>();
+        when(client.checkpoint(anyString(), anyString(), anyList())).thenAnswer(invocation -> {
+            callTimestamps.add(System.nanoTime());
+            int count = callCount.incrementAndGet();
+            if (count >= 4) {
+                return CheckpointDurableExecutionResponse.builder()
+                        .checkpointToken("token-2")
+                        .newExecutionState(CheckpointUpdatedExecutionState.builder()
+                                .operations(List.of(operation))
+                                .build())
+                        .build();
+            }
+            return CheckpointDurableExecutionResponse.builder()
+                    .checkpointToken("token-1")
+                    .build();
+        });
+
+        var future = backoffBatcher.pollForUpdate("op-1");
+        future.get(2000, TimeUnit.MILLISECONDS);
+
+        assertTrue(callCount.get() >= 4, "Expected at least 4 calls, got " + callCount.get());
+        // Verify that later intervals are generally longer than earlier ones
+        // (not exact due to scheduling, but the trend should hold)
+        if (callTimestamps.size() >= 4) {
+            var interval1 = callTimestamps.get(1) - callTimestamps.get(0);
+            var interval3 = callTimestamps.get(3) - callTimestamps.get(2);
+            assertTrue(
+                    interval3 >= interval1,
+                    "Later polling intervals should be >= earlier ones with backoff. "
+                            + "interval1=" + Duration.ofNanos(interval1).toMillis()
+                            + "ms, interval3=" + Duration.ofNanos(interval3).toMillis() + "ms");
+        }
+    }
+
+    @Test
+    void pollForUpdate_withFixedDelay_intervalsAreConsistent() throws Exception {
+        var fixedConfig = DurableConfig.builder()
+                .withDurableExecutionClient(client)
+                .withPollingStrategy(PollingStrategies.fixedDelay(Duration.ofMillis(50)))
+                .withCheckpointDelay(Duration.ofMillis(50))
+                .build();
+        var fixedBatcher = new CheckpointBatcher(fixedConfig, "arn:test", "token-1", callbackOperations::addAll);
+
+        var operation = Operation.builder()
+                .id("op-1")
+                .type(OperationType.STEP)
+                .status(OperationStatus.SUCCEEDED)
+                .build();
+
+        var callCount = new AtomicInteger(0);
+        var callTimestamps = new ArrayList<Long>();
+        when(client.checkpoint(anyString(), anyString(), anyList())).thenAnswer(invocation -> {
+            callTimestamps.add(System.nanoTime());
+            int count = callCount.incrementAndGet();
+            if (count >= 5) {
+                return CheckpointDurableExecutionResponse.builder()
+                        .checkpointToken("token-2")
+                        .newExecutionState(CheckpointUpdatedExecutionState.builder()
+                                .operations(List.of(operation))
+                                .build())
+                        .build();
+            }
+            return CheckpointDurableExecutionResponse.builder()
+                    .checkpointToken("token-1")
+                    .build();
+        });
+
+        var future = fixedBatcher.pollForUpdate("op-1");
+        future.get(2000, TimeUnit.MILLISECONDS);
+
+        assertTrue(callCount.get() >= 5, "Expected at least 5 calls, got " + callCount.get());
+
+        // Verify intervals are roughly consistent (no exponential growth)
+        if (callTimestamps.size() >= 5) {
+            var intervals = new ArrayList<Long>();
+            for (int i = 1; i < callTimestamps.size(); i++) {
+                intervals.add(TimeUnit.NANOSECONDS.toMillis(callTimestamps.get(i) - callTimestamps.get(i - 1)));
+            }
+            var maxInterval =
+                    intervals.stream().mapToLong(Long::longValue).max().orElse(0);
+            var minInterval =
+                    intervals.stream().mapToLong(Long::longValue).min().orElse(0);
+            // With fixed delay of 50ms, the spread between min and max should be small
+            // (no exponential growth). Allow generous tolerance for scheduling jitter.
+            assertTrue(
+                    maxInterval - minInterval < 150,
+                    "Fixed delay intervals should be roughly consistent. min=" + minInterval + "ms, max=" + maxInterval
+                            + "ms, intervals=" + intervals);
+        }
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/retry/JitterStrategyTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/retry/JitterStrategyTest.java
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.retry;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class JitterStrategyTest {
+
+    private static final int ITERATIONS = 100;
+
+    @Test
+    void none_returnsExactBaseDelay() {
+        assertEquals(100.0, JitterStrategy.NONE.apply(100.0));
+        assertEquals(0.0, JitterStrategy.NONE.apply(0.0));
+        assertEquals(1.5, JitterStrategy.NONE.apply(1.5));
+    }
+
+    @Test
+    void full_returnsBetweenZeroAndBaseDelay() {
+        double baseDelay = 1000.0;
+        for (int i = 0; i < ITERATIONS; i++) {
+            double result = JitterStrategy.FULL.apply(baseDelay);
+            assertTrue(result >= 0, "FULL jitter should be >= 0, got: " + result);
+            assertTrue(result <= baseDelay, "FULL jitter should be <= baseDelay, got: " + result);
+        }
+    }
+
+    @Test
+    void half_returnsBetweenHalfAndBaseDelay() {
+        double baseDelay = 1000.0;
+        for (int i = 0; i < ITERATIONS; i++) {
+            double result = JitterStrategy.HALF.apply(baseDelay);
+            assertTrue(result >= baseDelay / 2, "HALF jitter should be >= baseDelay/2, got: " + result);
+            assertTrue(result <= baseDelay, "HALF jitter should be <= baseDelay, got: " + result);
+        }
+    }
+
+    @Test
+    void full_withZeroBaseDelay_returnsZero() {
+        assertEquals(0.0, JitterStrategy.FULL.apply(0.0));
+    }
+
+    @Test
+    void half_withZeroBaseDelay_returnsZero() {
+        assertEquals(0.0, JitterStrategy.HALF.apply(0.0));
+    }
+
+    @Test
+    void full_producesVariation() {
+        double baseDelay = 1000.0;
+        boolean sawDifferentValues = false;
+        double firstResult = JitterStrategy.FULL.apply(baseDelay);
+        for (int i = 0; i < ITERATIONS; i++) {
+            if (JitterStrategy.FULL.apply(baseDelay) != firstResult) {
+                sawDifferentValues = true;
+                break;
+            }
+        }
+        assertTrue(sawDifferentValues, "FULL jitter should produce varying results");
+    }
+
+    @Test
+    void half_producesVariation() {
+        double baseDelay = 1000.0;
+        boolean sawDifferentValues = false;
+        double firstResult = JitterStrategy.HALF.apply(baseDelay);
+        for (int i = 0; i < ITERATIONS; i++) {
+            if (JitterStrategy.HALF.apply(baseDelay) != firstResult) {
+                sawDifferentValues = true;
+                break;
+            }
+        }
+        assertTrue(sawDifferentValues, "HALF jitter should produce varying results");
+    }
+
+    @Test
+    void allStrategies_withSmallBaseDelay_returnNonNegative() {
+        double baseDelay = 0.001;
+        for (int i = 0; i < ITERATIONS; i++) {
+            assertTrue(JitterStrategy.NONE.apply(baseDelay) >= 0);
+            assertTrue(JitterStrategy.FULL.apply(baseDelay) >= 0);
+            assertTrue(JitterStrategy.HALF.apply(baseDelay) >= 0);
+        }
+    }
+
+    @Test
+    void enumValues_containsAllStrategies() {
+        var values = JitterStrategy.values();
+        assertEquals(3, values.length);
+        assertEquals(JitterStrategy.NONE, JitterStrategy.valueOf("NONE"));
+        assertEquals(JitterStrategy.FULL, JitterStrategy.valueOf("FULL"));
+        assertEquals(JitterStrategy.HALF, JitterStrategy.valueOf("HALF"));
+    }
+}

--- a/sdk/src/test/java/software/amazon/lambda/durable/retry/PollingStrategiesTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/retry/PollingStrategiesTest.java
@@ -1,0 +1,241 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.retry;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class PollingStrategiesTest {
+
+    private static final Duration DEFAULT_MAX = Duration.ofSeconds(10);
+
+    @Test
+    void defaultPreset_usesExpectedConfiguration() {
+        var strategy = PollingStrategies.Presets.DEFAULT;
+
+        // Default: base=1000ms, rate=2.0, jitter=FULL, maxInterval=10s
+        // With FULL jitter, delay should be between 0 and base*rate^attempt
+        for (int i = 0; i < 10; i++) {
+            var delay = strategy.computeDelay(0);
+            assertTrue(
+                    delay.toMillis() >= 0 && delay.toMillis() <= 1000,
+                    "Attempt 0 delay should be in [0, 1000]ms, got " + delay.toMillis());
+        }
+    }
+
+    @Test
+    void fixedDelay_computesFixedDelay() {
+        var strategy = PollingStrategies.fixedDelay(Duration.ofMillis(500));
+
+        assertEquals(Duration.ofMillis(500), strategy.computeDelay(0));
+        assertEquals(Duration.ofMillis(500), strategy.computeDelay(1));
+        assertEquals(Duration.ofMillis(500), strategy.computeDelay(2));
+        assertEquals(Duration.ofMillis(500), strategy.computeDelay(3));
+    }
+
+    @Test
+    void exponentialBackoff_withNoJitter_computesDeterministicDelays() {
+        var strategy =
+                PollingStrategies.exponentialBackoff(Duration.ofMillis(100), 2.0, JitterStrategy.NONE, DEFAULT_MAX);
+
+        // delay = base * rate^attempt
+        assertEquals(100, strategy.computeDelay(0).toMillis()); // 100 * 2^0
+        assertEquals(200, strategy.computeDelay(1).toMillis()); // 100 * 2^1
+        assertEquals(400, strategy.computeDelay(2).toMillis()); // 100 * 2^2
+        assertEquals(800, strategy.computeDelay(3).toMillis()); // 100 * 2^3
+        assertEquals(1600, strategy.computeDelay(4).toMillis()); // 100 * 2^4
+    }
+
+    @Test
+    void exponentialBackoff_withNoJitter_differentBackoffRates() {
+        var strategy =
+                PollingStrategies.exponentialBackoff(Duration.ofMillis(50), 3.0, JitterStrategy.NONE, DEFAULT_MAX);
+
+        assertEquals(50, strategy.computeDelay(0).toMillis()); // 50 * 3^0
+        assertEquals(150, strategy.computeDelay(1).toMillis()); // 50 * 3^1
+        assertEquals(450, strategy.computeDelay(2).toMillis()); // 50 * 3^2
+        assertEquals(1350, strategy.computeDelay(3).toMillis()); // 50 * 3^3
+    }
+
+    @Test
+    void exponentialBackoff_withFullJitter_delayInExpectedRange() {
+        var strategy =
+                PollingStrategies.exponentialBackoff(Duration.ofMillis(100), 2.0, JitterStrategy.FULL, DEFAULT_MAX);
+
+        for (int i = 0; i < 20; i++) {
+            var delay0 = strategy.computeDelay(0).toMillis();
+            assertTrue(
+                    delay0 >= 0 && delay0 <= 100, "Attempt 0 with FULL jitter should be in [0, 100]ms, got " + delay0);
+
+            var delay2 = strategy.computeDelay(2).toMillis();
+            assertTrue(
+                    delay2 >= 0 && delay2 <= 400, "Attempt 2 with FULL jitter should be in [0, 400]ms, got " + delay2);
+        }
+    }
+
+    @Test
+    void exponentialBackoff_withHalfJitter_delayInExpectedRange() {
+        var strategy =
+                PollingStrategies.exponentialBackoff(Duration.ofMillis(100), 2.0, JitterStrategy.HALF, DEFAULT_MAX);
+
+        for (int i = 0; i < 20; i++) {
+            var delay0 = strategy.computeDelay(0).toMillis();
+            assertTrue(
+                    delay0 >= 50 && delay0 <= 100,
+                    "Attempt 0 with HALF jitter should be in [50, 100]ms, got " + delay0);
+
+            var delay2 = strategy.computeDelay(2).toMillis();
+            assertTrue(
+                    delay2 >= 200 && delay2 <= 400,
+                    "Attempt 2 with HALF jitter should be in [200, 400]ms, got " + delay2);
+        }
+    }
+
+    // --- maxInterval tests ---
+
+    @Test
+    void exponentialBackoff_withMaxInterval_capsDelay() {
+        // base=100ms, rate=2.0, NONE jitter → deterministic: 100, 200, 400, 800, 1600...
+        // maxInterval=500ms → should cap at 500
+        var strategy = PollingStrategies.exponentialBackoff(
+                Duration.ofMillis(100), 2.0, JitterStrategy.NONE, Duration.ofMillis(500));
+
+        assertEquals(100, strategy.computeDelay(0).toMillis()); // 100 < 500
+        assertEquals(200, strategy.computeDelay(1).toMillis()); // 200 < 500
+        assertEquals(400, strategy.computeDelay(2).toMillis()); // 400 < 500
+        assertEquals(500, strategy.computeDelay(3).toMillis()); // 800 → capped to 500
+        assertEquals(500, strategy.computeDelay(4).toMillis()); // 1600 → capped to 500
+        assertEquals(500, strategy.computeDelay(10).toMillis()); // huge → capped to 500
+    }
+
+    @Test
+    void exponentialBackoff_withMaxInterval_capsAfterJitter() {
+        // With FULL jitter, delay = random(0, base*rate^attempt), then capped by maxInterval
+        // base=100ms, rate=2.0, maxInterval=300ms
+        var strategy = PollingStrategies.exponentialBackoff(
+                Duration.ofMillis(100), 2.0, JitterStrategy.FULL, Duration.ofMillis(300));
+
+        for (int i = 0; i < 50; i++) {
+            // At attempt 5, uncapped range would be [0, 3200]ms
+            // After maxInterval cap, should never exceed 300ms
+            var delay = strategy.computeDelay(i).toMillis();
+            assertTrue(delay >= 0 && delay <= 300, "Delay should be capped at maxInterval=300ms, got " + delay + "ms");
+        }
+    }
+
+    @Test
+    void exponentialBackoff_withMaxInterval_defaultPresetCapsAt10Seconds() {
+        var strategy = PollingStrategies.Presets.DEFAULT;
+
+        // Default: base=1000ms, rate=2.0, FULL jitter, maxInterval=10s
+        // At high attempts, uncapped delay would be huge, but should cap at 10s
+        for (int i = 0; i < 20; i++) {
+            var delay = strategy.computeDelay(i).toMillis();
+            assertTrue(delay <= 10_000, "Default preset should cap at 10s maxInterval, got " + delay + "ms");
+        }
+    }
+
+    // --- Parameter validation tests ---
+
+    @Test
+    void exponentialBackoff_nullBaseInterval_throwsNullPointerException() {
+        assertThrows(
+                NullPointerException.class,
+                () -> PollingStrategies.exponentialBackoff(null, 2.0, JitterStrategy.NONE, DEFAULT_MAX));
+    }
+
+    @Test
+    void exponentialBackoff_nullJitter_throwsNullPointerException() {
+        assertThrows(
+                NullPointerException.class,
+                () -> PollingStrategies.exponentialBackoff(Duration.ofMillis(100), 2.0, null, DEFAULT_MAX));
+    }
+
+    @Test
+    void exponentialBackoff_nullMaxInterval_throwsNullPointerException() {
+        assertThrows(
+                NullPointerException.class,
+                () -> PollingStrategies.exponentialBackoff(Duration.ofMillis(100), 2.0, JitterStrategy.NONE, null));
+    }
+
+    @Test
+    void exponentialBackoff_zeroBackoffRate_throwsException() {
+        var exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(100), 0.0, JitterStrategy.NONE, DEFAULT_MAX));
+
+        assertEquals("backoffRate must be positive", exception.getMessage());
+    }
+
+    @Test
+    void exponentialBackoff_negativeBackoffRate_throwsException() {
+        var exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(100), -1.0, JitterStrategy.NONE, DEFAULT_MAX));
+
+        assertEquals("backoffRate must be positive", exception.getMessage());
+    }
+
+    @Test
+    void exponentialBackoff_zeroBaseInterval_throwsException() {
+        var exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> PollingStrategies.exponentialBackoff(Duration.ZERO, 2.0, JitterStrategy.NONE, DEFAULT_MAX));
+
+        assertEquals("baseInterval must be positive", exception.getMessage());
+    }
+
+    @Test
+    void exponentialBackoff_negativeBaseInterval_throwsException() {
+        var exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(-100), 2.0, JitterStrategy.NONE, DEFAULT_MAX));
+
+        assertEquals("baseInterval must be positive", exception.getMessage());
+    }
+
+    @Test
+    void exponentialBackoff_zeroMaxInterval_throwsException() {
+        var exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(100), 2.0, JitterStrategy.NONE, Duration.ZERO));
+
+        assertEquals("maxInterval must be positive", exception.getMessage());
+    }
+
+    @Test
+    void exponentialBackoff_negativeMaxInterval_throwsException() {
+        var exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> PollingStrategies.exponentialBackoff(
+                        Duration.ofMillis(100), 2.0, JitterStrategy.NONE, Duration.ofMillis(-500)));
+
+        assertEquals("maxInterval must be positive", exception.getMessage());
+    }
+
+    @Test
+    void fixedDelay_nullInterval_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> PollingStrategies.fixedDelay(null));
+    }
+
+    @Test
+    void fixedDelay_zeroInterval_throwsException() {
+        var exception = assertThrows(IllegalArgumentException.class, () -> PollingStrategies.fixedDelay(Duration.ZERO));
+
+        assertEquals("interval must be positive", exception.getMessage());
+    }
+
+    @Test
+    void fixedDelay_negativeInterval_throwsException() {
+        var exception = assertThrows(
+                IllegalArgumentException.class, () -> PollingStrategies.fixedDelay(Duration.ofMillis(-100)));
+
+        assertEquals("interval must be positive", exception.getMessage());
+    }
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
close #82 

### Description

- Refactored the jitter
- Add backoff rate and jitter to config
- Implement backoff and jitter logic for polling interval
- Added a flag for internal polling, jitter and backoff will not be applied if we want fixed polling interval (e.g. for wait operations)


### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Yes

#### Integration Tests

Have integration tests been written for these changes? Yes

#### Examples

Has a new example been added for the change? (if applicable) Yes
