### PR TITLE
[Chore] Add workflow to auto merge dependency upgrades (#174)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,38 @@
+name: Auto-merge Dependabot PRs
+run-name: Auto-merge - PR #${{ github.event.pull_request.number }}
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
https://github.com/aws/aws-durable-execution-sdk-java/issues/174

### Description
- Added a script to auto-approve and auto-merge patch version upgrades by bot.
- We would still need to approve major versions manually, because there could be breaking changes.
- Enabled `Allow auto-merge` setting for repo.
- If we want all checks to pass before auto approve and auto merge, we would need to enable `require status checks to pass` for main branch. I haven't enabled it yet because we are actively developing this sdk and we might need to bypass some failures.
- There is no way to test this locally, I will keep an eye for version bump PRs tomorrow to see if this works.

### Demo/Screenshots
Forked repo, and ran github workflow. 
Patch version changes were automatically merged - https://github.com/ayushiahjolia/aws-durable-execution-sdk-java/pull/1
Minor version changes were not merged - https://github.com/ayushiahjolia/aws-durable-execution-sdk-java/pull/3

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
