### PR TITLE
feat(map): Implement Map Operation

### DIFF
--- a/examples/src/main/java/software/amazon/lambda/durable/examples/SimpleMapExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/SimpleMapExample.java
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples;
+
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/**
+ * Example demonstrating the map operation with the Durable Execution SDK.
+ *
+ * <p>This handler processes a list of names concurrently using {@code map()}, where each item runs in its own child
+ * context with full checkpoint-and-replay support.
+ *
+ * <ol>
+ *   <li>Create a list of names from the input
+ *   <li>Map over each name concurrently, applying a greeting transformation via a durable step
+ *   <li>Collect and join the results
+ * </ol>
+ */
+public class SimpleMapExample extends DurableHandler<GreetingRequest, String> {
+
+    @Override
+    public String handleRequest(GreetingRequest input, DurableContext context) {
+        var name = input.getName();
+        context.getLogger().info("Starting map example for {}", name);
+
+        var names = List.of(name, name.toUpperCase(), name.toLowerCase());
+
+        // Map over each name concurrently — each iteration runs in its own child context
+        var result = context.map("greet-all", names, String.class, (ctx, item, index) -> {
+            return ctx.step("greet-" + index, String.class, stepCtx -> "Hello, " + item + "!");
+        });
+
+        context.getLogger().info("Map completed: allSucceeded={}, size={}", result.allSucceeded(), result.size());
+
+        return String.join(" | ", result.results());
+    }
+}

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/CloudBasedIntegrationTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/CloudBasedIntegrationTest.java
@@ -539,4 +539,13 @@ class CloudBasedIntegrationTest {
         assertTrue(minimalReplayTimeMs < maxReplayTime);
         assertTrue(minimalExecutionTimeMs < maxExecutionTime);
     }
+
+    @Test
+    void testSimpleMapExample() {
+        var runner = CloudDurableTestRunner.create(arn("simple-map-example"), GreetingRequest.class, String.class);
+        var result = runner.run(new GreetingRequest("Alice"));
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("Hello, Alice! | Hello, ALICE! | Hello, alice!", result.getResult(String.class));
+    }
 }

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/SimpleMapExampleTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/SimpleMapExampleTest.java
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
+
+class SimpleMapExampleTest {
+
+    @Test
+    void testSimpleMapExample() {
+        var handler = new SimpleMapExample();
+        var runner = LocalDurableTestRunner.create(GreetingRequest.class, handler);
+
+        var result = runner.runUntilComplete(new GreetingRequest("Alice"));
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("Hello, Alice! | Hello, ALICE! | Hello, alice!", result.getResult(String.class));
+    }
+
+    @Test
+    void testWithDefaultName() {
+        var handler = new SimpleMapExample();
+        var runner = LocalDurableTestRunner.create(GreetingRequest.class, handler);
+
+        var result = runner.runUntilComplete(new GreetingRequest());
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("Hello, World! | Hello, WORLD! | Hello, world!", result.getResult(String.class));
+    }
+
+    @Test
+    void testReplay() {
+        var handler = new SimpleMapExample();
+        var runner = LocalDurableTestRunner.create(GreetingRequest.class, handler);
+
+        var input = new GreetingRequest("Bob");
+        var result1 = runner.runUntilComplete(input);
+        assertEquals("Hello, Bob! | Hello, BOB! | Hello, bob!", result1.getResult(String.class));
+
+        // Replay — should use cached results
+        var result2 = runner.runUntilComplete(input);
+        assertEquals(result1.getResult(String.class), result2.getResult(String.class));
+    }
+}

--- a/examples/template.yaml
+++ b/examples/template.yaml
@@ -468,6 +468,31 @@ Resources:
       DockerContext: ../
       DockerTag: durable-examples
 
+  SimpleMapExampleFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      FunctionName: !Join
+        - ''
+        - - 'simple-map-example'
+          - !Ref FunctionNameSuffix
+      ImageConfig:
+        Command: ["software.amazon.lambda.durable.examples.SimpleMapExample::handleRequest"]
+      DurableConfig:
+        ExecutionTimeout: 300
+        RetentionPeriodInDays: 7
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - lambda:CheckpointDurableExecutions
+                - lambda:GetDurableExecutionState
+              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:simple-map-example${FunctionNameSuffix}"
+    Metadata:
+      Dockerfile: !Ref DockerFile
+      DockerContext: ../
+      DockerTag: durable-examples
+
 Outputs:
   NoopExampleFunction:
     Description: Noop Example Function ARN
