### PR TITLE
[refactor]: clean up null for subType

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableContext.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableContext.java
@@ -135,7 +135,7 @@ public class DurableContext extends BaseContext {
 
         // Create and start step operation with TypeToken
         var operation = new StepOperation<>(
-                new OperationIdentifier(operationId, name, OperationType.STEP, null), func, typeToken, config, this);
+                OperationIdentifier.of(operationId, name, OperationType.STEP), func, typeToken, config, this);
 
         operation.execute(); // Start the step (returns immediately)
 
@@ -205,7 +205,7 @@ public class DurableContext extends BaseContext {
 
         // Create and start wait operation
         var operation =
-                new WaitOperation(new OperationIdentifier(operationId, name, OperationType.WAIT, null), duration, this);
+                new WaitOperation(OperationIdentifier.of(operationId, name, OperationType.WAIT), duration, this);
 
         operation.execute(); // Checkpoint the wait
         return operation;
@@ -279,7 +279,7 @@ public class DurableContext extends BaseContext {
 
         // Create and start invoke operation
         var operation = new InvokeOperation<>(
-                new OperationIdentifier(operationId, name, OperationType.CHAINED_INVOKE, null),
+                OperationIdentifier.of(operationId, name, OperationType.CHAINED_INVOKE),
                 functionName,
                 payload,
                 typeToken,
@@ -313,7 +313,7 @@ public class DurableContext extends BaseContext {
         var operationId = nextOperationId();
 
         var operation = new CallbackOperation<>(
-                new OperationIdentifier(operationId, name, OperationType.CALLBACK, null), typeToken, config, this);
+                OperationIdentifier.of(operationId, name, OperationType.CALLBACK), typeToken, config, this);
         operation.execute();
 
         return operation;
@@ -346,7 +346,7 @@ public class DurableContext extends BaseContext {
         var operationId = nextOperationId();
 
         var operation = new ChildContextOperation<>(
-                new OperationIdentifier(operationId, name, OperationType.CONTEXT, subType),
+                OperationIdentifier.of(operationId, name, OperationType.CONTEXT, subType),
                 func,
                 typeToken,
                 getDurableConfig().getSerDes(),

--- a/sdk/src/main/java/software/amazon/lambda/durable/model/OperationIdentifier.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/model/OperationIdentifier.java
@@ -5,4 +5,13 @@ package software.amazon.lambda.durable.model;
 import software.amazon.awssdk.services.lambda.model.OperationType;
 
 public record OperationIdentifier(
-        String operationId, String name, OperationType operationType, OperationSubType subType) {}
+        String operationId, String name, OperationType operationType, OperationSubType subType) {
+    public static OperationIdentifier of(String operationId, String name, OperationType type) {
+        return new OperationIdentifier(operationId, name, type, null);
+    }
+
+    public static OperationIdentifier of(
+            String operationId, String name, OperationType type, OperationSubType subType) {
+        return new OperationIdentifier(operationId, name, type, subType);
+    }
+}

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/BaseDurableOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/BaseDurableOperationTest.java
@@ -47,7 +47,7 @@ class BaseDurableOperationTest {
     private static final Operation OPERATION = Operation.builder().build();
     private static final OperationType OPERATION_TYPE = OperationType.STEP;
     private static final OperationIdentifier OPERATION_IDENTIFIER =
-            new OperationIdentifier(OPERATION_ID, OPERATION_NAME, OPERATION_TYPE, null);
+            OperationIdentifier.of(OPERATION_ID, OPERATION_NAME, OPERATION_TYPE);
     private static final TypeToken<String> RESULT_TYPE = TypeToken.get(String.class);
     private static final SerDes SER_DES = new JacksonSerDes();
     private static final String RESULT = "name";

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/CallbackOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/CallbackOperationTest.java
@@ -34,7 +34,7 @@ class CallbackOperationTest {
     private static final String OPERATION_ID = "1";
     private static final String OPERATION_NAME = "approval";
     private static final OperationIdentifier OPERATION_IDENTIFIER =
-            new OperationIdentifier(OPERATION_ID, OPERATION_NAME, OperationType.CALLBACK, null);
+            OperationIdentifier.of(OPERATION_ID, OPERATION_NAME, OperationType.CALLBACK);
 
     private DurableContext durableContext;
 

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/ChildContextOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/ChildContextOperationTest.java
@@ -52,7 +52,7 @@ class ChildContextOperationTest {
     }
 
     private static final OperationIdentifier OPERATION_IDENTIFIER =
-            new OperationIdentifier("1", "test-context", OperationType.CONTEXT, OperationSubType.RUN_IN_CHILD_CONTEXT);
+            OperationIdentifier.of("1", "test-context", OperationType.CONTEXT, OperationSubType.RUN_IN_CHILD_CONTEXT);
 
     private ChildContextOperation<String> createOperation(Function<DurableContext, String> func) {
         return new ChildContextOperation<>(

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/InvokeOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/InvokeOperationTest.java
@@ -31,7 +31,7 @@ class InvokeOperationTest {
     private static final String OPERATION_ID = "2";
     private static final String OPERATION_NAME = "test-invoke";
     private static final OperationIdentifier OPERATION_IDENTIFIER =
-            new OperationIdentifier(OPERATION_ID, OPERATION_NAME, OperationType.CHAINED_INVOKE, null);
+            OperationIdentifier.of(OPERATION_ID, OPERATION_NAME, OperationType.CHAINED_INVOKE);
 
     private ExecutionManager executionManager;
     private DurableContext durableContext;

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/StepOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/StepOperationTest.java
@@ -32,7 +32,7 @@ class StepOperationTest {
     private static final String OPERATION_NAME = "test-step";
     private static final String RESULT = "result";
     private static final OperationIdentifier OPERATION_IDENTIFIER =
-            new OperationIdentifier(OPERATION_ID, OPERATION_NAME, OperationType.STEP, null);
+            OperationIdentifier.of(OPERATION_ID, OPERATION_NAME, OperationType.STEP);
     private ExecutionManager executionManager;
     private DurableContext durableContext;
 

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/WaitOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/WaitOperationTest.java
@@ -25,7 +25,7 @@ class WaitOperationTest {
     private static final String CONTEXT_ID = "handler";
     private static final String OPERATION_NAME = "test-wait";
     private static final OperationIdentifier OPERATION_IDENTIFIER =
-            new OperationIdentifier(OPERATION_ID, OPERATION_NAME, OperationType.WAIT, null);
+            OperationIdentifier.of(OPERATION_ID, OPERATION_NAME, OperationType.WAIT);
     private ExecutionManager executionManager;
     private DurableContext durableContext;
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

remove usage of `null` when creating `OperationIdentifier` by having a factory method `of`

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
