### PR TITLE
[fix]: Fix the negative polling time

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/CheckpointManager.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/CheckpointManager.java
@@ -72,12 +72,14 @@ class CheckpointManager {
     }
 
     /**
-     * Polls for updates of the specified operation with specified delay
+     * Polls for updates of the specified operation at the specified time. If the give time is at the past, SDK will
+     * immediately make a polling call.
      *
+     * @param at the time to poll for the update
      * @return a future that completes when the operation is updated
      */
-    CompletableFuture<Operation> pollForUpdate(String operationId, Duration delay) {
-        return pollForUpdate(operationId, PollingStrategies.fixedDelay(delay));
+    CompletableFuture<Operation> pollForUpdate(String operationId, Instant at) {
+        return pollForUpdate(operationId, PollingStrategies.at(at));
     }
 
     /**

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.execution;
 
-import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -247,8 +247,15 @@ public class ExecutionManager implements AutoCloseable {
         return checkpointManager.pollForUpdate(operationId);
     }
 
-    public CompletableFuture<Operation> pollForOperationUpdates(String operationId, Duration delay) {
-        return checkpointManager.pollForUpdate(operationId, delay);
+    /**
+     * Pools for operation updates at a specific time
+     *
+     * @param operationId the operation id to poll for updates
+     * @param at the time to poll for updates
+     * @return a completable future that completes with the operation update
+     */
+    public CompletableFuture<Operation> pollForOperationUpdates(String operationId, Instant at) {
+        return checkpointManager.pollForUpdate(operationId, at);
     }
 
     // ===== Utilities =====

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.operation;
 
-import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -341,13 +341,13 @@ public abstract class BaseDurableOperation {
     }
 
     /**
-     * Polls the backend for updates to this operation after the specified delay.
+     * Polls the backend for updates to this operation at a specific time.
      *
-     * @param delay the delay before polling
+     * @param at the time to poll for updates
      * @return a future that completes with the updated operation
      */
-    protected CompletableFuture<Operation> pollForOperationUpdates(Duration delay) {
-        return executionManager.pollForOperationUpdates(getOperationId(), delay);
+    protected CompletableFuture<Operation> pollForOperationUpdates(Instant at) {
+        return executionManager.pollForOperationUpdates(getOperationId(), at);
     }
 
     /** Sends an operation update synchronously (blocks until the update is acknowledged). */

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.operation;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
@@ -87,10 +85,10 @@ public class StepOperation<T> extends SerializableDurableOperation<T> {
 
     private CompletableFuture<Void> pollReadyAndExecuteStepLogic(Operation existing, int attempt) {
         var nextAttemptInstant = existing.stepDetails().nextAttemptTimestamp();
-        return pollForOperationUpdates(Duration.between(Instant.now(), nextAttemptInstant))
+        return pollForOperationUpdates(nextAttemptInstant)
                 .thenCompose(op -> op.status() == OperationStatus.READY
                         ? CompletableFuture.completedFuture(op)
-                        : pollForOperationUpdates())
+                        : pollForOperationUpdates(nextAttemptInstant))
                 .thenRun(() -> executeStepLogic(attempt));
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitOperation.java
@@ -60,21 +60,14 @@ public class WaitOperation extends BaseDurableOperation implements DurableFuture
     }
 
     private void pollForWaitExpiration() {
-        // Always calculate remaining time from scheduledEndTimestamp if scheduledEndTimestamp exists
-        var remainingWaitTime = duration;
+        var scheduledEndTimestamp = Instant.now().plusMillis(duration.toMillis());
         var existing = getOperation();
         if (existing != null
                 && existing.waitDetails() != null
                 && existing.waitDetails().scheduledEndTimestamp() != null) {
-            remainingWaitTime =
-                    Duration.between(Instant.now(), existing.waitDetails().scheduledEndTimestamp());
-            // If the wait has already elapsed, poll immediately with a minimal positive interval
-            if (remainingWaitTime.isNegative() || remainingWaitTime.isZero()) {
-                remainingWaitTime = Duration.ofMillis(1);
-            }
+            scheduledEndTimestamp = existing.waitDetails().scheduledEndTimestamp();
         }
-        logger.debug("Remaining wait time: {} ms", remainingWaitTime.toMillis());
-        pollForOperationUpdates(remainingWaitTime);
+        pollForOperationUpdates(scheduledEndTimestamp);
     }
 
     @Override

--- a/sdk/src/main/java/software/amazon/lambda/durable/retry/PollingStrategies.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/retry/PollingStrategies.java
@@ -3,6 +3,7 @@
 package software.amazon.lambda.durable.retry;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Objects;
 
 /** Factory class for creating common polling strategies. */
@@ -66,5 +67,23 @@ public class PollingStrategies {
             throw new IllegalArgumentException("interval must be positive");
         }
         return (attempt) -> interval;
+    }
+
+    /**
+     * Creates a polling strategy that polls at a specific instant in time.
+     *
+     * @param instant The instant to poll at
+     * @return PollingStrategy that calculates delay until the specified instant
+     */
+    public static PollingStrategy at(Instant instant) {
+        Objects.requireNonNull(instant, "instant must not be null");
+        return (attempt) -> {
+            var duration = Duration.between(Instant.now(), instant);
+            if (duration.isNegative()) {
+                // as soon as possible
+                return Duration.ZERO;
+            }
+            return duration;
+        };
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/execution/CheckpointManagerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/execution/CheckpointManagerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -276,7 +277,7 @@ class CheckpointManagerTest {
                                 .build())
                         .build());
 
-        var future = batcher.pollForUpdate("op-1", Duration.ofMillis(100));
+        var future = batcher.pollForUpdate("op-1", Instant.now().plusMillis(100));
 
         var result = future.get(300, TimeUnit.MILLISECONDS);
 
@@ -410,7 +411,7 @@ class CheckpointManagerTest {
         });
 
         // Use explicit delay (fixed interval) — should NOT apply backoff
