### PR TITLE
Add subtype to checkpoint updates in BaseDurableOperation

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -263,11 +263,12 @@ public abstract class BaseDurableOperation<T> implements DurableFuture<T> {
     }
 
     protected CompletableFuture<Void> sendOperationUpdateAsync(OperationUpdate.Builder builder) {
-        return executionManager.sendOperationUpdate(builder.id(getOperationId())
-                .name(getName())
-                .type(getType())
-                .parentId(durableContext.getContextId())
-                .build());
+        var updateBuilder =
+                builder.id(getOperationId()).name(getName()).type(getType()).parentId(durableContext.getContextId());
+        if (getSubType() != null) {
+            updateBuilder.subType(getSubType().getValue());
+        }
+        return executionManager.sendOperationUpdate(updateBuilder.build());
     }
 
     // serialization/deserialization utilities

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
@@ -60,9 +60,7 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
     @Override
     protected void start() {
         // First execution: fire-and-forget START checkpoint, then run
-        sendOperationUpdateAsync(OperationUpdate.builder()
-                .action(OperationAction.START)
-                .subType(getSubType().getValue()));
+        sendOperationUpdateAsync(OperationUpdate.builder().action(OperationAction.START));
         executeChildContext();
     }
 
@@ -139,17 +137,14 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
         var serializedBytes = serialized.getBytes(StandardCharsets.UTF_8);
 
         if (serializedBytes.length < LARGE_RESULT_THRESHOLD) {
-            sendOperationUpdate(OperationUpdate.builder()
-                    .action(OperationAction.SUCCEED)
-                    .subType(getSubType().getValue())
-                    .payload(serialized));
+            sendOperationUpdate(
+                    OperationUpdate.builder().action(OperationAction.SUCCEED).payload(serialized));
         } else {
             // Large result: checkpoint with empty payload + ReplayChildren flag.
             // Store the result so get() can return it directly without deserializing the empty payload.
             this.reconstructedResult = result;
             sendOperationUpdate(OperationUpdate.builder()
                     .action(OperationAction.SUCCEED)
-                    .subType(getSubType().getValue())
                     .payload("")
                     .contextOptions(
                             ContextOptions.builder().replayChildren(true).build()));
@@ -173,10 +168,8 @@ public class ChildContextOperation<T> extends BaseDurableOperation<T> {
             errorObject = serializeException(exception);
         }
 
-        sendOperationUpdate(OperationUpdate.builder()
-                .action(OperationAction.FAIL)
-                .subType(getSubType().getValue())
-                .error(errorObject));
+        sendOperationUpdate(
+                OperationUpdate.builder().action(OperationAction.FAIL).error(errorObject));
     }
 
     @Override


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

N/A

### Description

Subtype was moved to the BaseDurableOperation, but the subtype isn't included when updating checkpoints (in the `sendOperationUpdateAsync()` method. Subtype is now added to the update, it a subtype exists.

Also the ChildContextOperation was manually adding subtype to it's checkpoint updates. Since this is being done in the BaseDurableOperation, it no longer needs to be done in ChildContextOperation.

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
