### PR TITLE
[feature]: add generic support for execution input and output

### DIFF
--- a/examples/src/main/java/software/amazon/lambda/durable/examples/GenericInputOutputExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/GenericInputOutputExample.java
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.StepConfig;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+
+/**
+ * Example demonstrating a durable Lambda function that uses generic types in input and output.
+ *
+ * <p>This example shows how to use TypeToken to work with generic types like List<String>, Map<String, List<String,
+ * String>, and nested generics that cannot be represented by simple Class objects.
+ */
+public class GenericInputOutputExample
+        extends DurableHandler<Map<String, String>, Map<String, Map<String, List<String>>>> {
+
+    private static final Logger logger = LoggerFactory.getLogger(GenericInputOutputExample.class);
+
+    @Override
+    public Map<String, Map<String, List<String>>> handleRequest(Map<String, String> input, DurableContext context) {
+        logger.info("Starting generic types example for user: {}", input.get("userId"));
+
+        // Fetch nested generic type with retry (Map<String, List<String>>)
+        Map<String, List<String>> categories = context.step(
+                "fetch-categories",
+                new TypeToken<Map<String, List<String>>>() {},
+                stepCtx -> {
+                    logger.info("Fetching category details");
+                    var result = new HashMap<String, List<String>>();
+                    result.put("electronics", List.of("laptop", "phone"));
+                    result.put("books", List.of("fiction"));
+                    result.put("clothing", List.of("shirt"));
+                    return result;
+                },
+                StepConfig.builder()
+                        .retryStrategy(RetryStrategies.Presets.DEFAULT)
+                        .build());
+        logger.info("Fetched {} category details", categories.size());
+        logger.info("Generic types example completed successfully");
+
+        // return a result of Map<String, Map<String, List<String>>>
+        return new HashMap<>(Map.of("categories", categories));
+    }
+}

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/CloudBasedIntegrationTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/CloudBasedIntegrationTest.java
@@ -3,7 +3,10 @@
 package software.amazon.lambda.durable.examples;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static software.amazon.lambda.durable.TypeToken.get;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -13,6 +16,7 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.lambda.durable.TypeToken;
 import software.amazon.lambda.durable.model.ExecutionStatus;
 import software.amazon.lambda.durable.testing.CloudDurableTestRunner;
 
