### PR TITLE
[feature]: add BaseConcurrentOperation

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableContext.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableContext.java
@@ -3,19 +3,15 @@
 package software.amazon.lambda.durable;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
-import java.util.HexFormat;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.lambda.model.OperationType;
 import software.amazon.lambda.durable.execution.ExecutionManager;
+import software.amazon.lambda.durable.execution.OperationIdGenerator;
 import software.amazon.lambda.durable.execution.ThreadType;
 import software.amazon.lambda.durable.logging.DurableLogger;
 import software.amazon.lambda.durable.model.OperationIdentifier;
@@ -32,7 +28,7 @@ public class DurableContext extends BaseContext {
     private static final String WAIT_FOR_CALLBACK_SUBMITTER_SUFFIX = "-submitter";
     private static final int MAX_WAIT_FOR_CALLBACK_NAME_LENGTH = ParameterValidator.MAX_OPERATION_NAME_LENGTH
             - Math.max(WAIT_FOR_CALLBACK_CALLBACK_SUFFIX.length(), WAIT_FOR_CALLBACK_SUBMITTER_SUFFIX.length());
-    private final AtomicInteger operationCounter;
+    private final OperationIdGenerator operationIdGenerator;
     private volatile DurableLogger logger;
 
     /** Shared initialization — sets all fields. */
@@ -43,7 +39,7 @@ public class DurableContext extends BaseContext {
             String contextId,
             String contextName) {
         super(executionManager, durableConfig, lambdaContext, contextId, contextName, ThreadType.CONTEXT);
-        this.operationCounter = new AtomicInteger(0);
+        operationIdGenerator = new OperationIdGenerator(contextId);
     }
 
     /**
@@ -350,7 +346,8 @@ public class DurableContext extends BaseContext {
                 func,
                 typeToken,
                 getDurableConfig().getSerDes(),
-                this);
+                this,
+                null);
 
         operation.execute();
         return operation;
@@ -490,14 +487,6 @@ public class DurableContext extends BaseContext {
      * matches the Python SDK's stepPrefix convention and prevents ID collisions in checkpoint batches.
      */
     private String nextOperationId() {
-        var counter = String.valueOf(operationCounter.incrementAndGet());
-        var rawId = getContextId() != null ? getContextId() + "-" + counter : counter;
-        try {
-            var messageDigest = MessageDigest.getInstance("SHA-256");
-            var hash = messageDigest.digest(rawId.getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("failed to get next operation id, SHA-256 not available", e);
-        }
+        return operationIdGenerator.nextOperationId();
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/OperationIdGenerator.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/OperationIdGenerator.java
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.execution;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Generates operation IDs for the durable operations. */
+public class OperationIdGenerator {
+    private final AtomicInteger operationCounter;
+    private final String contextId;
+
+    public OperationIdGenerator(String contextId) {
+        this.operationCounter = new AtomicInteger(0);
+        this.contextId = contextId;
+    }
+
+    /**
+     * Get the next operationId. Returns a globally unique operation ID by hashing a sequential operation counter. For
+     * root contexts, the counter value is hashed directly (e.g. "1", "2", "3"). For child contexts, the values are
+     * prefixed with the parent hashed contextId (e.g. "<hash>-1", "<hash>-2" inside parent context <hash>). This
+     * matches the Python SDK's stepPrefix convention and prevents ID collisions in checkpoint batches.
+     */
+    public String nextOperationId() {
+        var counter = String.valueOf(operationCounter.incrementAndGet());
+        var rawId = contextId != null ? contextId + "-" + counter : counter;
+        try {
+            var messageDigest = MessageDigest.getInstance("SHA-256");
+            var hash = messageDigest.digest(rawId.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("failed to get next operation id, SHA-256 not available", e);
+        }
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/model/OperationSubType.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/model/OperationSubType.java
@@ -11,7 +11,9 @@ package software.amazon.lambda.durable.model;
 public enum OperationSubType {
     RUN_IN_CHILD_CONTEXT("RunInChildContext"),
     MAP("Map"),
+    MAP_ITERATION("MapInteration"),
     PARALLEL("Parallel"),
+    PARALLEL_BRANCH("ParallelBranch"),
     WAIT_FOR_CALLBACK("WaitForCallback");
 
     private final String value;

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseConcurrentOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseConcurrentOperation.java
@@ -1,0 +1,174 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.operation;
+
+import java.util.ArrayList;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import software.amazon.awssdk.services.lambda.model.Operation;
+import software.amazon.awssdk.services.lambda.model.OperationAction;
+import software.amazon.awssdk.services.lambda.model.OperationType;
+import software.amazon.awssdk.services.lambda.model.OperationUpdate;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.execution.OperationIdGenerator;
+import software.amazon.lambda.durable.model.OperationIdentifier;
+import software.amazon.lambda.durable.model.OperationSubType;
+import software.amazon.lambda.durable.serde.SerDes;
+
+/**
+ * Base class for concurrent operations like {@link ParallelOperation} and {@link MapOperation}.
+ *
+ * @param <T> the type of the operation's result (BatchResult for MapOperation or ParallelResult for ParallelOperation)
+ */
+public abstract class BaseConcurrentOperation<T> extends BaseDurableOperation<T> {
+    private final int maxConcurrency;
+    private final ArrayList<ChildContextOperation<?>> branches;
+    private final Queue<ChildContextOperation<?>> pendingBranches;
+    private final DurableContext thisContext; // parent context of branches
+    private final AtomicInteger succeeded;
+    private final AtomicInteger failed;
+    private final AtomicInteger activeBranches;
+    private final AtomicBoolean shouldExecuteChildBranches;
+    private final OperationIdGenerator operationIdGenerator;
+
+    public BaseConcurrentOperation(
+            OperationIdentifier operationIdentifier,
+            TypeToken<T> resultTypeToken,
+            SerDes resultSerDes,
+            int maxConcurrency,
+            DurableContext durableContext) {
+        super(operationIdentifier, resultTypeToken, resultSerDes, durableContext);
+        this.maxConcurrency = maxConcurrency;
+        this.activeBranches = new AtomicInteger(0);
+        this.branches = new ArrayList<>();
+        this.pendingBranches = new ConcurrentLinkedQueue<>();
+        this.thisContext = durableContext.createChildContext(getOperationId(), getName());
+        this.succeeded = new AtomicInteger(0);
+        this.failed = new AtomicInteger(0);
+        this.shouldExecuteChildBranches = new AtomicBoolean(true);
+        this.operationIdGenerator = new OperationIdGenerator(operationIdentifier.operationId());
+    }
+
+    @Override
+    protected void start() {
+        // start the child context operation for Parallel/Map
+        sendOperationUpdateAsync(OperationUpdate.builder().action(OperationAction.START));
+    }
+
+    @Override
+    protected void replay(Operation existing) {
+        switch (existing.status()) {
+            case SUCCEEDED, FAILED -> {
+                if (existing.contextDetails() != null
+                        && Boolean.TRUE.equals(existing.contextDetails().replayChildren())) {
+                    // re-execute child branches to reconstruct result
+                } else {
+                    shouldExecuteChildBranches.set(false);
+                    markAlreadyCompleted();
+                }
+            }
+            case STARTED -> {
+                // wait for branches to be added
+            }
+            default -> {
+                // unexpected status which should not happen
+                terminateExecutionWithIllegalDurableOperationException(
+                        "Unexpected parallel/map status: " + existing.status());
+            }
+        }
+    }
+
+    protected <U> ChildContextOperation<U> branchInternal(
+            String name, TypeToken<U> resultType, SerDes resultSerDes, Function<DurableContext, U> func) {
+        var operationId = operationIdGenerator.nextOperationId();
+        ChildContextOperation<U> operation = new ChildContextOperation<>(
+                OperationIdentifier.of(operationId, name, OperationType.CONTEXT, OperationSubType.PARALLEL_BRANCH),
+                func,
+                resultType,
+                resultSerDes,
+                thisContext,
+                this);
+
+        branches.add(operation);
+        pendingBranches.add(operation);
+        if (shouldExecuteChildBranches.get()) {
+            executeNewBranchIfConcurrencyAllows();
+        }
+
+        return operation;
+    }
+
+    private void executeNewBranchIfConcurrencyAllows() {
+        // use one extra thread from user's thread pool to wait for the semaphore
+        while (activeBranches.get() < maxConcurrency && !pendingBranches.isEmpty()) {
+            ChildContextOperation<?> op = null;
+            // synchronized block to ensure activeBranches and queue are updated atomically
+            synchronized (this) {
+                if (activeBranches.get() < maxConcurrency && !pendingBranches.isEmpty()) {
+                    activeBranches.incrementAndGet();
+                    op = pendingBranches.poll();
+                }
+            }
+            if (op != null) {
+                op.execute();
+            }
+        }
+    }
+
+    public <U> void onChildContextComplete(ChildContextOperation<U> childOperation) {
+        if (!shouldExecuteChildBranches.get()) {
+            // the execution of child branches is already done, ignore the callback
+            return;
+        }
+
+        activeBranches.decrementAndGet();
+
+        // handle branch results
+        try {
+            childOperation.get();
+            succeeded.incrementAndGet();
+        } catch (Throwable e) {
+            failed.incrementAndGet();
+        }
+
+        if (isDone(succeeded.get(), failed.get())) {
+            shouldExecuteChildBranches.set(true);
+            // mark this operation SUCCEEDED or FAILED
+            markOperationAsCompleted(succeeded.get(), failed.get());
+        } else {
+            // we must make sure the thread for the new branch is registered before the child thread is deregistered
+            executeNewBranchIfConcurrencyAllows();
+        }
+    }
+
+    /**
+     * Gets the list of branches in the concurrent operation.
+     *
+     * @return the list of branches in the concurrent operation
+     */
+    protected ArrayList<ChildContextOperation<?>> getBranches() {
+        return branches;
+    }
+
+    /**
+     * Checks if the concurrent operation is done based on the number of succeeded and failed branches.
+     *
+     * @param succeeded the number of succeeded branches
+     * @param failed the number of failed branches
+     * @return true if the concurrent operation is done (the completion condition is met)
+     */
+    protected abstract boolean isDone(int succeeded, int failed);
+
+    /**
+     * Marks the concurrent operation as completed (SUCCEEDED or FAILED) based on the number of succeeded and failed
+     * branches and checkpoint the result.
+     *
+     * @param succeeded the number of succeeded branches
+     * @param failed the number of failed branches
+     */
+    protected abstract void markOperationAsCompleted(int succeeded, int failed);
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -50,8 +50,8 @@ public abstract class BaseDurableOperation<T> implements DurableFuture<T> {
 
     private final OperationIdentifier operationIdentifier;
     private final ExecutionManager executionManager;
-    private final TypeToken<T> resultTypeToken;
-    private final SerDes resultSerDes;
+    protected final TypeToken<T> resultTypeToken;
+    protected final SerDes resultSerDes;
     protected final CompletableFuture<Void> completionFuture;
     private final DurableContext durableContext;
 
@@ -266,6 +266,7 @@ public abstract class BaseDurableOperation<T> implements DurableFuture<T> {
         return executionManager.sendOperationUpdate(builder.id(getOperationId())
                 .name(getName())
                 .type(getType())
+                .subType(getSubType().getValue())
                 .parentId(durableContext.getContextId())
                 .build());
     }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
@@ -42,6 +42,7 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
 
     private final Function<DurableContext, T> function;
     private final ExecutorService userExecutor;
+    private final BaseConcurrentOperation<?> parentOperation;
     private boolean replayChildContext;
     private T reconstructedResult;
 
@@ -50,10 +51,12 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
             Function<DurableContext, T> function,
             TypeToken<T> resultTypeToken,
             SerDes resultSerDes,
-            DurableContext durableContext) {
+            DurableContext durableContext,
+            BaseConcurrentOperation<?> parentOperation) {
         super(operationIdentifier, resultTypeToken, resultSerDes, durableContext);
         this.function = function;
         this.userExecutor = getContext().getDurableConfig().getExecutorService();
+        this.parentOperation = parentOperation;
     }
 
     /** Starts the operation. */
@@ -115,6 +118,10 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
                     handleChildContextSuccess(result);
                 } catch (Throwable e) {
                     handleChildContextFailure(e);
+                } finally {
+                    if (parentOperation != null) {
+                        parentOperation.onChildContextComplete(this);
+                    }
                 }
             }
         };
@@ -135,6 +142,9 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
     }
 
     private void checkpointSuccess(T result) {
+        if (parentOperation != null && parentOperation.isOperationCompleted()) {
+            return; // Already completed by parent operation
+        }
         var serialized = serializeResult(result);
         var serializedBytes = serialized.getBytes(StandardCharsets.UTF_8);
 
@@ -164,6 +174,10 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
         }
         if (exception instanceof UnrecoverableDurableExecutionException) {
             terminateExecution((UnrecoverableDurableExecutionException) exception);
+        }
+
+        if (parentOperation != null && parentOperation.isOperationCompleted()) {
+            return; // Already completed by parent operation
         }
 
         final ErrorObject errorObject;
@@ -207,6 +221,8 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
                 case MAP -> throw new ChildContextFailedException(op);
                 case PARALLEL -> throw new ChildContextFailedException(op);
                 case RUN_IN_CHILD_CONTEXT -> throw new ChildContextFailedException(op);
+                case PARALLEL_BRANCH -> throw new ChildContextFailedException(op);
+                case MAP_ITERATION -> throw new ChildContextFailedException(op);
             };
         }
     }

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/BaseConcurrentOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/BaseConcurrentOperationTest.java
@@ -1,0 +1,370 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.operation;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.lambda.model.ContextDetails;
+import software.amazon.awssdk.services.lambda.model.Operation;
+import software.amazon.awssdk.services.lambda.model.OperationStatus;
+import software.amazon.awssdk.services.lambda.model.OperationType;
+import software.amazon.lambda.durable.DurableConfig;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.execution.ExecutionManager;
+import software.amazon.lambda.durable.execution.ThreadContext;
+import software.amazon.lambda.durable.execution.ThreadType;
+import software.amazon.lambda.durable.model.OperationIdentifier;
+import software.amazon.lambda.durable.model.OperationSubType;
+import software.amazon.lambda.durable.serde.JacksonSerDes;
+import software.amazon.lambda.durable.serde.SerDes;
+
+/** Unit tests for BaseConcurrentOperation. */
+class BaseConcurrentOperationTest {
+
+    private static final JacksonSerDes SERDES = new JacksonSerDes();
+    private static final OperationIdentifier OP_ID =
+            OperationIdentifier.of("op-1", "test-parallel", OperationType.CONTEXT, OperationSubType.PARALLEL);
+
+    private DurableContext durableContext;
+    private ExecutionManager executionManager;
+    private DurableContext childContext;
+
+    @BeforeEach
+    void setUp() {
+        durableContext = mock(DurableContext.class);
+        executionManager = mock(ExecutionManager.class);
+        childContext = mock(DurableContext.class);
+
+        when(durableContext.getExecutionManager()).thenReturn(executionManager);
+        when(durableContext.getDurableConfig()).thenReturn(createConfig());
+        when(executionManager.getCurrentThreadContext()).thenReturn(new ThreadContext("Root", ThreadType.CONTEXT));
+        when(durableContext.createChildContext(anyString(), anyString())).thenReturn(childContext);
+        when(childContext.getExecutionManager()).thenReturn(executionManager);
+        when(childContext.getDurableConfig()).thenReturn(createConfig());
+        when(executionManager.sendOperationUpdate(any())).thenReturn(CompletableFuture.completedFuture(null));
+    }
+
+    private DurableConfig createConfig() {
+        return DurableConfig.builder()
+                .withExecutorService(Executors.newCachedThreadPool())
+                .build();
+    }
+
+    // ===== Concrete test subclass =====
+
+    /**
+     * Minimal concrete subclass that completes when all branches succeed. Tracks isDone and markOperationAsCompleted
+     * calls for verification.
+     */
+    static class TestConcurrentOperation extends BaseConcurrentOperation<String> {
+        private final AtomicInteger isDoneCalls = new AtomicInteger(0);
+        private final AtomicInteger markCompletedCalls = new AtomicInteger(0);
+        int lastSucceeded;
+        int lastFailed;
+        int totalBranches;
+
+        TestConcurrentOperation(int maxConcurrency, int totalBranches, DurableContext durableContext) {
+            super(OP_ID, TypeToken.get(String.class), SERDES, maxConcurrency, durableContext);
+            this.totalBranches = totalBranches;
+        }
+
+        /** Expose branchInternal for testing. */
+        <T> ChildContextOperation<T> addBranch(
+                String name, TypeToken<T> resultType, SerDes resultSerDes, Function<DurableContext, T> func) {
+            return branchInternal(name, resultType, resultSerDes, func);
+        }
+
+        @Override
+        protected boolean isDone(int succeeded, int failed) {
+            isDoneCalls.incrementAndGet();
+            lastSucceeded = succeeded;
+            lastFailed = failed;
+            // done when all branches have completed (succeeded + failed == total branches)
+            return (succeeded + failed) >= totalBranches;
+        }
+
+        @Override
+        protected void markOperationAsCompleted(int succeeded, int failed) {
+            markCompletedCalls.incrementAndGet();
+            lastSucceeded = succeeded;
+            lastFailed = failed;
+        }
+
+        /**
+         * Blocks until the operation completes and returns the result.
+         *
+         * <p>This delegates to operation.get() which handles: - Thread deregistration (allows suspension) - Thread
+         * reactivation (resumes execution) - Result retrieval
+         *
+         * @return the operation result
+         */
+        @Override
+        public String get() {
+            waitForOperationCompletion();
+            return "";
+        }
+    }
+
+    // ===== start() sends START update =====
+
+    @Test
+    void startSendsOperationUpdate() {
+        // first execution — no existing operation
+        when(executionManager.getOperationAndUpdateReplayState("op-1")).thenReturn(null);
+
+        var operation = new TestConcurrentOperation(10, 0, durableContext);
+        operation.execute();
+
+        verify(executionManager)
+                .sendOperationUpdate(
+                        argThat(update -> update.action().toString().equals("START")
+                                && update.id().equals("op-1")
+                                && update.name().equals("test-parallel")));
+    }
+
+    // ===== replay SUCCEEDED without replayChildren marks completed =====
+
+    @Test
+    void replaySucceededMarksAlreadyCompleted() {
+        when(executionManager.getOperationAndUpdateReplayState("op-1"))
+                .thenReturn(Operation.builder()
+                        .id("op-1")
+                        .name("test-parallel")
+                        .type(OperationType.CONTEXT)
+                        .subType(OperationSubType.PARALLEL.getValue())
+                        .status(OperationStatus.SUCCEEDED)
+                        .contextDetails(ContextDetails.builder().build())
+                        .build());
+
+        var operation = new TestConcurrentOperation(10, 0, durableContext);
+        operation.execute();
+
+        assertTrue(operation.isOperationCompleted());
+    }
+
+    // ===== replay FAILED without replayChildren marks completed =====
+
+    @Test
+    void replayFailedMarksAlreadyCompleted() {
+        when(executionManager.getOperationAndUpdateReplayState("op-1"))
+                .thenReturn(Operation.builder()
+                        .id("op-1")
+                        .name("test-parallel")
+                        .type(OperationType.CONTEXT)
+                        .subType(OperationSubType.PARALLEL.getValue())
+                        .status(OperationStatus.FAILED)
+                        .contextDetails(ContextDetails.builder().build())
+                        .build());
+
+        var operation = new TestConcurrentOperation(10, 0, durableContext);
+        operation.execute();
+
+        assertTrue(operation.isOperationCompleted());
+    }
+
+    // ===== replay SUCCEEDED with replayChildren does NOT mark completed =====
+
+    @Test
+    void replaySucceededWithReplayChildrenDoesNotMarkCompleted() {
+        when(executionManager.getOperationAndUpdateReplayState("op-1"))
+                .thenReturn(Operation.builder()
+                        .id("op-1")
+                        .name("test-parallel")
+                        .type(OperationType.CONTEXT)
+                        .subType(OperationSubType.PARALLEL.getValue())
+                        .status(OperationStatus.SUCCEEDED)
+                        .contextDetails(
+                                ContextDetails.builder().replayChildren(true).build())
+                        .build());
+
+        var operation = new TestConcurrentOperation(10, 0, durableContext);
+        operation.execute();
+
+        assertFalse(operation.isOperationCompleted(), "Should not be completed — branches need to re-execute");
+    }
+
+    // ===== replay STARTED does not mark completed =====
+
+    @Test
+    void replayStartedDoesNotMarkCompleted() {
+        when(executionManager.getOperationAndUpdateReplayState("op-1"))
+                .thenReturn(Operation.builder()
+                        .id("op-1")
+                        .name("test-parallel")
+                        .type(OperationType.CONTEXT)
+                        .subType(OperationSubType.PARALLEL.getValue())
+                        .status(OperationStatus.STARTED)
+                        .build());
+
+        var operation = new TestConcurrentOperation(10, 0, durableContext);
+        operation.execute();
+
+        assertFalse(operation.isOperationCompleted(), "STARTED replay should wait for branches");
+    }
+
+    // ===== branchInternal adds to branches list =====
+
+    @Test
+    void branchInternalAddsToBranchesList() {
+        when(executionManager.getOperationAndUpdateReplayState("op-1")).thenReturn(null);
+        // branch operations will also look up their own operation
+        when(executionManager.getOperationAndUpdateReplayState("branch-1")).thenReturn(null);
+        when(executionManager.getOperationAndUpdateReplayState("branch-2")).thenReturn(null);
+
+        var operation = new TestConcurrentOperation(10, 2, durableContext);
+        operation.execute();
+
+        operation.addBranch("b1", TypeToken.get(String.class), SERDES, ctx -> "r1");
+        operation.addBranch("b2", TypeToken.get(String.class), SERDES, ctx -> "r2");
+
+        assertEquals(2, operation.getBranches().size());
+    }
+
+    // ===== branchInternal does not execute when shouldExecuteChildBranches is false (replay SUCCEEDED) =====
+
+    @Test
+    void branchInternalSkipsExecutionOnCompletedReplay() {
+        when(executionManager.getOperationAndUpdateReplayState("op-1"))
+                .thenReturn(Operation.builder()
+                        .id("op-1")
+                        .name("test-parallel")
+                        .type(OperationType.CONTEXT)
+                        .subType(OperationSubType.PARALLEL.getValue())
+                        .status(OperationStatus.SUCCEEDED)
+                        .contextDetails(ContextDetails.builder().build())
+                        .build());
+
+        var operation = new TestConcurrentOperation(10, 1, durableContext);
+        operation.execute();
+
+        // Adding a branch after replay SUCCEEDED should not trigger execution
+        var branch = operation.addBranch("b1", TypeToken.get(String.class), SERDES, ctx -> "result");
+
+        // The branch should be added to the list but not executed
+        assertEquals(1, operation.getBranches().size());
+        // branch-1 should NOT have been looked up in executionManager (no execute() call)
+        verify(executionManager, never()).getOperationAndUpdateReplayState("branch-1");
+    }
+
+    // ===== concurrency limiting: maxConcurrency=1 executes branches sequentially =====
+
+    @Test
+    void maxConcurrencyOneExecutesBranchesSequentially() throws Exception {
+        when(executionManager.getOperationAndUpdateReplayState("op-1")).thenReturn(null);
+        when(executionManager.getOperationAndUpdateReplayState("branch-1")).thenReturn(null);
+        when(executionManager.getOperationAndUpdateReplayState("branch-2")).thenReturn(null);
+        when(executionManager.hasOperationsForContext("branch-1")).thenReturn(false);
+        when(executionManager.hasOperationsForContext("branch-2")).thenReturn(false);
+        when(childContext.createChildContext(anyString(), anyString())).thenReturn(childContext);
+
+        var concurrentCount = new AtomicInteger(0);
+        var maxConcurrent = new AtomicInteger(0);
+
+        var operation = new TestConcurrentOperation(1, 2, durableContext);
+        operation.execute();
+
+        operation.addBranch("b1", TypeToken.get(String.class), SERDES, ctx -> {
+            var current = concurrentCount.incrementAndGet();
+            maxConcurrent.updateAndGet(max -> Math.max(max, current));
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            concurrentCount.decrementAndGet();
+            return "r1";
+        });
+
+        operation.addBranch("b2", TypeToken.get(String.class), SERDES, ctx -> {
+            var current = concurrentCount.incrementAndGet();
+            maxConcurrent.updateAndGet(max -> Math.max(max, current));
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            concurrentCount.decrementAndGet();
+            return "r2";
+        });
+        Thread.sleep(1000);
+
+        assertEquals(1, maxConcurrent.get(), "Only 1 branch should run at a time with maxConcurrency=1");
+    }
+
+    // ===== onChildContextComplete increments failed counter on exception =====
+
+    @Test
+    void onChildContextCompleteIncrementsFailedOnException() throws Exception {
+        when(executionManager.getOperationAndUpdateReplayState("op-1")).thenReturn(null);
+        when(executionManager.getOperationAndUpdateReplayState("branch-1")).thenReturn(null);
+        when(executionManager.hasOperationsForContext("branch-1")).thenReturn(false);
+        when(childContext.createChildContext(anyString(), anyString())).thenReturn(childContext);
+
+        var operation = new TestConcurrentOperation(10, 1, durableContext) {};
+        operation.execute();
+
+        var b1 = operation.addBranch("b1", TypeToken.get(String.class), SERDES, ctx -> {
+            throw new RuntimeException("branch failed");
+        });
+
+        Thread.sleep(1000); // improve
+        b1.markAlreadyCompleted();
+
+        assertEquals(0, operation.lastSucceeded);
+        assertEquals(1, operation.lastFailed);
+    }
+
+    // ===== onChildContextComplete is no-op after shouldExecuteChildBranches is false =====
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void onChildContextCompleteIgnoredWhenShouldExecuteIsFalse() {
+        when(executionManager.getOperationAndUpdateReplayState("op-1"))
+                .thenReturn(Operation.builder()
+                        .id("op-1")
+                        .name("test-parallel")
+                        .type(OperationType.CONTEXT)
+                        .subType(OperationSubType.PARALLEL.getValue())
+                        .status(OperationStatus.SUCCEEDED)
+                        .contextDetails(ContextDetails.builder().build())
+                        .build());
+
+        var operation = new TestConcurrentOperation(10, 0, durableContext);
+        operation.execute();
+
+        // Simulate a late callback from a child — should be ignored
+        var mockChild = mock(ChildContextOperation.class);
+        operation.onChildContextComplete(mockChild);
+
+        // get() should never be called on the child since the callback is ignored
+        verify(mockChild, never()).get();
+        assertEquals(0, operation.isDoneCalls.get());
+    }
+
+    // ===== replay with unexpected status terminates execution =====
+
+    @Test
+    void replayUnexpectedStatusTerminatesExecution() {
+        when(executionManager.getOperationAndUpdateReplayState("op-1"))
+                .thenReturn(Operation.builder()
+                        .id("op-1")
+                        .name("test-parallel")
+                        .type(OperationType.CONTEXT)
+                        .subType(OperationSubType.PARALLEL.getValue())
+                        .status(OperationStatus.PENDING)
+                        .build());
+
+        var operation = new TestConcurrentOperation(10, 0, durableContext);
+
+        // Should terminate execution for unexpected status
+        assertThrows(Exception.class, operation::execute);
+    }
+}

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/ChildContextOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/ChildContextOperationTest.java
@@ -56,7 +56,7 @@ class ChildContextOperationTest {
 
     private ChildContextOperation<String> createOperation(Function<DurableContext, String> func) {
         return new ChildContextOperation<>(
-                OPERATION_IDENTIFIER, func, TypeToken.get(String.class), SERDES, durableContext);
+                OPERATION_IDENTIFIER, func, TypeToken.get(String.class), SERDES, durableContext, null);
     }
 
     // ===== SUCCEEDED replay =====


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Required for #88 and #39 

### Description

- added a base class BaseConcurrentOperation for Map and Parallel operations
  - this is not fully tested. Needs to be further tested with Map and Parallel operation. 
- added OperationIdGenerator so that it can be reused

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [ ] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Added

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
