### PR TITLE
Remove waitForCondition checkpoint deserialize exception catch

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitForConditionOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitForConditionOperation.java
@@ -105,11 +105,7 @@ public class WaitForConditionOperation<T> extends BaseDurableOperation<T> {
         var checkpointData = stepDetails != null ? stepDetails.result() : null;
         T currentState; // Get current state
         if (checkpointData != null) {
-            try {
-                currentState = deserializeResult(checkpointData);
-            } catch (Exception e) {
-                currentState = initialState;
-            }
+            currentState = deserializeResult(checkpointData);
         } else {
             currentState = initialState;
         }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

https://github.com/aws/aws-durable-execution-sdk-java/pull/195#discussion_r2948181986

### Description

Currently if there is a failure with deserializing a checkpoint in waitForCondition, we simply revert back to the initial state (matching the behaviour in the Python and JS SDKs).

But because Java is statically typed, this is unlikely to happen unless due to a user coding error.

So we are changing the behaviour to simply throw the SerDesException without catching it, which will then propagate up to the user's waitForCondition call, and they can decide how to handle it.

### Demo/Screenshots

N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