@@ -612,4 +637,12 @@ Outputs:
   ManyAsyncChildContextExampleFunctionName:
     Description: Many Async Child Context Example Function Name
     Value: !Ref ManyAsyncChildContextExampleFunction
+
+  SimpleMapExampleFunction:
+    Description: Simple Map Example Function ARN
+    Value: !GetAtt SimpleMapExampleFunction.Arn
+
+  SimpleMapExampleFunctionName:
+    Description: Simple Map Example Function Name
+    Value: !Ref SimpleMapExampleFunction
 

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
+
+class MapIntegrationTest {
+
+    @Test
+    void testSimpleMap() {
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var items = List.of("a", "b", "c");
+            var result = context.map("process-items", items, String.class, (ctx, item, index) -> {
+                return item.toUpperCase();
+            });
+
+            assertTrue(result.allSucceeded());
+            assertEquals(3, result.size());
+            assertEquals("A", result.getResult(0));
+            assertEquals("B", result.getResult(1));
+            assertEquals("C", result.getResult(2));
+
+            return String.join(",", result.results());
+        });
+
+        var result = runner.runUntilComplete("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("A,B,C", result.getResult(String.class));
+    }
+
+    @Test
+    void testMapWithStepsInsideBranches() {
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var items = List.of("hello", "world");
+            var result = context.map("map-with-steps", items, String.class, (ctx, item, index) -> {
+                return ctx.step("process-" + index, String.class, stepCtx -> item.toUpperCase());
+            });
+
+            assertTrue(result.allSucceeded());
+            return String.join(" ", result.results());
+        });
+
+        var result = runner.runUntilComplete("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("HELLO WORLD", result.getResult(String.class));
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/CompletedDurableFuture.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/CompletedDurableFuture.java
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable;
+
+/**
+ * A {@link DurableFuture} that is already completed with a value.
+ *
+ * <p>Used for short-circuit cases (e.g., empty collection in map) where no checkpoint or async execution is needed.
+ *
+ * @param <T> the result type
+ */
+class CompletedDurableFuture<T> implements DurableFuture<T> {
+    private final T value;
+
+    CompletedDurableFuture(T value) {
+        this.value = value;
+    }
+
+    @Override
+    public T get() {
+        return value;
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/CompletionConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/CompletionConfig.java
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable;
+
+/**
+ * Controls when a concurrent operation (map or parallel) completes.
+ *
+ * <p>Provides factory methods for common completion strategies and fine-grained control via {@code minSuccessful},
+ * {@code toleratedFailureCount}, and {@code toleratedFailurePercentage}.
+ */
+public class CompletionConfig {
+    private final Integer minSuccessful;
+    private final Integer toleratedFailureCount;
+    private final Double toleratedFailurePercentage;
+
+    private CompletionConfig(Integer minSuccessful, Integer toleratedFailureCount, Double toleratedFailurePercentage) {
+        this.minSuccessful = minSuccessful;
+        this.toleratedFailureCount = toleratedFailureCount;
+        this.toleratedFailurePercentage = toleratedFailurePercentage;
+    }
+
+    /** All items must succeed. Zero failures tolerated. */
+    public static CompletionConfig allSuccessful() {
+        return new CompletionConfig(null, 0, null);
+    }
+
+    /** All items run regardless of failures. Failures captured per-item. */
+    public static CompletionConfig allCompleted() {
+        return new CompletionConfig(null, null, null);
+    }
+
+    /** Complete as soon as the first item succeeds. */
+    public static CompletionConfig firstSuccessful() {
+        return new CompletionConfig(1, null, null);
+    }
+
+    /** @return minimum number of successful items required, or null if not set */
+    public Integer minSuccessful() {
+        return minSuccessful;
+    }
+
+    /** @return maximum number of failures tolerated, or null if unlimited */
+    public Integer toleratedFailureCount() {
+        return toleratedFailureCount;
+    }
+
+    /** @return maximum percentage of failures tolerated (0.0 to 1.0), or null if not set */
+    public Double toleratedFailurePercentage() {
+        return toleratedFailurePercentage;
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableContext.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableContext.java
@@ -4,6 +4,8 @@ package software.amazon.lambda.durable;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -14,11 +16,13 @@ import software.amazon.lambda.durable.execution.ExecutionManager;
 import software.amazon.lambda.durable.execution.OperationIdGenerator;
 import software.amazon.lambda.durable.execution.ThreadType;
 import software.amazon.lambda.durable.logging.DurableLogger;
+import software.amazon.lambda.durable.model.BatchResult;
 import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
 import software.amazon.lambda.durable.operation.CallbackOperation;
 import software.amazon.lambda.durable.operation.ChildContextOperation;
 import software.amazon.lambda.durable.operation.InvokeOperation;
+import software.amazon.lambda.durable.operation.MapOperation;
 import software.amazon.lambda.durable.operation.StepOperation;
 import software.amazon.lambda.durable.operation.WaitOperation;
 import software.amazon.lambda.durable.validation.ParameterValidator;
@@ -357,6 +361,83 @@ public class DurableContext extends BaseContext {
                 getDurableConfig().getSerDes(),
                 this);
 
+        operation.execute();
+        return operation;
+    }
+
+    // ========== map methods ==========
+
+    public <I, O> BatchResult<O> map(
+            String name, Collection<I> items, Class<O> resultType, MapFunction<I, O> function) {
+        return mapAsync(
+                        name,
+                        items,
+                        TypeToken.get(resultType),
+                        function,
+                        MapConfig.builder().build())
+                .get();
+    }
+
+    public <I, O> BatchResult<O> map(
+            String name, Collection<I> items, Class<O> resultType, MapFunction<I, O> function, MapConfig config) {
+        return mapAsync(name, items, TypeToken.get(resultType), function, config)
+                .get();
+    }
+
+    public <I, O> BatchResult<O> map(
+            String name, Collection<I> items, TypeToken<O> resultType, MapFunction<I, O> function) {
+        return mapAsync(name, items, resultType, function, MapConfig.builder().build())
+                .get();
+    }
+
+    public <I, O> BatchResult<O> map(
+            String name, Collection<I> items, TypeToken<O> resultType, MapFunction<I, O> function, MapConfig config) {
+        return mapAsync(name, items, resultType, function, config).get();
+    }
+
+    public <I, O> DurableFuture<BatchResult<O>> mapAsync(
+            String name, Collection<I> items, Class<O> resultType, MapFunction<I, O> function) {
+        return mapAsync(
+                name,
+                items,
+                TypeToken.get(resultType),
+                function,
+                MapConfig.builder().build());
+    }
+
+    public <I, O> DurableFuture<BatchResult<O>> mapAsync(
+            String name, Collection<I> items, Class<O> resultType, MapFunction<I, O> function, MapConfig config) {
+        return mapAsync(name, items, TypeToken.get(resultType), function, config);
+    }
+
+    public <I, O> DurableFuture<BatchResult<O>> mapAsync(
+            String name, Collection<I> items, TypeToken<O> resultType, MapFunction<I, O> function) {
+        return mapAsync(name, items, resultType, function, MapConfig.builder().build());
+    }
+
+    public <I, O> DurableFuture<BatchResult<O>> mapAsync(
+            String name, Collection<I> items, TypeToken<O> resultType, MapFunction<I, O> function, MapConfig config) {
+        Objects.requireNonNull(items, "items cannot be null");
+        Objects.requireNonNull(function, "function cannot be null");
+        Objects.requireNonNull(resultType, "resultType cannot be null");
+        Objects.requireNonNull(config, "config cannot be null");
+        ParameterValidator.validateOperationName(name);
+        ParameterValidator.validateOrderedCollection(items);
+
+        if (config.serDes() == null) {
+            config = config.toBuilder().serDes(getDurableConfig().getSerDes()).build();
+        }
+
+        // Short-circuit for empty collections — no checkpoint overhead
+        if (items.isEmpty()) {
+            return new CompletedDurableFuture<>(BatchResult.empty());
+        }
+
+        // Convert to List for deterministic index-based access
+        var itemList = List.copyOf(items);
+        var operationId = nextOperationId();
+
+        var operation = new MapOperation<>(operationId, name, itemList, function, resultType, config, this);
         operation.execute();
         return operation;
     }

--- a/sdk/src/main/java/software/amazon/lambda/durable/MapConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/MapConfig.java
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable;
+
+import software.amazon.lambda.durable.serde.SerDes;
+
+/**
+ * Configuration for map operations.
+ *
+ * <p>Defaults to lenient completion (all items run regardless of failures) and unlimited concurrency.
+ */
+public class MapConfig {
+    private final Integer maxConcurrency;
+    private final CompletionConfig completionConfig;
+    private final SerDes serDes;
+
+    private MapConfig(Builder builder) {
+        this.maxConcurrency = builder.maxConcurrency;
+        this.completionConfig = builder.completionConfig;
+        this.serDes = builder.serDes;
+    }
+
+    /** @return max concurrent items, or null for unlimited */
+    public Integer maxConcurrency() {
+        return maxConcurrency;
+    }
+
+    /** @return completion criteria, defaults to {@link CompletionConfig#allCompleted()} */
+    public CompletionConfig completionConfig() {
+        return completionConfig != null ? completionConfig : CompletionConfig.allCompleted();
+    }
+
+    /** @return the custom serializer, or null to use the default */
+    public SerDes serDes() {
+        return serDes;
+    }
+
+    public static Builder builder() {
+        return new Builder(null, null, null);
+    }
+
+    public Builder toBuilder() {
+        return new Builder(maxConcurrency, completionConfig, serDes);
+    }
+
+    /** Builder for creating MapConfig instances. */
+    public static class Builder {
+        private Integer maxConcurrency;
+        private CompletionConfig completionConfig;
+        private SerDes serDes;
+
+        private Builder(Integer maxConcurrency, CompletionConfig completionConfig, SerDes serDes) {
+            this.maxConcurrency = maxConcurrency;
+            this.completionConfig = completionConfig;
+            this.serDes = serDes;
+        }
+
+        public Builder maxConcurrency(Integer maxConcurrency) {
+            this.maxConcurrency = maxConcurrency;
+            return this;
+        }
+
+        public Builder completionConfig(CompletionConfig completionConfig) {
+            this.completionConfig = completionConfig;
+            return this;
+        }
+
+        public Builder serDes(SerDes serDes) {
+            this.serDes = serDes;
+            return this;
+        }
+
+        public MapConfig build() {
+            return new MapConfig(this);
+        }
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/MapFunction.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/MapFunction.java
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable;
+
+/**
+ * Function applied to each item in a map operation.
+ *
+ * <p>Each invocation receives its own {@link DurableContext}, allowing the use of durable operations like
+ * {@code step()} and {@code wait()} within the function body. The index parameter indicates the item's position in the
+ * input collection.
+ *
+ * @param <I> the input item type
+ * @param <O> the output result type
+ */
+@FunctionalInterface
+public interface MapFunction<I, O> {
+
+    /**
+     * Applies this function to the given item.
+     *
+     * @param context the durable context for this item's execution
+     * @param item the input item to process
+     * @param index the zero-based index of the item in the input collection
+     * @return the result of processing the item
+     * @throws Exception if the function fails
+     */
+    O apply(DurableContext context, I item, int index) throws Exception;
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/model/BatchResult.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/model/BatchResult.java
@@ -1,0 +1,76 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Result container for batch concurrent operations (map, parallel).
+ *
+ * <p>Holds ordered results and errors from a batch of concurrent operations. Each index corresponds to the input item
+ * at the same position. Includes the {@link CompletionReason} indicating why the operation completed.
+ *
+ * @param <T> the result type of each item
+ */
+public class BatchResult<T> {
+    private final List<T> results;
+    private final List<Throwable> errors;
+    private final CompletionReason completionReason;
+
+    public BatchResult(List<T> results, List<Throwable> errors, CompletionReason completionReason) {
+        this.results = results;
+        this.errors = errors;
+        this.completionReason = completionReason;
+    }
+
+    /** Returns an empty BatchResult with no results and no errors. */
+    public static <T> BatchResult<T> empty() {
+        return new BatchResult<>(Collections.emptyList(), Collections.emptyList(), CompletionReason.ALL_COMPLETED);
+    }
+
+    /** Returns the result at the given index, or null if that item failed. */
+    public T getResult(int index) {
+        return results.get(index);
+    }
+
+    /** Returns the error at the given index, or null if that item succeeded. */
+    public Throwable getError(int index) {
+        return errors.get(index);
+    }
+
+    /** Returns true if all items succeeded (no errors). */
+    public boolean allSucceeded() {
+        return errors.stream().noneMatch(e -> e != null);
+    }
+
+    /** Returns the reason the operation completed. */
+    public CompletionReason completionReason() {
+        return completionReason;
+    }
+
+    /** Returns all results as an unmodifiable list. */
+    public List<T> results() {
+        return Collections.unmodifiableList(results);
+    }
+
+    /** Returns all errors as an unmodifiable list. */
+    public List<Throwable> errors() {
+        return Collections.unmodifiableList(errors);
+    }
+
+    /** Returns the number of items in this batch. */
+    public int size() {
+        return results.size();
+    }
+
+    /** Returns results that succeeded (non-null results). */
+    public List<T> succeeded() {
+        return results.stream().filter(r -> r != null).toList();
+    }
+
+    /** Returns errors that occurred (non-null errors). */
+    public List<Throwable> failed() {
+        return errors.stream().filter(e -> e != null).toList();
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/model/CompletionReason.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/model/CompletionReason.java
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.model;
+
+/** Indicates why a concurrent operation (map or parallel) completed. */
+public enum CompletionReason {
+    ALL_COMPLETED,
+    MIN_SUCCESSFUL_REACHED,
+    FAILURE_TOLERANCE_EXCEEDED
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/model/OperationSubType.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/model/OperationSubType.java
@@ -11,6 +11,7 @@ package software.amazon.lambda.durable.model;
 public enum OperationSubType {
     RUN_IN_CHILD_CONTEXT("RunInChildContext"),
     MAP("Map"),
+    MAP_ITERATION("MapIteration"),
     PARALLEL("Parallel"),
     WAIT_FOR_CALLBACK("WaitForCallback");
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseConcurrentOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseConcurrentOperation.java
@@ -1,0 +1,299 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.operation;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.lambda.model.ContextOptions;
+import software.amazon.awssdk.services.lambda.model.Operation;
+import software.amazon.awssdk.services.lambda.model.OperationAction;
+import software.amazon.awssdk.services.lambda.model.OperationStatus;
+import software.amazon.awssdk.services.lambda.model.OperationType;
+import software.amazon.awssdk.services.lambda.model.OperationUpdate;
+import software.amazon.lambda.durable.CompletionConfig;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.execution.OperationIdGenerator;
+import software.amazon.lambda.durable.model.CompletionReason;
+import software.amazon.lambda.durable.model.OperationIdentifier;
+import software.amazon.lambda.durable.model.OperationSubType;
+import software.amazon.lambda.durable.serde.SerDes;
+
+/**
+ * Abstract base class for concurrent operations (map, parallel).
+ *
+ * <p>Provides the shared concurrent execution framework: root child context creation, queue-based concurrency limiting,
+ * success/failure tracking, completion criteria evaluation, and thread registration ordering.
+ *
+ * <p>Subclasses implement {@link #startBranches()} to create branches via {@link #branchInternal} and
+ * {@link #aggregateResults()} to collect branch results into the final result type.
+ *
+ * @param <R> the aggregate result type (e.g., {@code BatchResult<O>})
+ */
+public abstract class BaseConcurrentOperation<R> extends BaseDurableOperation<R> {
+
+    private static final Logger logger = LoggerFactory.getLogger(BaseConcurrentOperation.class);
+    private static final int LARGE_RESULT_THRESHOLD = 256 * 1024;
+
+    private final List<ChildContextOperation<?>> branches = new ArrayList<>();
+    private final Queue<ChildContextOperation<?>> pendingQueue = new ConcurrentLinkedQueue<>();
+    private final AtomicInteger activeBranches = new AtomicInteger(0);
+    private final AtomicInteger succeeded = new AtomicInteger(0);
+    private final AtomicInteger failed = new AtomicInteger(0);
+    private final Integer maxConcurrency;
+    private final CompletionConfig completionConfig;
+    private final OperationSubType subType;
+    private volatile CompletionReason completionReason;
+    private volatile boolean earlyTermination = false;
+    private DurableContext rootContext;
+    private OperationIdGenerator operationIdGenerator;
+
+    protected BaseConcurrentOperation(
+            String operationId,
+            String name,
+            OperationSubType subType,
+            Integer maxConcurrency,
+            CompletionConfig completionConfig,
+            TypeToken<R> resultTypeToken,
+            SerDes resultSerDes,
+            DurableContext durableContext) {
+        super(
+                OperationIdentifier.of(operationId, name, OperationType.CONTEXT, subType),
+                resultTypeToken,
+                resultSerDes,
+                durableContext);
+        this.subType = subType;
+        this.maxConcurrency = maxConcurrency;
+        this.completionConfig = completionConfig;
+    }
+
+    // ========== lifecycle ==========
+
+    @Override
+    protected void start() {
+        sendOperationUpdateAsync(
+                OperationUpdate.builder().action(OperationAction.START).subType(subType.getValue()));
+        this.rootContext = getContext().createChildContext(getOperationId(), getName());
+        this.operationIdGenerator = new OperationIdGenerator(getOperationId());
+        startBranches();
+    }
+
+    @Override
+    protected void replay(Operation existing) {
+        switch (existing.status()) {
+            case SUCCEEDED -> {
+                if (existing.contextDetails() != null
+                        && Boolean.TRUE.equals(existing.contextDetails().replayChildren())) {
+                    // Large result: reconstruct by replaying child contexts
+                    this.rootContext = getContext().createChildContext(getOperationId(), getName());
+                    this.operationIdGenerator = new OperationIdGenerator(getOperationId());
+                    startBranches();
+                } else {
+                    markAlreadyCompleted();
+                }
+            }
+            case FAILED -> markAlreadyCompleted();
+            case STARTED -> {
+                // Interrupted mid-execution: resume from last checkpoint
+                this.rootContext = getContext().createChildContext(getOperationId(), getName());
+                this.operationIdGenerator = new OperationIdGenerator(getOperationId());
+                startBranches();
+            }
+            default ->
+                terminateExecutionWithIllegalDurableOperationException(
+                        "Unexpected concurrent operation status: " + existing.status());
+        }
+    }
+
+    // ========== abstract methods for subclasses ==========
+
+    protected abstract void startBranches();
+
+    protected abstract R aggregateResults();
+
+    // ========== branch creation ==========
+
+    protected <T> ChildContextOperation<T> branchInternal(
+            String branchName,
+            OperationSubType branchSubType,
+            TypeToken<T> typeToken,
+            SerDes serDes,
+            Function<DurableContext, T> function) {
+        var branchOpId = operationIdGenerator.nextOperationId();
+        var branch = new ChildContextOperation<>(
+                OperationIdentifier.of(branchOpId, branchName, OperationType.CONTEXT, branchSubType),
+                function,
+                typeToken,
+                serDes,
+                rootContext);
+        branches.add(branch);
+
+        if (!earlyTermination && (maxConcurrency == null || activeBranches.get() < maxConcurrency)) {
+            activeBranches.incrementAndGet();
+            branch.execute();
+        } else {
+            pendingQueue.add(branch);
+        }
+        return branch;
+    }
+
+    // ========== completion callback ==========
+
+    protected void onChildContextComplete(ChildContextOperation<?> branch, boolean success) {
+        if (success) {
+            succeeded.incrementAndGet();
+        } else {
+            failed.incrementAndGet();
+        }
+
+        // Evaluate completion criteria
+        if (!earlyTermination && shouldTerminateEarly()) {
+            earlyTermination = true;
+            completionReason = evaluateCompletionReason();
+            logger.trace("Early termination triggered for operation {}: reason={}", getOperationId(), completionReason);
+        }
+
+        // Start next queued branch with correct thread ordering:
+        // register new branch thread BEFORE deregistering completed branch thread
+        if (!earlyTermination) {
+            var next = pendingQueue.poll();
+            if (next != null) {
+                // activeBranches stays the same (one completing, one starting)
+                next.execute(); // registers new thread internally via ChildContextOperation.start()
+            } else {
+                activeBranches.decrementAndGet();
+            }
+        } else {
+            activeBranches.decrementAndGet();
+        }
+        // completed branch's thread is deregistered by ChildContextOperation's close() in BaseContext
+
+        if (activeBranches.get() == 0 && pendingQueue.isEmpty()) {
+            finalizeOperation();
+        }
+    }
+
+    // ========== completion evaluation ==========
+
+    private boolean shouldTerminateEarly() {
+        // Check minSuccessful
+        if (completionConfig.minSuccessful() != null && succeeded.get() >= completionConfig.minSuccessful()) {
+            return true;
+        }
+
+        // Check toleratedFailureCount
+        if (completionConfig.toleratedFailureCount() != null
+                && failed.get() > completionConfig.toleratedFailureCount()) {
+            return true;
+        }
+
+        // Check toleratedFailurePercentage
+        int totalCompleted = succeeded.get() + failed.get();
+        if (completionConfig.toleratedFailurePercentage() != null
+                && totalCompleted > 0
+                && ((double) failed.get() / totalCompleted) > completionConfig.toleratedFailurePercentage()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private CompletionReason evaluateCompletionReason() {
+        if (completionConfig.minSuccessful() != null && succeeded.get() >= completionConfig.minSuccessful()) {
+            return CompletionReason.MIN_SUCCESSFUL_REACHED;
+        }
+        return CompletionReason.FAILURE_TOLERANCE_EXCEEDED;
+    }
+
+    private void finalizeOperation() {
+        if (completionReason == null) {
+            completionReason = CompletionReason.ALL_COMPLETED;
+        }
+
+        R result = aggregateResults();
+        checkpointResult(result);
+    }
+
+    private void checkpointResult(R result) {
+        var serialized = serializeResult(result);
+        var serializedBytes = serialized.getBytes(StandardCharsets.UTF_8);
+
+        if (serializedBytes.length < LARGE_RESULT_THRESHOLD) {
+            sendOperationUpdateAsync(OperationUpdate.builder()
+                    .action(OperationAction.SUCCEED)
+                    .subType(subType.getValue())
+                    .payload(serialized));
+        } else {
+            // Large result: checkpoint with empty payload + replayChildren flag
+            sendOperationUpdateAsync(OperationUpdate.builder()
+                    .action(OperationAction.SUCCEED)
+                    .subType(subType.getValue())
+                    .payload("")
+                    .contextOptions(
+                            ContextOptions.builder().replayChildren(true).build()));
+        }
+    }
+
+    // ========== get ==========
+
+    @Override
+    public R get() {
+        var op = waitForOperationCompletion();
+
+        if (op.status() == OperationStatus.SUCCEEDED) {
+            if (op.contextDetails() != null
+                    && Boolean.TRUE.equals(op.contextDetails().replayChildren())) {
+                // Large result was reconstructed via replay — aggregate from branches
+                return aggregateResults();
+            }
+            var contextDetails = op.contextDetails();
+            var result = (contextDetails != null) ? contextDetails.result() : null;
+            return deserializeResult(result);
+        } else if (op.status() == OperationStatus.FAILED) {
+            var contextDetails = op.contextDetails();
+            var errorObject = (contextDetails != null) ? contextDetails.error() : null;
+            var original = deserializeException(errorObject);
+            if (original != null) {
+                throw new RuntimeException(original);
+            }
+            throw new RuntimeException("Concurrent operation failed: " + getOperationId());
+        } else {
+            return terminateExecutionWithIllegalDurableOperationException(
+                    "Unexpected operation status after completion: " + op.status());
+        }
+    }
+
+    // ========== protected accessors for subclasses ==========
+
+    protected List<ChildContextOperation<?>> getBranches() {
+        return Collections.unmodifiableList(branches);
+    }
+
+    protected CompletionReason getCompletionReason() {
+        return completionReason;
+    }
+
+    protected AtomicInteger getSucceeded() {
+        return succeeded;
+    }
+
+    protected AtomicInteger getFailed() {
+        return failed;
+    }
+
+    protected boolean isEarlyTermination() {
+        return earlyTermination;
+    }
+
+    protected DurableContext getRootContext() {
+        return rootContext;
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
@@ -203,8 +203,8 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
             // throw a general failed exception if a user exception is not reconstructed
             return switch (getSubType()) {
                 case WAIT_FOR_CALLBACK -> handleWaitForCallbackFailure(op);
-                // todo: handle MAP/PARALLEL
                 case MAP -> throw new ChildContextFailedException(op);
+                case MAP_ITERATION -> throw new ChildContextFailedException(op);
                 case PARALLEL -> throw new ChildContextFailedException(op);
                 case RUN_IN_CHILD_CONTEXT -> throw new ChildContextFailedException(op);
             };

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
@@ -1,0 +1,101 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.operation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.MapConfig;
+import software.amazon.lambda.durable.MapFunction;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.model.BatchResult;
+import software.amazon.lambda.durable.model.CompletionReason;
+import software.amazon.lambda.durable.model.OperationSubType;
+import software.amazon.lambda.durable.serde.SerDes;
+
+/**
+ * Executes a map operation: applies a function to each item in a collection concurrently, with each item running in its
+ * own child context.
+ *
+ * @param <I> the input item type
+ * @param <O> the output result type per item
+ */
+public class MapOperation<I, O> extends BaseConcurrentOperation<BatchResult<O>> {
+
+    private final List<I> items;
+    private final MapFunction<I, O> function;
+    private final TypeToken<O> itemResultType;
+    private final SerDes serDes;
+
+    public MapOperation(
+            String operationId,
+            String name,
+            List<I> items,
+            MapFunction<I, O> function,
+            TypeToken<O> itemResultType,
+            MapConfig config,
+            DurableContext durableContext) {
+        super(
+                operationId,
+                name,
+                OperationSubType.MAP,
+                config.maxConcurrency(),
+                config.completionConfig(),
+                new TypeToken<>() {},
+                config.serDes(),
+                durableContext);
+        this.items = List.copyOf(items);
+        this.function = function;
+        this.itemResultType = itemResultType;
+        this.serDes = config.serDes();
+    }
+
+    @Override
+    protected void startBranches() {
+        for (int i = 0; i < items.size(); i++) {
+            var index = i;
+            var item = items.get(i);
+            branchInternal("map-iteration-" + i, OperationSubType.MAP_ITERATION, itemResultType, serDes, childCtx -> {
+                try {
+                    return function.apply(childCtx, item, index);
+                } catch (RuntimeException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+    }
+
+    /**
+     * Waits for all branches to complete and aggregates results. Overrides the base class get() to directly wait on
+     * each branch rather than relying on the parent operation's completion future, which avoids thread coordination
+     * issues between the checkpoint processing thread and the context thread.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public BatchResult<O> get() {
+        var branches = getBranches();
+        var results = new ArrayList<O>(Collections.nCopies(items.size(), null));
+        var errors = new ArrayList<Throwable>(Collections.nCopies(items.size(), null));
+
+        for (int i = 0; i < branches.size(); i++) {
+            var branch = (ChildContextOperation<O>) branches.get(i);
+            try {
+                results.set(i, branch.get());
+            } catch (Exception e) {
+                errors.set(i, e);
+            }
+        }
+
+        var reason = getCompletionReason() != null ? getCompletionReason() : CompletionReason.ALL_COMPLETED;
+        return new BatchResult<>(results, errors, reason);
+    }
+
+    @Override
+    protected BatchResult<O> aggregateResults() {
+        // Not used — get() handles aggregation directly
+        throw new UnsupportedOperationException("aggregateResults should not be called directly");
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/validation/ParameterValidator.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/validation/ParameterValidator.java
@@ -3,6 +3,13 @@
 package software.amazon.lambda.durable.validation;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Utility class for validating input parameters in the Durable Execution SDK.
@@ -102,5 +109,32 @@ public final class ParameterValidator {
                         "Operation name must contain only printable ASCII characters, got: " + name);
             }
         }
+    }
+
+    /** Known unordered map types whose views (keySet, values, entrySet) do not guarantee iteration order. */
+    private static final Set<Class<?>> UNORDERED_MAP_TYPES =
+            Set.of(HashMap.class, IdentityHashMap.class, WeakHashMap.class, ConcurrentHashMap.class);
+
+    /**
+     * Validates that a collection has deterministic iteration order.
+     *
+     * <p>Rejects known unordered collection types: {@link HashSet} (and subclasses), and views returned by
+     * {@link HashMap}, {@link IdentityHashMap}, {@link WeakHashMap}, and {@link ConcurrentHashMap}.
+     *
+     * @param items the collection to validate
+     * @throws IllegalArgumentException if items is null or has non-deterministic iteration order
+     */
+    public static void validateOrderedCollection(Collection<?> items) {
+        if (items == null) {
+            throw new IllegalArgumentException("items cannot be null");
+        }
+        if (items instanceof HashSet || isUnorderedMapView(items)) {
+            throw new IllegalArgumentException("items must have deterministic iteration order");
+        }
+    }
+
+    private static boolean isUnorderedMapView(Collection<?> collection) {
+        var enclosing = collection.getClass().getEnclosingClass();
+        return enclosing != null && UNORDERED_MAP_TYPES.contains(enclosing);
     }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
https://github.com/aws/aws-durable-execution-sdk-java/issues/39

Wire up the map() / mapAsync() API in DurableContext to a working MapOperation that executes user functions concurrently across collection items using child contexts.

### Description
- MapOperation: new class extending BaseConcurrentOperation that creates a ChildContextOperation branch per item via branchInternal(), with get() directly waiting on each branch and aggregating into BatchResult
- MapConfig: add optional serDes field with fallback to handler default in DurableContext.mapAsync()
- DurableContext: replace mapAsync() TODO stub with MapOperation wiring
- OperationSubType: add MAP_ITERATION enum value for branch subtype
- ChildContextOperation: consolidate MAP/MAP_ITERATION/PARALLEL/RUN_IN_CHILD_CONTEXT failure cases in get() switch
- BaseConcurrentOperation: use sendOperationUpdateAsync in checkpointResult 
- MapIntegrationTest: two integration tests using LocalDurableTestRunner verifying simple map and map with durable steps inside branches

Next changes, 
- Parent checkpointing
- maxConcurrency
- CompletionConfig

### Demo/Screenshots
<img width="1665" height="808" alt="Screenshot 2026-03-13 at 4 29 11 PM" src="https://github.com/user-attachments/assets/e7d94691-9d79-451c-a99a-a8561b93a579" />


### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? 
Added a basic test.

#### Examples

Has a new example been added for the change? (if applicable) N/A