-        var future = backoffBatcher.pollForUpdate("op-1", Duration.ofMillis(20));
+        var future = backoffBatcher.pollForUpdate("op-1", Instant.now().plusMillis(20));
         var result = future.get(1000, TimeUnit.MILLISECONDS);
 
         assertEquals(operation, result);


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

When polling for step retries and wait operations, the delay is determined by the expiration timestamp, which could be negative. This was fine until we added custom polling strategy and the validation of delay not being negative. 

```
"ErrorMessage": "interval must be positive",
        "ErrorType": "java.lang.IllegalArgumentException",
        "ErrorData": "{\"cause\":null,\"stackTrace\":{\"classLoaderName\":null,\"moduleName\":\"java.base\",\"moduleVersion\":\"17.0.18\",\"methodName\":\"run\",\"fileName\":null,\"lineNumber\":-1,\"className\":\"java.lang.Thread\",\"nativeMethod\":false}],\"message\":\"interval must be positive\",\"suppressed\":[],\"localizedMessage\":\"interval must be positive\"}",
        "StackTrace": [
          "software.amazon.lambda.durable.retry.PollingStrategies|fixedDelay|PollingStrategies.java|66",
          "software.amazon.lambda.durable.execution.CheckpointManager|pollForUpdate|CheckpointManager.java|80",
          "software.amazon.lambda.durable.execution.ExecutionManager|pollForOperationUpdates|ExecutionManager.java|251",
          "software.amazon.lambda.durable.operation.BaseDurableOperation|pollForOperationUpdates|BaseDurableOperation.java|350",
          "software.amazon.lambda.durable.operation.StepOperation|pollReadyAndExecuteStepLogic|StepOperation.java|90",
          "software.amazon.lambda.durable.operation.StepOperation|replay|StepOperation.java|79",
          "software.amazon.lambda.durable.operation.BaseDurableOperation|execute|BaseDurableOperation.java|114",
          "software.amazon.lambda.durable.context.DurableContextImpl|stepAsync|DurableContextImpl.java|135",
          "software.amazon.lambda.durable.DurableContext|step|DurableContext.java|78",
          "software.amazon.lambda.durable.DurableContext|step|DurableContext.java|37",
          "software.amazon.lambda.durable.examples.WaitExample|lambda$handleRequest$3|WaitExample.java|44",
          "software.amazon.lambda.durable.operation.MapOperation|lambda$addAllItems$0|MapOperation.java|83",
          "software.amazon.lambda.durable.operation.ChildContextOperation|lambda$executeChildContext$0|ChildContextOperation.java|120",
          "software.amazon.lambda.durable.operation.BaseDurableOperation|lambda$runUserHandler$1|BaseDurableOperation.java|226",
          "java.util.concurrent.CompletableFuture$AsyncRun|run|null|-1",
          "java.util.concurrent.ThreadPoolExecutor|runWorker|null|-1",
          "java.util.concurrent.ThreadPoolExecutor$Worker|run|null|-1",
          "java.lang.Thread|run|null|-1"
        ]
```

Fix

Use the absolute time for polling when we know the exact expiration time of a specific operation. 

All the steps succeeded without the polling errors:

<img width="1012" height="875" alt="image" src="https://github.com/user-attachments/assets/43370885-ad03-4240-a959-65c3f58719d5" />


### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
