### PR TITLE
chore(examples): remove deprecated class and function from examples.

### DIFF
--- a/examples/src/main/java/software/amazon/lambda/durable/examples/CustomPollingExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/CustomPollingExample.java
@@ -39,7 +39,7 @@ public class CustomPollingExample extends DurableHandler<GreetingRequest, String
         context.getLogger().info("Starting workflow with input: {}", input);
 
         // Step 1: low case the input
-        var lowered = context.stepAsync("validate", String.class, () -> {
+        var lowered = context.stepAsync("validate", String.class, stepCtx -> {
             try {
                 // prevent the execution from suspension
                 Thread.sleep(5000);

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/RetryExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/RetryExample.java
@@ -8,7 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
-import software.amazon.lambda.durable.StepConfig;
+import software.amazon.lambda.durable.config.StepConfig;
 import software.amazon.lambda.durable.retry.RetryStrategies;
 
 /**


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
#256 #257 

### Description
Removing the use of deprecated classes/functions from examples.

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? No.  I ran existing tests via `mvn test`

#### Integration Tests

Have integration tests been written for these changes? No

#### Examples

Has a new example been added for the change? (if applicable) Change is to examples.
