### PR TITLE
fix WaitForCondition, use polled state on replay resume

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitForConditionOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitForConditionOperation.java
@@ -115,7 +115,7 @@ public class WaitForConditionOperation<T> extends SerializableDurableOperation<T
                 .thenCompose(op -> op.status() == OperationStatus.READY
                         ? CompletableFuture.completedFuture(op)
                         : pollForOperationUpdates())
-                .thenRun(() -> resumeCheckLoop(existing));
+                .thenAccept(this::resumeCheckLoop);
     }
 
     private void executeCheckLogic(T currentState, int attempt) {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available N/A

### Description

When resuming a pending WaitForCondition operation, the existing code was polling for the updated status, but didn't actually pass it to the resume method. Instead it was resuming with the previous state, which caused WaitForCondition to replay unnecessarily.

Now the polled updated status is passed to resume correctly.

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
