### PR TITLE
[Experiment]: Testing virtual thread pool [DO NOT MERGE]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,7 +53,6 @@ body:
       label: Java Version
       description: What version of Java are you using?
       options:
-        - "17"
         - "21"
         - "25"
         - Other (specify in additional context)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@
 #   - push: when code is pushed to main
 #
 # Notes:
-#   Builds against Java 17, 21, and 25.
+#   Builds against Java 21, and 25.
 
 name: Build
 run-name: Build - ${{ github.event_name }}
@@ -43,7 +43,6 @@ jobs:
     strategy:
       matrix:
         java:
-          - 17
           - 21
           - 25
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,7 +40,6 @@ jobs:
     strategy:
       matrix:
         java:
-          - 17
           - 21
           - 25
     steps:

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM amazoncorretto:17-alpine AS builder
+FROM amazoncorretto:25-alpine AS builder
 
 # Install Maven
 RUN apk add --no-cache maven
@@ -19,7 +19,7 @@ RUN mvn clean install -DskipTests -pl sdk,sdk-testing -am
 RUN mvn clean package -DskipTests -pl examples -am
 
 # Runtime stage
-FROM public.ecr.aws/lambda/java:17
+FROM public.ecr.aws/lambda/java:25
 
 # Copy only the built JAR from build stage
 COPY --from=builder /build/examples/target/*.jar ${LAMBDA_TASK_ROOT}/lib/

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/ManyAsyncStepsExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/ManyAsyncStepsExample.java
@@ -4,7 +4,9 @@ package software.amazon.lambda.durable.examples;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableFuture;
 import software.amazon.lambda.durable.DurableHandler;
@@ -60,5 +62,13 @@ public class ManyAsyncStepsExample extends DurableHandler<ManyAsyncStepsExample.
         var replayTimeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
 
         return new Output(totalSum, executionTimeMs, replayTimeMs);
+    }
+
+    public DurableConfig createConfiguration() {
+
+        // using a virtual thread pool
+        return DurableConfig.builder()
+                .withExecutorService(Executors.newVirtualThreadPerTaskExecutor())
+                .build();
     }
 }

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/CloudBasedIntegrationTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/CloudBasedIntegrationTest.java
@@ -466,7 +466,7 @@ class CloudBasedIntegrationTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"100, 1000, 10", "500, 2000, 20", "1000, 3000, 30"})
+    @CsvSource({"100, 1000, 10", "500, 2000, 20", "1000, 3000, 30", "2000, 5000, 40"})
     void testManyAsyncStepsExample(int steps, long maxExecutionTime, long maxReplayTime) {
         long minimalExecutionTimeMs = Long.MAX_VALUE;
         long minimalReplayTimeMs = Long.MAX_VALUE;
@@ -502,8 +502,7 @@ class CloudBasedIntegrationTest {
     }
 
     @ParameterizedTest
-    // OOM if it creates 1000 child contexts
-    @CsvSource({"100, 1500, 10", "500, 3000, 20"})
+    @CsvSource({"100, 1500, 10", "500, 3000, 20", "1000, 4500, 30"})
     void testManyAsyncChildContextExample(int steps, long maxExecutionTime, long maxReplayTime) {
         long minimalExecutionTimeMs = Long.MAX_VALUE;
         long minimalReplayTimeMs = Long.MAX_VALUE;

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aws.sdk.version>2.42.9</aws.sdk.version>
         <jackson.version>2.21.1</jackson.version>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -79,6 +79,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
@@ -237,12 +237,7 @@ public final class DurableConfig {
      */
     private static ExecutorService createDefaultExecutor() {
         logger.debug("Creating default ExecutorService");
-        return Executors.newCachedThreadPool(r -> {
-            Thread t = new Thread(r);
-            t.setName("durable-exec-" + t.getId());
-            t.setDaemon(true);
-            return t;
-        });
+        return Executors.newVirtualThreadPerTaskExecutor();
     }
 
     /** Builder for DurableConfig. Provides fluent API for configuring SDK components. */


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

#152 

### Description

This is an experiment to test how good the performance is with virtual thread under Java 21/25