@@ -60,7 +64,8 @@ class CloudBasedIntegrationTest {
 
     @Test
     void testSimpleStepExample() {
-        var runner = CloudDurableTestRunner.create(arn("simple-step-example"), Map.class, String.class);
+        var runner = CloudDurableTestRunner.create(
+                arn("simple-step-example"), new TypeToken<Map<String, String>>() {}, get(String.class));
         var result = runner.run(Map.of("message", "test"));
 
         assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
@@ -73,7 +78,8 @@ class CloudBasedIntegrationTest {
 
     @Test
     void testNoopExampleWithLargeInput() {
-        var runner = CloudDurableTestRunner.create(arn("noop-example"), Map.class, String.class);
+        var runner = CloudDurableTestRunner.create(
+                arn("noop-example"), new TypeToken<Map<String, String>>() {}, get(String.class));
         // 6MB large input
         var largeInput = "A".repeat(1024 * 1024 * 6 - 12);
         var result = runner.run(Map.of("name", largeInput));
@@ -84,7 +90,8 @@ class CloudBasedIntegrationTest {
 
     @Test
     void testSimpleInvokeExample() {
-        var runner = CloudDurableTestRunner.create(arn("simple-invoke-example"), Map.class, String.class);
+        var runner = CloudDurableTestRunner.create(
+                arn("simple-invoke-example"), new TypeToken<Map<String, String>>() {}, get(String.class));
         var result = runner.run(Map.of("name", functionNameSuffix));
 
         assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
@@ -226,6 +233,31 @@ class CloudBasedIntegrationTest {
         // Verify operations were executed
         assertNotNull(runner.getOperation("fetch-items"));
         assertNotNull(runner.getOperation("count-by-category"));
+        assertNotNull(runner.getOperation("fetch-categories"));
+    }
+
+    @Test
+    void testGenericInputOutputExample() {
+        final TypeToken<Map<String, Map<String, List<String>>>> resultType = new TypeToken<>() {};
+        final TypeToken<Map<String, String>> inputType = new TypeToken<>() {};
+
+        var runner = CloudDurableTestRunner.create(arn("generic-input-output-example"), inputType, resultType);
+        var result = runner.run(new HashMap<>(Map.of("userId", "user123")));
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+
+        var output = result.getResult(resultType);
+        assertNotNull(output);
+
+        // Verify categories nested map
+        var categories = output.get("categories");
+        assertNotNull(categories);
+        assertEquals(3, categories.size());
+        assertEquals(2, categories.get("electronics").size());
+        assertTrue(categories.get("electronics").contains("laptop"));
+        assertTrue(categories.get("electronics").contains("phone"));
+
+        // Verify operations were executed
         assertNotNull(runner.getOperation("fetch-categories"));
     }
 

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/GenericInputOutputExampleTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/GenericInputOutputExampleTest.java
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
+
+class GenericInputOutputExampleTest {
+
+    private static final TypeToken<Map<String, Map<String, List<String>>>> resultType = new TypeToken<>() {};
+    private static final TypeToken<Map<String, String>> inputType = new TypeToken<>() {};
+
+    @Test
+    void testGenericTypesExample() {
+        var handler = new GenericInputOutputExample();
+        var runner = LocalDurableTestRunner.create(inputType, handler);
+
+        var input = new HashMap<>(Map.of("userId", "user123"));
+        var result = runner.run(input);
+
+        assertNotNull(result);
+        var output = result.getResult(resultType);
+        assertNotNull(output);
+
+        // Verify categories nested map
+        var categories = output.get("categories");
+        assertNotNull(categories);
+        assertEquals(3, categories.size());
+        assertEquals(2, categories.get("electronics").size());
+        assertTrue(categories.get("electronics").contains("laptop"));
+        assertTrue(categories.get("electronics").contains("phone"));
+        assertEquals(1, categories.get("books").size());
+        assertTrue(categories.get("books").contains("fiction"));
+    }
+
+    @Test
+    void testOperationTracking() {
+        var handler = new GenericInputOutputExample();
+        var runner = LocalDurableTestRunner.create(inputType, handler);
+
+        var input = new HashMap<>(Map.of("userId", "user123"));
+        var result = runner.run(input);
+
+        // Verify all operations were executed
+        var fetchCategories = result.getOperation("fetch-categories");
+        assertNotNull(fetchCategories);
+        assertEquals("fetch-categories", fetchCategories.getName());
+    }
+}

--- a/examples/template.yaml
+++ b/examples/template.yaml
@@ -243,6 +243,31 @@ Resources:
       DockerContext: ../
       DockerTag: durable-examples
 
+  GenericInputOutputExampleFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      FunctionName: !Join
+        - ''
+        - - 'generic-input-output-example'
+          - !Ref FunctionNameSuffix
+      ImageConfig:
+        Command: ["software.amazon.lambda.durable.examples.GenericInputOutputExample::handleRequest"]
+      DurableConfig:
+        ExecutionTimeout: 300
+        RetentionPeriodInDays: 7
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - lambda:CheckpointDurableExecutions
+                - lambda:GetDurableExecutionState
+              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:generic-input-output-example${FunctionNameSuffix}"
+    Metadata:
+      Dockerfile: !Ref DockerFile
+      DockerContext: ../
+      DockerTag: durable-examples
+
   CustomConfigExampleFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -490,6 +515,14 @@ Outputs:
   GenericTypesExampleFunctionName:
     Description: Generic Types Example Function Name
     Value: !Ref GenericTypesExampleFunction
+
+  GenericInputOutputExampleFunction:
+    Description: Generic Input Output Example Function ARN
+    Value: !GetAtt GenericInputOutputExampleFunction.Arn
+
+  GenericInputOutputExampleFunctionName:
+    Description: Generic Input Output Example Function Name
+    Value: !Ref GenericInputOutputExampleFunction
 
   CustomConfigExampleFunction:
     Description: Custom Config Example Function ARN

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/DurableExecutionCheckpointTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/DurableExecutionCheckpointTest.java
@@ -40,7 +40,11 @@ class DurableExecutionCheckpointTest {
         var largeString = "x".repeat(7 * 1024 * 1024); // 7MB string
 
         var output = DurableExecutor.execute(
-                input, null, String.class, (userInput, ctx) -> largeString, configWithMockClient(client));
+                input,
+                null,
+                TypeToken.get(String.class),
+                (userInput, ctx) -> largeString,
+                configWithMockClient(client));
 
         assertEquals(ExecutionStatus.SUCCEEDED, output.status());
         assertEquals("", output.result());
@@ -76,7 +80,11 @@ class DurableExecutionCheckpointTest {
         var smallResult = "Small result";
 
         var output = DurableExecutor.execute(
-                input, null, String.class, (userInput, ctx) -> smallResult, configWithMockClient(client));
+                input,
+                null,
+                TypeToken.get(String.class),
+                (userInput, ctx) -> smallResult,
+                configWithMockClient(client));
 
         assertEquals(ExecutionStatus.SUCCEEDED, output.status());
         assertNotNull(output.result());

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/AsyncExecution.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/AsyncExecution.java
@@ -11,6 +11,7 @@ import software.amazon.awssdk.services.lambda.model.Event;
 import software.amazon.awssdk.services.lambda.model.EventType;
 import software.amazon.awssdk.services.lambda.model.GetDurableExecutionHistoryRequest;
 import software.amazon.awssdk.services.lambda.model.ResourceNotFoundException;
+import software.amazon.lambda.durable.TypeToken;
 import software.amazon.lambda.durable.model.ExecutionStatus;
 
 /**
@@ -20,7 +21,7 @@ import software.amazon.lambda.durable.model.ExecutionStatus;
 public class AsyncExecution<O> {
     private final String executionArn;
     private final LambdaClient lambdaClient;
-    private final Class<O> outputType;
+    private final TypeToken<O> outputType;
     private final Duration pollInterval;
     private final Duration timeout;
     private final HistoryEventProcessor processor;
@@ -30,7 +31,7 @@ public class AsyncExecution<O> {
     public AsyncExecution(
             String executionArn,
             LambdaClient lambdaClient,
-            Class<O> outputType,
+            TypeToken<O> outputType,
             Duration pollInterval,
             Duration timeout) {
         this.executionArn = executionArn;

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/CloudDurableTestRunner.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/CloudDurableTestRunner.java
@@ -8,12 +8,13 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvocationType;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.lambda.durable.TypeToken;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
 
 public class CloudDurableTestRunner<I, O> {
     private final String functionArn;
-    private final Class<I> inputType;
-    private final Class<O> outputType;
+    private final TypeToken<I> inputType;
+    private final TypeToken<O> outputType;
     private final LambdaClient lambdaClient;
     private final Duration pollInterval;
     private final Duration timeout;
@@ -23,8 +24,8 @@ public class CloudDurableTestRunner<I, O> {
 
     private CloudDurableTestRunner(
             String functionArn,
-            Class<I> inputType,
-            Class<O> outputType,
+            TypeToken<I> inputType,
+            TypeToken<O> outputType,
             LambdaClient lambdaClient,
             Duration pollInterval,
             Duration timeout,
@@ -40,6 +41,11 @@ public class CloudDurableTestRunner<I, O> {
 
     public static <I, O> CloudDurableTestRunner<I, O> create(
             String functionArn, Class<I> inputType, Class<O> outputType) {
+        return create(functionArn, TypeToken.get(inputType), TypeToken.get(outputType));
+    }
+
+    public static <I, O> CloudDurableTestRunner<I, O> create(
+            String functionArn, TypeToken<I> inputType, TypeToken<O> outputType) {
         return new CloudDurableTestRunner<>(
                 functionArn,
                 inputType,
@@ -55,6 +61,11 @@ public class CloudDurableTestRunner<I, O> {
 
     public static <I, O> CloudDurableTestRunner<I, O> create(
             String functionArn, Class<I> inputType, Class<O> outputType, LambdaClient lambdaClient) {
+        return create(functionArn, TypeToken.get(inputType), TypeToken.get(outputType), lambdaClient);
+    }
+
+    public static <I, O> CloudDurableTestRunner<I, O> create(
+            String functionArn, TypeToken<I> inputType, TypeToken<O> outputType, LambdaClient lambdaClient) {
         return new CloudDurableTestRunner<>(
                 functionArn,
                 inputType,

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/HistoryEventProcessor.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/HistoryEventProcessor.java
@@ -15,13 +15,14 @@ import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.awssdk.services.lambda.model.OperationType;
 import software.amazon.awssdk.services.lambda.model.StepDetails;
 import software.amazon.awssdk.services.lambda.model.WaitDetails;
+import software.amazon.lambda.durable.TypeToken;
 import software.amazon.lambda.durable.model.ExecutionStatus;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
 
 public class HistoryEventProcessor {
     private final JacksonSerDes serDes = new JacksonSerDes();
 
-    public <O> TestResult<O> processEvents(List<Event> events, Class<O> outputType) {
+    public <O> TestResult<O> processEvents(List<Event> events, TypeToken<O> outputType) {
         var operations = new HashMap<String, Operation>();
         var operationEvents = new HashMap<String, List<Event>>();
         var status = ExecutionStatus.PENDING;

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
@@ -16,6 +16,7 @@ import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableExecutor;
 import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
 import software.amazon.lambda.durable.model.DurableExecutionInput;
 import software.amazon.lambda.durable.model.ExecutionStatus;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
@@ -24,13 +25,13 @@ import software.amazon.lambda.durable.serde.SerDes;
 public class LocalDurableTestRunner<I, O> {
     private static final int MAX_INVOCATIONS = 100;
 
-    private final Class<I> inputType;
+    private final TypeToken<I> inputType;
     private final BiFunction<I, DurableContext, O> handler;
     private final LocalMemoryExecutionClient storage;
     private final SerDes serDes;
     private final DurableConfig customerConfig;
 
-    private LocalDurableTestRunner(Class<I> inputType, BiFunction<I, DurableContext, O> handlerFn) {
+    private LocalDurableTestRunner(TypeToken<I> inputType, BiFunction<I, DurableContext, O> handlerFn) {
         this.inputType = inputType;
         this.handler = handlerFn;
         this.storage = new LocalMemoryExecutionClient();
@@ -39,7 +40,7 @@ public class LocalDurableTestRunner<I, O> {
     }
 
     private LocalDurableTestRunner(
-            Class<I> inputType, BiFunction<I, DurableContext, O> handlerFn, DurableConfig customerConfig) {
+            TypeToken<I> inputType, BiFunction<I, DurableContext, O> handlerFn, DurableConfig customerConfig) {
         this.inputType = inputType;
         this.handler = handlerFn;
         this.storage = new LocalMemoryExecutionClient();
@@ -50,12 +51,21 @@ public class LocalDurableTestRunner<I, O> {
     /**
      * Creates a LocalDurableTestRunner with default configuration. Use this method when your handler uses the default
      * DurableConfig.
+     */
+    public static <I, O> LocalDurableTestRunner<I, O> create(
+            Class<I> inputType, BiFunction<I, DurableContext, O> handlerFn) {
+        return new LocalDurableTestRunner<>(TypeToken.get(inputType), handlerFn);
+    }
+
+    /**
+     * Creates a LocalDurableTestRunner with default configuration. Use this method when your handler uses the default
+     * DurableConfig.
      *
-     * <p>If your handler has custom configuration (custom SerDes, ExecutorService, etc.), use {@link #create(Class,
+     * <p>If your handler has custom configuration (custom SerDes, ExecutorService, etc.), use {@link #create(TypeToken,
      * DurableHandler)} instead to ensure the test runner uses the same configuration as your handler.
      *
-     * <p>Optionally, you can also use {@link #create(Class, BiFunction, DurableConfig)} to pass in any DurableConfig
-     * directly.
+     * <p>Optionally, you can also use {@link #create(TypeToken, BiFunction, DurableConfig)} to pass in any
+     * DurableConfig directly.
      *
      * @param inputType The input type class
      * @param handlerFn The handler function
@@ -64,10 +74,18 @@ public class LocalDurableTestRunner<I, O> {
      * @return LocalDurableTestRunner with default configuration
      */
     public static <I, O> LocalDurableTestRunner<I, O> create(
-            Class<I> inputType, BiFunction<I, DurableContext, O> handlerFn) {
+            TypeToken<I> inputType, BiFunction<I, DurableContext, O> handlerFn) {
         return new LocalDurableTestRunner<>(inputType, handlerFn);
     }
 
+    /**
+     * Creates a LocalDurableTestRunner that uses a custom configuration. This allows the test runner to use custom
+     * SerDes and other configuration, while overriding the DurableExecutionClient with the in-memory implementation.
+     */
+    public static <I, O> LocalDurableTestRunner<I, O> create(
+            Class<I> inputType, BiFunction<I, DurableContext, O> handlerFn, DurableConfig config) {
+        return new LocalDurableTestRunner<>(TypeToken.get(inputType), handlerFn, config);
+    }
     /**
      * Creates a LocalDurableTestRunner that uses a custom configuration. This allows the test runner to use custom
      * SerDes and other configuration, while overriding the DurableExecutionClient with the in-memory implementation.
@@ -103,8 +121,18 @@ public class LocalDurableTestRunner<I, O> {
      * @return LocalDurableTestRunner configured with the provided settings
      */
     public static <I, O> LocalDurableTestRunner<I, O> create(
-            Class<I> inputType, BiFunction<I, DurableContext, O> handlerFn, DurableConfig config) {
+            TypeToken<I> inputType, BiFunction<I, DurableContext, O> handlerFn, DurableConfig config) {
         return new LocalDurableTestRunner<>(inputType, handlerFn, config);
+    }
+
+    /**
+     * Creates a LocalDurableTestRunner from a DurableHandler instance, automatically extracting the configuration. This
+     * is a convenient method when you have a handler instance and want to test it with the same configuration it uses
+     * in production.
+     */
+    public static <I, O> LocalDurableTestRunner<I, O> create(Class<I> inputType, DurableHandler<I, O> handler) {
+        return new LocalDurableTestRunner<>(
+                TypeToken.get(inputType), handler::handleRequest, handler.getConfiguration());
     }
 
     /**
@@ -139,7 +167,7 @@ public class LocalDurableTestRunner<I, O> {
      * @param <O> Output type
      * @return LocalDurableTestRunner configured with the handler's settings
      */
-    public static <I, O> LocalDurableTestRunner<I, O> create(Class<I> inputType, DurableHandler<I, O> handler) {
+    public static <I, O> LocalDurableTestRunner<I, O> create(TypeToken<I> inputType, DurableHandler<I, O> handler) {
         return new LocalDurableTestRunner<>(inputType, handler::handleRequest, handler.getConfiguration());
     }
 

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/TestOperation.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/TestOperation.java
@@ -58,13 +58,17 @@ public class TestOperation {
         return operation.callbackDetails();
     }
 
-    /** Type-safe result extraction from step details. */
     public <T> T getStepResult(Class<T> type) {
+        return getStepResult(TypeToken.get(type));
+    }
+
+    /** Type-safe result extraction from step details. */
+    public <T> T getStepResult(TypeToken<T> type) {
         var details = operation.stepDetails();
         if (details == null || details.result() == null) {
             return null;
         }
-        return serDes.deserialize(details.result(), TypeToken.get(type));
+        return serDes.deserialize(details.result(), type);
     }
 
     public ErrorObject getError() {

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/TestResult.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/TestResult.java
@@ -48,6 +48,10 @@ public class TestResult<O> {
     }
 
     public <T> T getResult(Class<T> resultType) {
+        return getResult(TypeToken.get(resultType));
+    }
+
+    public <T> T getResult(TypeToken<T> resultType) {
         if (status != ExecutionStatus.SUCCEEDED) {
             throw new IllegalStateException("Execution did not succeed: " + status);
         }
@@ -55,11 +59,11 @@ public class TestResult<O> {
             var lastEvent = allEvents.get(allEvents.size() - 1);
             if (lastEvent.eventType() == EventType.EXECUTION_SUCCEEDED) {
                 return serDes.deserialize(
-                        lastEvent.executionSucceededDetails().result().payload(), TypeToken.get(resultType));
+                        lastEvent.executionSucceededDetails().result().payload(), resultType);
             }
             return null;
         }
-        return serDes.deserialize(resultPayload, TypeToken.get(resultType));
+        return serDes.deserialize(resultPayload, resultType);
     }
 
     public Optional<ErrorObject> getError() {

--- a/sdk-testing/src/test/java/software/amazon/lambda/durable/testing/LocalDurableTestRunnerTest.java
+++ b/sdk-testing/src/test/java/software/amazon/lambda/durable/testing/LocalDurableTestRunnerTest.java
@@ -3,8 +3,13 @@
 package software.amazon.lambda.durable.testing;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static software.amazon.lambda.durable.TypeToken.get;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.TypeToken;
 import software.amazon.lambda.durable.model.ExecutionStatus;
 
 class LocalDurableTestRunnerTest {
@@ -55,6 +60,23 @@ class LocalDurableTestRunnerTest {
         var op2 = runner.getOperation("step-2");
         assertNotNull(op2);
         assertEquals("step-2", op2.getName());
-        assertEquals("result2", op2.getStepResult(String.class));
+        assertEquals("result2", op2.getStepResult(get(String.class)));
+    }
+
+    @Test
+    void testGenericTypeInput() {
+        var resultType = new TypeToken<ArrayList<String>>() {};
+        var runner = LocalDurableTestRunner.create(resultType, (input, ctx) -> {
+            return ctx.step("process", resultType, stepCtx -> {
+                var reversed = new ArrayList<>(input);
+                Collections.reverse(reversed);
+                return reversed;
+            });
+        });
+
+        var testResult = runner.run(new ArrayList<>(List.of("item1", "item2")));
+
+        assertEquals(ExecutionStatus.SUCCEEDED, testResult.getStatus());
+        assertEquals(List.of("item2", "item1"), testResult.getResult(resultType));
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableExecutor.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableExecutor.java
@@ -33,7 +33,7 @@ public class DurableExecutor {
     public static <I, O> DurableExecutionOutput execute(
             DurableExecutionInput input,
             Context lambdaContext,
-            Class<I> inputType,
+            TypeToken<I> inputType,
             BiFunction<I, DurableContext, O> handler,
             DurableConfig config) {
         try (var executionManager = new ExecutionManager(input, config)) {
@@ -116,17 +116,17 @@ public class DurableExecutor {
         return ExceptionHelper.buildErrorObject(e, serDes);
     }
 
-    private static <I> I extractUserInput(Operation executionOp, SerDes serDes, Class<I> inputType) {
+    private static <I> I extractUserInput(Operation executionOp, SerDes serDes, TypeToken<I> inputType) {
         if (executionOp.executionDetails() == null) {
             throw new IllegalDurableOperationException("EXECUTION operation missing executionDetails");
         }
 
         var inputPayload = executionOp.executionDetails().inputPayload();
-        return serDes.deserialize(inputPayload, TypeToken.get(inputType));
+        return serDes.deserialize(inputPayload, inputType);
     }
 
     public static <I, O> RequestHandler<DurableExecutionInput, DurableExecutionOutput> wrap(
-            Class<I> inputType, BiFunction<I, DurableContext, O> handler, DurableConfig config) {
+            TypeToken<I> inputType, BiFunction<I, DurableContext, O> handler, DurableConfig config) {
         return (input, context) -> execute(input, context, inputType, handler, config);
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableHandler.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableHandler.java
@@ -34,17 +34,16 @@ import software.amazon.lambda.durable.serde.AwsSdkV2Module;
 
 public abstract class DurableHandler<I, O> implements RequestStreamHandler {
 
-    private final Class<I> inputType;
+    private final TypeToken<I> inputType;
     private final DurableConfig config;
     private final ObjectMapper objectMapper = createObjectMapper(); // Internal ObjectMapper
     private static final Logger logger = LoggerFactory.getLogger(DurableHandler.class);
 
-    @SuppressWarnings("unchecked")
     protected DurableHandler() {
         // Extract input type from generic superclass
         var superClass = getClass().getGenericSuperclass();
         if (superClass instanceof ParameterizedType paramType) {
-            this.inputType = (Class<I>) paramType.getActualTypeArguments()[0];
+            this.inputType = TypeToken.get(paramType.getActualTypeArguments()[0]);
         } else {
             throw new IllegalArgumentException("Cannot determine input type parameter");
         }

--- a/sdk/src/main/java/software/amazon/lambda/durable/TypeToken.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/TypeToken.java
@@ -52,6 +52,10 @@ public abstract class TypeToken<T> {
         return new TypeToken<>(clazz) {};
     }
 
+    static <U> TypeToken<U> get(Type clazz) {
+        return new TypeToken<>(clazz) {};
+    }
+
     /**
      * Returns the captured type.
      *

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableExecutionTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableExecutionTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static software.amazon.lambda.durable.TypeToken.get;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -53,7 +54,7 @@ class DurableExecutionTest {
         var output = DurableExecutor.execute(
                 input,
                 null,
-                String.class,
+                get(String.class),
                 (userInput, ctx) -> ctx.step("test", String.class, stepCtx -> "Hello " + userInput),
                 configWithMockClient());
 
@@ -83,7 +84,7 @@ class DurableExecutionTest {
         var output = DurableExecutor.execute(
                 input,
                 null,
-                String.class,
+                get(String.class),
                 (userInput, ctx) -> {
                     ctx.step("step1", String.class, stepCtx -> "Done");
                     ctx.wait(null, java.time.Duration.ofSeconds(60));
@@ -116,7 +117,7 @@ class DurableExecutionTest {
         var output = DurableExecutor.execute(
                 input,
                 null,
-                String.class,
+                get(String.class),
                 (userInput, ctx) -> {
                     throw new RuntimeException("Test error");
                 },
@@ -157,7 +158,7 @@ class DurableExecutionTest {
         var output = DurableExecutor.execute(
                 input,
                 null,
-                String.class,
+                get(String.class),
                 (userInput, ctx) -> ctx.step("step1", String.class, stepCtx -> "Second"),
                 configWithMockClient());
 
@@ -175,7 +176,7 @@ class DurableExecutionTest {
         var exception = assertThrows(
                 IllegalStateException.class,
                 () -> DurableExecutor.execute(
-                        input, null, String.class, (userInput, ctx) -> "result", configWithMockClient()));
+                        input, null, get(String.class), (userInput, ctx) -> "result", configWithMockClient()));
 
         assertEquals("First operation must be EXECUTION", exception.getMessage());
     }
@@ -199,7 +200,7 @@ class DurableExecutionTest {
         var exception = assertThrows(
                 IllegalStateException.class,
                 () -> DurableExecutor.execute(
-                        input, null, String.class, (userInput, ctx) -> "result", configWithMockClient()));
+                        input, null, get(String.class), (userInput, ctx) -> "result", configWithMockClient()));
 
         assertEquals("First operation must be EXECUTION", exception.getMessage());
     }
@@ -220,7 +221,7 @@ class DurableExecutionTest {
                         .build());
 
         var result = DurableExecutor.execute(
-                input, null, String.class, (userInput, ctx) -> "result", configWithMockClient());
+                input, null, get(String.class), (userInput, ctx) -> "result", configWithMockClient());
 
         assertEquals(ExecutionStatus.FAILED, result.status());
         assertEquals(
@@ -256,7 +257,7 @@ class DurableExecutionTest {
         var output1 = DurableExecutor.execute(
                 input1,
                 null,
-                String.class,
+                get(String.class),
                 (userInput, ctx) -> ctx.step("test1", String.class, stepCtx -> "Result 1: " + userInput),
                 config);
 
@@ -284,7 +285,7 @@ class DurableExecutionTest {
         var output2 = DurableExecutor.execute(
                 input2,
                 null,
-                String.class,
+                get(String.class),
                 (userInput, ctx) -> ctx.step("test2", String.class, stepCtx -> "Result 2: " + userInput),
                 config);
 

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableExecutionWrapperTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableExecutionWrapperTest.java
@@ -4,6 +4,7 @@ package software.amazon.lambda.durable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static software.amazon.lambda.durable.TypeToken.get;
 
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import java.util.List;
@@ -50,7 +51,7 @@ class DurableExecutionWrapperTest {
         var config =
                 DurableConfig.builder().withDurableExecutionClient(mockClient()).build();
         RequestHandler<DurableExecutionInput, DurableExecutionOutput> handler = DurableExecutor.wrap(
-                TestInput.class,
+                get(TestInput.class),
                 (input, context) -> {
                     var result = context.step("process", String.class, stepCtx -> "Wrapped: " + input.value);
                     return new TestOutput(result);
@@ -83,7 +84,7 @@ class DurableExecutionWrapperTest {
         assertEquals(ExecutionStatus.SUCCEEDED, output.status());
         assertNotNull(output.result());
 
-        var result = serDes.deserialize(output.result(), TypeToken.get(TestOutput.class));
+        var result = serDes.deserialize(output.result(), get(TestOutput.class));
         assertEquals("Wrapped: test", result.result);
     }
 
@@ -92,7 +93,7 @@ class DurableExecutionWrapperTest {
         var config =
                 DurableConfig.builder().withDurableExecutionClient(mockClient()).build();
         RequestHandler<DurableExecutionInput, DurableExecutionOutput> handler =
-                DurableExecutor.wrap(TestInput.class, DurableExecutionWrapperTest::handleRequest, config);
+                DurableExecutor.wrap(get(TestInput.class), DurableExecutionWrapperTest::handleRequest, config);
 
         var serDes = new JacksonSerDes();
 
@@ -115,7 +116,7 @@ class DurableExecutionWrapperTest {
         var output = handler.handleRequest(input, null);
 
         assertEquals(ExecutionStatus.SUCCEEDED, output.status());
-        var result = serDes.deserialize(output.result(), TypeToken.get(TestOutput.class));
+        var result = serDes.deserialize(output.result(), get(TestOutput.class));
         assertEquals("Method: method-ref", result.result);
     }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fixes #155 

### Description

allow execution input and output to be generic types
- added an example to verify generic input and output works
- added overloaded methods with TypeToken as a parameter for Local/Cloud runner
- replaced all the occurrences of `Class<>` in internal classes with `TypeToken<>` to support generic types.

### Demo/Screenshots

<img width="1601" height="948" alt="image" src="https://github.com/user-attachments/assets/4f17ba11-e8d2-4b83-9991-4fcce7416762" />


### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Updated

#### Integration Tests

Have integration tests been written for these changes? Updated

#### Examples

Has a new example been added for the change? (if applicable) added
