### PR TITLE
[refactor]: simplifies the logic to find EXECUTION op

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/DurableExecutionCheckpointTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/DurableExecutionCheckpointTest.java
@@ -13,6 +13,10 @@ import software.amazon.lambda.durable.testing.LocalMemoryExecutionClient;
 
 /** Integration tests that verify checkpoint behavior using LocalMemoryExecutionClient */
 class DurableExecutionCheckpointTest {
+    private static final String EXECUTION_NAME = "test-execution";
+    private static final String EXECUTION_OP_ID = "01234567-0123-0123-0123-012345678901";
+    private static final String EXECUTION_ARN = "arn:aws:lambda:us-east-1:123456789012:function:test/durable-execution/"
+            + EXECUTION_NAME + "/" + EXECUTION_OP_ID;
 
     private DurableConfig configWithMockClient(LocalMemoryExecutionClient client) {
         return DurableConfig.builder().withDurableExecutionClient(client).build();
@@ -22,7 +26,7 @@ class DurableExecutionCheckpointTest {
     void testLargePayloadCheckpointing() {
         var client = new LocalMemoryExecutionClient();
         var executionOp = Operation.builder()
-                .id("0")
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -31,7 +35,7 @@ class DurableExecutionCheckpointTest {
                 .build();
 
         var input = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token1",
                 CheckpointUpdatedExecutionState.builder()
                         .operations(List.of(executionOp))
@@ -62,7 +66,7 @@ class DurableExecutionCheckpointTest {
     void testSmallPayloadNoExtraCheckpoint() {
         var client = new LocalMemoryExecutionClient();
         var executionOp = Operation.builder()
-                .id("0")
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -71,7 +75,7 @@ class DurableExecutionCheckpointTest {
                 .build();
 
         var input = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token1",
                 CheckpointUpdatedExecutionState.builder()
                         .operations(List.of(executionOp))

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/IntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/IntegrationTest.java
@@ -110,7 +110,11 @@ class IntegrationTest {
         assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
         assertEquals(3, result.getSucceededOperations().size());
         assertEquals("Step 1 done", result.getOperation("step1").getStepResult(String.class));
-        assertEquals(OperationType.WAIT, result.getSucceededOperations().get(1).getType());
+        assertEquals(
+                OperationType.WAIT,
+                result.getSucceededOperations()
+                        .get(1)
+                        .getType()); // todo: the result of getSucceededOperations is not ordered
         assertEquals(
                 OperationStatus.SUCCEEDED,
                 result.getSucceededOperations().get(1).getStatus());

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
@@ -5,6 +5,7 @@ package software.amazon.lambda.durable.testing;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.BiFunction;
 import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
@@ -308,9 +309,15 @@ public class LocalDurableTestRunner<I, O> {
     }
 
     private DurableExecutionInput createDurableInput(I input) {
+        var executionName = UUID.randomUUID().toString();
+        var invocationId = UUID.randomUUID().toString();
+        var executionArn = String.format(
+                "arn:aws:lambda:us-east-1:123456789012:function:test:$LATEST/durable-execution/%s/%s",
+                executionName, invocationId);
         var inputJson = serDes.serialize(input);
         var executionOp = Operation.builder()
-                .id("0")
+                .id(invocationId)
+                .name(executionName)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(
@@ -318,14 +325,13 @@ public class LocalDurableTestRunner<I, O> {
                 .build();
 
         // Load previous operations and include them in InitialExecutionState
-        var existingOps = storage.getExecutionState(
-                        "arn:aws:lambda:us-east-1:123456789012:function:test", "test-token", null)
-                .operations();
+        var existingOps =
+                storage.getExecutionState(executionArn, "test-token", null).operations();
         var allOps = new ArrayList<>(List.of(executionOp));
         allOps.addAll(existingOps);
 
         return new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                executionArn,
                 "test-token",
                 CheckpointUpdatedExecutionState.builder().operations(allOps).build());
     }

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableExecutor.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableExecutor.java
@@ -32,6 +32,7 @@ import software.amazon.lambda.durable.util.ExceptionHelper;
  * production of the {@link DurableExecutionOutput} (success, failure, or pending suspension).
  */
 public class DurableExecutor {
+    private static final String ROOT_THREAD_ID = null;
     private static final Logger logger = LoggerFactory.getLogger(DurableExecutor.class);
 
     // Lambda response size limit is 6MB minus small epsilon for envelope

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
@@ -16,10 +16,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
-import software.amazon.awssdk.services.lambda.model.OperationType;
 import software.amazon.awssdk.services.lambda.model.OperationUpdate;
 import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.exception.UnrecoverableDurableExecutionException;
@@ -81,11 +79,14 @@ public class ExecutionManager implements AutoCloseable {
         this.executionMode =
                 new AtomicReference<>(operationStorage.size() > 1 ? ExecutionMode.REPLAY : ExecutionMode.EXECUTION);
 
-        executionOp = findExecutionOp(input.initialExecutionState());
+        // parse durableExecutionArn and get the last part after / which is the invocation id
+        var durableExecutionArnParts = durableExecutionArn.split("/", -1);
+        var invocationId = durableExecutionArnParts[durableExecutionArnParts.length - 1];
+        executionOp = operationStorage.get(invocationId);
 
         // Validate initial operation is an EXECUTION operation
         if (executionOp == null) {
-            throw new IllegalStateException("First operation must be EXECUTION");
+            throw new IllegalStateException("EXECUTION operation not found");
         }
         logger.debug("DurableExecution.execute() called");
         logger.debug("DurableExecutionArn: {}", durableExecutionArn);
@@ -161,26 +162,6 @@ public class ExecutionManager implements AutoCloseable {
     /** Returns the initial EXECUTION operation from the checkpoint state. */
     public Operation getExecutionOperation() {
         return executionOp;
-    }
-
-    private Operation findExecutionOp(CheckpointUpdatedExecutionState initialExecutionState) {
-        // find execution OP in the input
-        if (initialExecutionState != null
-                && initialExecutionState.operations() != null
-                && !initialExecutionState.operations().isEmpty()) {
-            var op = initialExecutionState.operations().get(0);
-            if (op.type() != OperationType.EXECUTION) {
-                throw new IllegalStateException("First operation must be EXECUTION");
-            }
-            return op;
-        }
-        // find execution OP in the checkpoint result
-        for (Operation op : operationStorage.values()) {
-            if (op.type() == OperationType.EXECUTION) {
-                return op;
-            }
-        }
-        return null;
     }
 
     /**

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/OperationIdGenerator.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/OperationIdGenerator.java
@@ -11,22 +11,20 @@ import java.util.concurrent.atomic.AtomicInteger;
 /** Generates operation IDs for the durable operations. */
 public class OperationIdGenerator {
     private final AtomicInteger operationCounter;
-    private final String contextId;
+    private final String operationIdPrefix;
 
     public OperationIdGenerator(String contextId) {
         this.operationCounter = new AtomicInteger(0);
-        this.contextId = contextId;
+        this.operationIdPrefix = contextId != null ? contextId + "-" : "";
     }
 
     /**
-     * Get the next operationId. Returns a globally unique operation ID by hashing a sequential operation counter. For
-     * root contexts, the counter value is hashed directly (e.g. "1", "2", "3"). For child contexts, the values are
-     * prefixed with the parent hashed contextId (e.g. "<hash>-1", "<hash>-2" inside parent context <hash>). This
-     * matches the Python SDK's stepPrefix convention and prevents ID collisions in checkpoint batches.
+     * Hashes the given string using SHA-256
+     *
+     * @param rawId the string to hash
+     * @return the hashed string
      */
-    public String nextOperationId() {
-        var counter = String.valueOf(operationCounter.incrementAndGet());
-        var rawId = contextId != null ? contextId + "-" + counter : counter;
+    public static String hashOperationId(String rawId) {
         try {
             var messageDigest = MessageDigest.getInstance("SHA-256");
             var hash = messageDigest.digest(rawId.getBytes(StandardCharsets.UTF_8));
@@ -34,5 +32,17 @@ public class OperationIdGenerator {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("failed to get next operation id, SHA-256 not available", e);
         }
+    }
+
+    /**
+     * Returns the next globally unique operation ID. Increments an internal counter, concatenates it with the context
+     * ID prefix ({@code contextId + "-" + counter}), and SHA-256 hashes the result. For root contexts the prefix is the
+     * EXECUTION operation ID; for child contexts it is the parent's hashed context ID. This produces IDs like
+     * {@code hash("execId-1")}, {@code hash("execId-2")} at the root level, and {@code hash("<parentHash>-1")},
+     * {@code hash("<parentHash>-2")} inside a child context.
+     */
+    public String nextOperationId() {
+        var counter = String.valueOf(operationCounter.incrementAndGet());
+        return hashOperationId(operationIdPrefix + counter);
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableContextTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableContextTest.java
@@ -20,9 +20,12 @@ import software.amazon.lambda.durable.retry.RetryStrategies;
 
 class DurableContextTest {
     private static final String EXECUTION_NAME = "349beff4-a89d-4bc8-a56f-af7a8af67a5f";
-    private static final String INVOCATION_ID = "20dae574-53da-37a1-bfd5-b0e2e6ec715d";
+    private static final String EXECUTION_OP_ID = "20dae574-53da-37a1-bfd5-b0e2e6ec715d";
+    private static final String EXECUTION_ARN = "arn:aws:lambda:us-east-1:123456789012:function:test/durable-execution/"
+            + EXECUTION_NAME + "/" + EXECUTION_OP_ID;
+
     private static final Operation EXECUTION_OP = Operation.builder()
-            .id(INVOCATION_ID)
+            .id(EXECUTION_OP_ID)
             .type(OperationType.EXECUTION)
             .status(OperationStatus.STARTED)
             .build();
@@ -41,11 +44,7 @@ class DurableContextTest {
         var initialExecutionState =
                 CheckpointUpdatedExecutionState.builder().operations(operations).build();
         var executionManager = new ExecutionManager(
-                new DurableExecutionInput(
-                        "arn:aws:lambda:us-east-1:123456789012:function:test:$LATEST/durable-execution/"
-                                + EXECUTION_NAME + "/" + INVOCATION_ID,
-                        "test-token",
-                        initialExecutionState),
+                new DurableExecutionInput(EXECUTION_ARN, "test-token", initialExecutionState),
                 DurableConfig.builder().withDurableExecutionClient(client).build());
         var root = DurableContextImpl.createRootContext(
                 executionManager, DurableConfig.builder().build(), null);
@@ -67,10 +66,7 @@ class DurableContextTest {
         var context = createTestContext();
 
         assertNotNull(context.getExecutionArn());
-        assertEquals(
-                "arn:aws:lambda:us-east-1:123456789012:function:test:$LATEST/durable-execution/" + EXECUTION_NAME + "/"
-                        + INVOCATION_ID,
-                context.getExecutionArn());
+        assertEquals(EXECUTION_ARN, context.getExecutionArn());
     }
 
     @Test

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableExecutionTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableExecutionTest.java
@@ -24,8 +24,11 @@ import software.amazon.lambda.durable.model.ExecutionStatus;
 
 class DurableExecutionTest {
 
-    private static final String OPERATION_ID0 = TestUtils.hashOperationId("0");
+    private static final String EXECUTION_OP_ID = "20dae574-53da-37a1-bfd5-b0e2e6ec715d";
     private static final String OPERATION_ID1 = TestUtils.hashOperationId("1");
+    private static final String EXECUTION_NAME = "exec-name";
+    private static final String EXECUTION_ARN = "arn:aws:lambda:us-east-1:123456789012:function:test/durable-execution/"
+            + EXECUTION_NAME + "/" + EXECUTION_OP_ID;
 
     private DurableConfig configWithMockClient() {
         return DurableConfig.builder()
@@ -36,7 +39,7 @@ class DurableExecutionTest {
     @Test
     void testExecuteSuccess() {
         var executionOp = Operation.builder()
-                .id(OPERATION_ID0)
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -45,7 +48,7 @@ class DurableExecutionTest {
                 .build();
 
         var input = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token1",
                 CheckpointUpdatedExecutionState.builder()
                         .operations(List.of(executionOp))
@@ -66,7 +69,7 @@ class DurableExecutionTest {
     @Test
     void testExecutePending() {
         var executionOp = Operation.builder()
-                .id(OPERATION_ID0)
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -75,7 +78,7 @@ class DurableExecutionTest {
                 .build();
 
         var input = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token1",
                 CheckpointUpdatedExecutionState.builder()
                         .operations(List.of(executionOp))
@@ -99,7 +102,7 @@ class DurableExecutionTest {
     @Test
     void testExecuteFailure() {
         var executionOp = Operation.builder()
-                .id(OPERATION_ID0)
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -108,7 +111,7 @@ class DurableExecutionTest {
                 .build();
 
         var input = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token1",
                 CheckpointUpdatedExecutionState.builder()
                         .operations(List.of(executionOp))
@@ -132,7 +135,7 @@ class DurableExecutionTest {
     @Test
     void testExecuteReplay() {
         var executionOp = Operation.builder()
-                .id(OPERATION_ID0)
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -149,7 +152,7 @@ class DurableExecutionTest {
                 .build();
 
         var input = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token2",
                 CheckpointUpdatedExecutionState.builder()
                         .operations(List.of(executionOp, completedStep))
@@ -169,7 +172,7 @@ class DurableExecutionTest {
     @Test
     void testValidationNoOperations() {
         var input = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token1",
                 CheckpointUpdatedExecutionState.builder().operations(List.of()).build());
 
@@ -178,7 +181,7 @@ class DurableExecutionTest {
                 () -> DurableExecutor.execute(
                         input, null, get(String.class), (userInput, ctx) -> "result", configWithMockClient()));
 
-        assertEquals("First operation must be EXECUTION", exception.getMessage());
+        assertEquals("EXECUTION operation not found", exception.getMessage());
     }
 
     @Test
@@ -191,7 +194,7 @@ class DurableExecutionTest {
                 .build();
 
         var input = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token1",
                 CheckpointUpdatedExecutionState.builder()
                         .operations(List.of(stepOp))
@@ -202,19 +205,19 @@ class DurableExecutionTest {
                 () -> DurableExecutor.execute(
                         input, null, get(String.class), (userInput, ctx) -> "result", configWithMockClient()));
 
-        assertEquals("First operation must be EXECUTION", exception.getMessage());
+        assertEquals("EXECUTION operation not found", exception.getMessage());
     }
 
     @Test
     void testValidationMissingExecutionDetails() {
         var executionOp = Operation.builder()
-                .id(OPERATION_ID0)
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .build();
 
         var input = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token1",
                 CheckpointUpdatedExecutionState.builder()
                         .operations(List.of(executionOp))
@@ -238,7 +241,7 @@ class DurableExecutionTest {
         assertFalse(sharedExecutor.isShutdown(), "Executor should not be shutdown initially");
 
         var executionOp = Operation.builder()
-                .id(OPERATION_ID0)
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -247,7 +250,7 @@ class DurableExecutionTest {
                 .build();
 
         var input1 = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token1",
                 CheckpointUpdatedExecutionState.builder()
                         .operations(List.of(executionOp))
@@ -266,7 +269,7 @@ class DurableExecutionTest {
 
         // Create second input with different execution operation
         var executionOp2 = Operation.builder()
-                .id(OPERATION_ID0)
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -275,7 +278,7 @@ class DurableExecutionTest {
                 .build();
 
         var input2 = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token2",
                 CheckpointUpdatedExecutionState.builder()
                         .operations(List.of(executionOp2))

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableExecutionWrapperTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableExecutionWrapperTest.java
@@ -21,6 +21,10 @@ import software.amazon.lambda.durable.model.ExecutionStatus;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
 
 class DurableExecutionWrapperTest {
+    private static final String EXECUTION_OP_ID = "f3d7b0c0-1234-5678-90ab-cdef12345678";
+    private static final String EXECUTION_NAME = "exec-name";
+    private static final String EXECUTION_ARN = "arn:aws:lambda:us-east-1:123456789012:function:test/durable-execution/"
+            + EXECUTION_NAME + "/" + EXECUTION_OP_ID;
 
     static class TestInput {
         public String value;
@@ -62,7 +66,7 @@ class DurableExecutionWrapperTest {
 
         // Create input with EXECUTION operation
         var executionOp = Operation.builder()
-                .id("0")
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -71,7 +75,7 @@ class DurableExecutionWrapperTest {
                 .build();
 
         var input = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token-1",
                 CheckpointUpdatedExecutionState.builder()
                         .operations(List.of(executionOp))
@@ -98,7 +102,7 @@ class DurableExecutionWrapperTest {
         var serDes = new JacksonSerDes();
 
         var executionOp = Operation.builder()
-                .id("0")
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .executionDetails(ExecutionDetails.builder()
@@ -107,7 +111,7 @@ class DurableExecutionWrapperTest {
                 .build();
 
         var input = new DurableExecutionInput(
-                "arn:aws:lambda:us-east-1:123456789012:function:test",
+                EXECUTION_ARN,
                 "token-1",
                 CheckpointUpdatedExecutionState.builder()
                         .operations(List.of(executionOp))

--- a/sdk/src/test/java/software/amazon/lambda/durable/ReplayValidationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/ReplayValidationTest.java
@@ -23,14 +23,16 @@ import software.amazon.lambda.durable.execution.ThreadType;
 import software.amazon.lambda.durable.model.DurableExecutionInput;
 
 class ReplayValidationTest {
-    public static final String EXECUTION_NAME = "exec-name";
-    public static final String INVOCATION_ID = "invocation-id";
-    public static final String OPERATION_ID1 = TestUtils.hashOperationId("1");
+    private static final String EXECUTION_NAME = "exec-name";
+    private static final String EXECUTION_OP_ID = "invocation-id";
+    private static final String EXECUTION_ARN = "arn:aws:lambda:us-east-1:123456789012:function:test/durable-execution/"
+            + EXECUTION_NAME + "/" + EXECUTION_OP_ID;
+    private static final String OPERATION_ID1 = TestUtils.hashOperationId("1");
 
     private DurableContext createTestContext(List<Operation> initialOperations) {
         var client = TestUtils.createMockClient();
         var executionOp = Operation.builder()
-                .id(INVOCATION_ID)
+                .id(EXECUTION_OP_ID)
                 .name(EXECUTION_NAME)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
@@ -40,12 +42,11 @@ class ReplayValidationTest {
         var initialExecutionState =
                 CheckpointUpdatedExecutionState.builder().operations(operations).build();
         var executionManager = new ExecutionManager(
-                new DurableExecutionInput(
-                        "arn:aws:lambda:us-east-1:123456789012:function:test", "test-token", initialExecutionState),
+                new DurableExecutionInput(EXECUTION_ARN, "test-token", initialExecutionState),
                 DurableConfig.builder().withDurableExecutionClient(client).build());
         var context = DurableContextImpl.createRootContext(
                 executionManager, DurableConfig.builder().build(), null);
-        executionManager.setCurrentThreadContext(new ThreadContext(INVOCATION_ID + "-execution", ThreadType.CONTEXT));
+        executionManager.setCurrentThreadContext(new ThreadContext(EXECUTION_OP_ID + "-execution", ThreadType.CONTEXT));
 
         return context;
     }

--- a/sdk/src/test/java/software/amazon/lambda/durable/TestUtils.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/TestUtils.java
@@ -5,15 +5,12 @@ package software.amazon.lambda.durable;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.UUID;
 import software.amazon.awssdk.services.lambda.model.*;
 import software.amazon.lambda.durable.client.DurableExecutionClient;
+import software.amazon.lambda.durable.execution.OperationIdGenerator;
 
 public class TestUtils {
 
@@ -70,12 +67,6 @@ public class TestUtils {
     }
 
     public static String hashOperationId(String rawId) {
-        try {
-            var messageDigest = MessageDigest.getInstance("SHA-256");
-            var hash = messageDigest.digest(rawId.getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException e) {
-            throw new AssertionError("SHA-256 not available", e);
-        }
+        return OperationIdGenerator.hashOperationId(rawId);
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/execution/ExecutionManagerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/execution/ExecutionManagerTest.java
@@ -20,6 +20,11 @@ import software.amazon.lambda.durable.client.DurableExecutionClient;
 import software.amazon.lambda.durable.model.DurableExecutionInput;
 
 class ExecutionManagerTest {
+    private static final String EXECUTION_OP_ID = "01234567-0123-0123-0123-012345678901";
+    private static final String EXECUTION_NAME = "exec-name";
+    private static final String EXECUTION_ARN = "arn:aws:lambda:us-east-1:123456789012:function:test/durable-execution/"
+            + EXECUTION_NAME + "/" + EXECUTION_OP_ID;
+
     private DurableExecutionClient client;
 
     private ExecutionManager createManager(List<Operation> operations) {
@@ -27,14 +32,13 @@ class ExecutionManagerTest {
         var initialState =
                 CheckpointUpdatedExecutionState.builder().operations(operations).build();
         return new ExecutionManager(
-                new DurableExecutionInput(
-                        "arn:aws:lambda:us-east-1:123456789012:function:test", "test-token", initialState),
+                new DurableExecutionInput(EXECUTION_ARN, "test-token", initialState),
                 DurableConfig.builder().withDurableExecutionClient(client).build());
     }
 
     private Operation executionOp() {
         return Operation.builder()
-                .id("0")
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .build();
@@ -129,11 +133,10 @@ class ExecutionManagerTest {
                 .nextMarker("marker")
                 .build();
         var executionManager = new ExecutionManager(
-                new DurableExecutionInput(
-                        "arn:aws:lambda:us-east-1:123456789012:function:test", "test-token", initialState),
+                new DurableExecutionInput(EXECUTION_ARN, "test-token", initialState),
                 DurableConfig.builder().withDurableExecutionClient(client).build());
 
         assertNotNull(executionManager.getExecutionOperation());
-        assertEquals("0", executionManager.getExecutionOperation().id());
+        assertEquals(EXECUTION_OP_ID, executionManager.getExecutionOperation().id());
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/logging/DurableLoggerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/logging/DurableLoggerTest.java
@@ -15,8 +15,10 @@ import software.amazon.lambda.durable.context.DurableContextImpl;
 import software.amazon.lambda.durable.execution.ExecutionManager;
 
 class DurableLoggerTest {
-
-    private static final String EXECUTION_ARN = "arn:aws:lambda:us-east-1:123456789012:function:test:exec-123";
+    private static final String EXECUTION_NAME = "exec-123";
+    private static final String EXECUTION_OP_ID = "20dae574-53da-37a1-bfd5-b0e2e6ec715d";
+    private static final String EXECUTION_ARN = "arn:aws:lambda:us-east-1:123456789012:function:test/durable-execution/"
+            + EXECUTION_NAME + "/" + EXECUTION_OP_ID;
     private static final String REQUEST_ID = "req-456";
 
     private enum Mode {

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/CallbackOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/CallbackOperationTest.java
@@ -31,10 +31,14 @@ import software.amazon.lambda.durable.serde.SerDes;
 
 class CallbackOperationTest {
 
-    private static final String OPERATION_ID = "1";
+    private static final String OPERATION_ID = TestUtils.hashOperationId("1");
     private static final String OPERATION_NAME = "approval";
     private static final OperationIdentifier OPERATION_IDENTIFIER =
             OperationIdentifier.of(OPERATION_ID, OPERATION_NAME, OperationType.CALLBACK);
+    private static final String EXECUTION_NAME = "exec-name";
+    private static final String EXECUTION_OP_ID = "123";
+    private static final String EXECUTION_ARN = "arn:aws:lambda:us-east-1:123456789012:function:test/durable-execution/"
+            + EXECUTION_NAME + "/" + EXECUTION_OP_ID;
 
     private DurableContextImpl durableContext;
 
@@ -81,7 +85,7 @@ class CallbackOperationTest {
         var client = TestUtils.createMockClient();
         var operations = new ArrayList<Operation>();
         operations.add(Operation.builder()
-                .id("0")
+                .id(EXECUTION_OP_ID)
                 .type(OperationType.EXECUTION)
                 .status(OperationStatus.STARTED)
                 .build());
@@ -89,8 +93,7 @@ class CallbackOperationTest {
         var initialState =
                 CheckpointUpdatedExecutionState.builder().operations(operations).build();
         var executionManager = new ExecutionManager(
-                new DurableExecutionInput(
-                        "arn:aws:lambda:us-east-1:123456789012:function:test", "test-token", initialState),
+                new DurableExecutionInput(EXECUTION_ARN, "test-token", initialState),
                 DurableConfig.builder().withDurableExecutionClient(client).build());
         executionManager.setCurrentThreadContext(new ThreadContext("Root", ThreadType.CONTEXT));
         return executionManager;


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

- Simplifies the logic to find the EXECUTION op in the history.
   - It used to iterate over all operations and look for an operation with EXECUTION type.
   - Now it extracts `InvocationId` from `ExecutionArn` and looks for an operation with operation id = `InvocationId`
- Update ExecutionArn used local runner to look more like real

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