Performance in main branch (JDK 25 from [this run](https://github.com/aws/aws-durable-execution-sdk-java/actions/runs/22926502512/job/66538179499)):
```
ManyAsyncChildContextExample result (100 child contexts): Output[result=9900, executionTimeMs=1419, replayTimeMs=21]
ManyAsyncChildContextExample result (100 child contexts): Output[result=9900, executionTimeMs=652, replayTimeMs=1]
ManyAsyncChildContextExample result (100 child contexts): Output[result=9900, executionTimeMs=328, replayTimeMs=1]
ManyAsyncChildContextExample result (500 child contexts): Output[result=249500, executionTimeMs=1732, replayTimeMs=2]
ManyAsyncChildContextExample result (500 child contexts): Output[result=249500, executionTimeMs=1540, replayTimeMs=34]
ManyAsyncChildContextExample result (500 child contexts): Output[result=249500, executionTimeMs=1243, replayTimeMs=6]
ManyAsyncStepsExample result (100 steps): Output[result=9900, executionTimeMs=841, replayTimeMs=4]
ManyAsyncStepsExample result (100 steps): Output[result=9900, executionTimeMs=278, replayTimeMs=3]
ManyAsyncStepsExample result (100 steps): Output[result=9900, executionTimeMs=156, replayTimeMs=2]
ManyAsyncStepsExample result (500 steps): Output[result=249500, executionTimeMs=842, replayTimeMs=8]
ManyAsyncStepsExample result (500 steps): Output[result=249500, executionTimeMs=631, replayTimeMs=10]
ManyAsyncStepsExample result (500 steps): Output[result=249500, executionTimeMs=568, replayTimeMs=2]
ManyAsyncStepsExample result (1000 steps): Output[result=999000, executionTimeMs=1134, replayTimeMs=4]
ManyAsyncStepsExample result (1000 steps): Output[result=999000, executionTimeMs=990, replayTimeMs=4]
ManyAsyncStepsExample result (1000 steps): Output[result=999000, executionTimeMs=949, replayTimeMs=4]
```

Performance using virtual thread pool (JDK 25):

```
ManyAsyncChildContextExample result (100 child contexts): Output[result=9900, executionTimeMs=1420, replayTimeMs=20]
ManyAsyncChildContextExample result (100 child contexts): Output[result=9900, executionTimeMs=676, replayTimeMs=2]
ManyAsyncChildContextExample result (100 child contexts): Output[result=9900, executionTimeMs=562, replayTimeMs=1]
ManyAsyncChildContextExample result (500 child contexts): Output[result=249500, executionTimeMs=1565, replayTimeMs=3]
ManyAsyncChildContextExample result (500 child contexts): Output[result=249500, executionTimeMs=1336, replayTimeMs=21]
ManyAsyncChildContextExample result (500 child contexts): Output[result=249500, executionTimeMs=1023, replayTimeMs=14]
ManyAsyncChildContextExample result (1000 child contexts): Output[result=999000, executionTimeMs=2548, replayTimeMs=85]
ManyAsyncChildContextExample result (1000 child contexts): Output[result=999000, executionTimeMs=2455, replayTimeMs=5]
ManyAsyncChildContextExample result (1000 child contexts): Output[result=999000, executionTimeMs=2115, replayTimeMs=9]
ManyAsyncStepsExample result (100 steps): Output[result=9900, executionTimeMs=858, replayTimeMs=13]
ManyAsyncStepsExample result (100 steps): Output[result=9900, executionTimeMs=425, replayTimeMs=2]
ManyAsyncStepsExample result (100 steps): Output[result=9900, executionTimeMs=235, replayTimeMs=1]
ManyAsyncStepsExample result (500 steps): Output[result=249500, executionTimeMs=756, replayTimeMs=4]
ManyAsyncStepsExample result (500 steps): Output[result=249500, executionTimeMs=607, replayTimeMs=19]
ManyAsyncStepsExample result (500 steps): Output[result=249500, executionTimeMs=806, replayTimeMs=2]
ManyAsyncStepsExample result (1000 steps): Output[result=999000, executionTimeMs=1129, replayTimeMs=5]
ManyAsyncStepsExample result (1000 steps): Output[result=999000, executionTimeMs=953, replayTimeMs=13]
ManyAsyncStepsExample result (1000 steps): Output[result=999000, executionTimeMs=1061, replayTimeMs=5]
ManyAsyncStepsExample result (2000 steps): Output[result=3998000, executionTimeMs=2128, replayTimeMs=11]
ManyAsyncStepsExample result (2000 steps): Output[result=3998000, executionTimeMs=1667, replayTimeMs=22]
ManyAsyncStepsExample result (2000 steps): Output[result=3998000, executionTimeMs=1713, replayTimeMs=21]
```

### Demo/Screenshots

### Checklist

- [ ] I have filled out every section of the PR template
- [ ] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
