### PR TITLE
[fix]: fix exception types for child executions

### DIFF
--- a/examples/src/main/java/software/amazon/lambda/durable/examples/map/DeserializationFailedMapExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/map/DeserializationFailedMapExample.java
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples.map;
+
+import java.time.Duration;
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.MapConfig;
+import software.amazon.lambda.durable.examples.types.GreetingRequest;
+import software.amazon.lambda.durable.exception.SerDesException;
+import software.amazon.lambda.durable.serde.JacksonSerDes;
+
+/**
+ * Example demonstrating the map operation with the Durable Execution SDK.
+ *
+ * <p>This handler processes a list of names concurrently using {@code map()}, where each item runs in its own child
+ * context with full checkpoint-and-replay support.
+ *
+ * <ol>
+ *   <li>Create a list of names from the input
+ *   <li>Map over each name concurrently, applying a greeting transformation via a durable step
+ *   <li>Collect and join the results
+ * </ol>
+ */
+public class DeserializationFailedMapExample extends DurableHandler<GreetingRequest, String> {
+
+    @Override
+    public String handleRequest(GreetingRequest input, DurableContext context) {
+        var name = input.getName();
+        context.getLogger().info("Starting map example for {}", name);
+
+        var names = List.of(name, name.toUpperCase(), name.toLowerCase());
+
+        // Map over each name concurrently — each iteration runs in its own child context
+        var result = context.map(
+                "greet-all",
+                names,
+                String.class,
+                (item, index, ctx) -> {
+                    return ctx.step("greet-" + index, String.class, stepCtx -> {
+                        throw new RuntimeException("Failure from " + item + "!");
+                    });
+                },
+                MapConfig.builder().serDes(new FailedSerDes()).build());
+
+        context.getLogger().info("Map completed: allSucceeded={}, size={}", result.allSucceeded(), result.size());
+
+        context.wait("suspend and replay", Duration.ofSeconds(1));
+
+        return result.getError(0).errorMessage();
+    }
+
+    private static class FailedSerDes extends JacksonSerDes {
+
+        @Override
+        public <T> T deserialize(String json, TypeToken<T> typeToken) {
+            T result = super.deserialize(json, typeToken);
+            if (result instanceof RuntimeException ex) {
+                throw new SerDesException("Deserialization failed", ex);
+            }
+            return result;
+        }
+    }
+}

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/parallel/DeserializationFailedParallelExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/parallel/DeserializationFailedParallelExample.java
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples.parallel;
+
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.ParallelBranchConfig;
+import software.amazon.lambda.durable.config.ParallelConfig;
+import software.amazon.lambda.durable.exception.SerDesException;
+import software.amazon.lambda.durable.serde.JacksonSerDes;
+
+/**
+ * Example demonstrating parallel branch execution with the Durable Execution SDK.
+ *
+ * <p>This handler processes a list of items concurrently using {@code context.parallel()}:
+ *
+ * <ol>
+ *   <li>Each item is processed in its own branch (child context)
+ *   <li>All branches run concurrently and their results are collected
+ *   <li>A final step combines the results into a summary
+ * </ol>
+ *
+ * <p>The {@link ParallelDurableFuture} implements {@link AutoCloseable}, so try-with-resources guarantees
+ * {@code join()} is called even if an exception occurs.
+ */
+public class DeserializationFailedParallelExample
+        extends DurableHandler<DeserializationFailedParallelExample.Input, String> {
+
+    public record Input(List<String> items) {}
+
+    @Override
+    public String handleRequest(Input input, DurableContext context) {
+        var logger = context.getLogger();
+        var items = input.items();
+        logger.info("Starting parallel processing of {} items", items.size());
+
+        var config = ParallelConfig.builder().build();
+
+        var parallel = context.parallel("process-items", config);
+
+        try (parallel) {
+            var future = parallel.branch(
+                    "process",
+                    String.class,
+                    branchCtx -> {
+                        return branchCtx.step("transform", String.class, stepCtx -> {
+                            throw new RuntimeException("Intentional failure for transform");
+                        });
+                    },
+                    ParallelBranchConfig.builder().serDes(new FailedSerDes()).build());
+
+            parallel.get();
+            try {
+                return future.get();
+            } catch (Exception e) {
+                return e.getMessage();
+            }
+        }
+    }
+
+    private static class FailedSerDes extends JacksonSerDes {
+
+        @Override
+        public <T> T deserialize(String json, TypeToken<T> typeToken) {
+            T result = super.deserialize(json, typeToken);
+            if (result instanceof RuntimeException ex) {
+                throw new SerDesException("Deserialization failed", ex);
+            }
+            return result;
+        }
+    }
+}

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/step/DeserializationFailureExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/step/DeserializationFailureExample.java
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples.step;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.exception.SerDesException;
+import software.amazon.lambda.durable.serde.JacksonSerDes;
+
+public class DeserializationFailureExample extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        try {
+            context.step(
+                    "fail-step",
+                    String.class,
+                    stepCtx -> {
+                        throw new RuntimeException("this is a test");
+                    },
+                    StepConfig.builder().serDes(new FailedSerDes()).build());
+        } catch (Exception e) {
+            context.wait("suspend and replay", Duration.ofSeconds(1));
+            return e.getClass().getSimpleName() + ":" + e.getMessage();
+        }
+
+        throw new IllegalStateException("should not reach here");
+    }
+
+    private static class FailedSerDes extends JacksonSerDes {
+
+        @Override
+        public <T> T deserialize(String json, TypeToken<T> typeToken) {
+            T result = super.deserialize(json, typeToken);
+            if (result instanceof RuntimeException ex) {
+                throw new SerDesException("Deserialization failed", ex);
+            }
+            return result;
+        }
+    }
+}

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/map/DeserializationFailedMapExampleTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/map/DeserializationFailedMapExampleTest.java
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples.map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.examples.types.GreetingRequest;
+import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
+
+class DeserializationFailedMapExampleTest {
+
+    @Test
+    void testDeserializationFailedExample() {
+        var handler = new DeserializationFailedMapExample();
+        var runner = LocalDurableTestRunner.create(GreetingRequest.class, handler);
+
+        var result = runner.runUntilComplete(new GreetingRequest("Alice"));
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(
+                "Map iteration failed with error of type java.lang.RuntimeException. Message: Failure from Alice!",
+                result.getResult(String.class));
+    }
+}

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/parallel/DeserializationFailedParallelExampleTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/parallel/DeserializationFailedParallelExampleTest.java
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples.parallel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
+
+class DeserializationFailedParallelExampleTest {
+
+    @Test
+    void testDeserializationFailedParallelExample() {
+        var handler = new DeserializationFailedParallelExample();
+        var runner = LocalDurableTestRunner.create(DeserializationFailedParallelExample.Input.class, handler);
+
+        var input = new DeserializationFailedParallelExample.Input(List.of("apple", "banana", "cherry"));
+        var result = runner.runUntilComplete(input);
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+
+        var output = result.getResult(String.class);
+        assertEquals(
+                "Parallel branch failed with error of type java.lang.RuntimeException. Message: Intentional failure for transform",
+                output);
+    }
+}

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/step/DeserializationFailureExampleTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/step/DeserializationFailureExampleTest.java
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
+
+class DeserializationFailureExampleTest {
+
+    @Test
+    void testDeserializationExample() {
+        var handler = new DeserializationFailureExample();
+
+        // Create test runner from handler (automatically extracts config)
+        var runner = LocalDurableTestRunner.create(String.class, handler);
+
+        // Run with input
+        var result = runner.runUntilComplete("test-input");
+
+        // Verify result
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+
+        // assert StepFailedException is thrown when SerDes fails to deserialize the exception
+        assertEquals(
+                "StepFailedException:Step failed with error of type java.lang.RuntimeException. Message: this is a test",
+                result.getResult(String.class));
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/exception/MapIterationFailedException.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/exception/MapIterationFailedException.java
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.exception;
+
+import software.amazon.awssdk.services.lambda.model.ErrorObject;
+import software.amazon.awssdk.services.lambda.model.Operation;
+
+/** Thrown when a map iteration fails and deserialization of the original exception also fails. */
+public class MapIterationFailedException extends DurableOperationException {
+    public MapIterationFailedException(Operation operation) {
+        super(operation, getError(operation), formatMessage(getError(operation)));
+    }
+
+    private static ErrorObject getError(Operation operation) {
+        return operation.contextDetails() != null ? operation.contextDetails().error() : null;
+    }
+
+    private static String formatMessage(ErrorObject errorObject) {
+        if (errorObject == null) {
+            return "Map iteration failed without an error";
+        }
+        return String.format(
+                "Map iteration failed with error of type %s. Message: %s",
+                errorObject.errorType(), errorObject.errorMessage());
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/exception/ParallelBranchFailedException.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/exception/ParallelBranchFailedException.java
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.exception;
+
+import software.amazon.awssdk.services.lambda.model.ErrorObject;
+import software.amazon.awssdk.services.lambda.model.Operation;
+
+/** Thrown when a parallel branch fails and deserialization of the original exception also fails. */
+public class ParallelBranchFailedException extends DurableOperationException {
+    public ParallelBranchFailedException(Operation operation) {
+        super(operation, getError(operation), formatMessage(getError(operation)));
+    }
+
+    private static ErrorObject getError(Operation operation) {
+        return operation.contextDetails() != null ? operation.contextDetails().error() : null;
+    }
+
+    private static String formatMessage(ErrorObject errorObject) {
+        if (errorObject == null) {
+            return "Parallel branch failed without an error";
+        }
+        return String.format(
+                "Parallel branch failed with error of type %s. Message: %s",
+                errorObject.errorType(), errorObject.errorMessage());
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
@@ -23,6 +23,8 @@ import software.amazon.lambda.durable.exception.CallbackSubmitterException;
 import software.amazon.lambda.durable.exception.CallbackTimeoutException;
 import software.amazon.lambda.durable.exception.ChildContextFailedException;
 import software.amazon.lambda.durable.exception.DurableOperationException;
+import software.amazon.lambda.durable.exception.MapIterationFailedException;
+import software.amazon.lambda.durable.exception.ParallelBranchFailedException;
 import software.amazon.lambda.durable.exception.StepFailedException;
 import software.amazon.lambda.durable.exception.StepInterruptedException;
 import software.amazon.lambda.durable.exception.UnrecoverableDurableExecutionException;
@@ -217,12 +219,13 @@ public class ChildContextOperation<T> extends SerializableDurableOperation<T> {
             // throw a general failed exception if a user exception is not reconstructed
             return switch (getSubType()) {
                 case WAIT_FOR_CALLBACK -> handleWaitForCallbackFailure();
-                case MAP -> throw new ChildContextFailedException(op);
-                case MAP_ITERATION -> throw new ChildContextFailedException(op);
-                case PARALLEL -> throw new ChildContextFailedException(op);
-                case PARALLEL_BRANCH -> throw new ChildContextFailedException(op);
+                case MAP_ITERATION -> throw new MapIterationFailedException(op);
+                case PARALLEL_BRANCH -> throw new ParallelBranchFailedException(op);
                 case RUN_IN_CHILD_CONTEXT -> throw new ChildContextFailedException(op);
-                case WAIT_FOR_CONDITION -> throw new ChildContextFailedException(op);
+
+                // the following subtypes should not be able to reach here
+                case PARALLEL, MAP, WAIT_FOR_CONDITION ->
+                    throw new IllegalStateException("Unexpected sub-type: " + getSubType());
             };
         }
     }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ConcurrencyOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ConcurrencyOperation.java
@@ -116,8 +116,8 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
                 this);
     }
 
-    /** Called when the concurrency operation succeeds. Subclasses define checkpointing behavior. */
-    protected abstract void handleSuccess(ConcurrencyCompletionStatus concurrencyCompletionStatus);
+    /** Called when the concurrency operation completes. Subclasses define checkpointing behavior. */
+    protected abstract void handleCompletion(ConcurrencyCompletionStatus concurrencyCompletionStatus);
 
     // ========== Concurrency control ==========
 
@@ -173,7 +173,7 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
                 }
                 var completionStatus = canComplete(succeededCount, failedCount, runningChildren);
                 if (completionStatus != null) {
-                    handleSuccess(completionStatus);
+                    handleCompletion(completionStatus);
                     return;
                 }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
@@ -142,7 +142,7 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected void handleSuccess(ConcurrencyCompletionStatus concurrencyCompletionStatus) {
+    protected void handleCompletion(ConcurrencyCompletionStatus concurrencyCompletionStatus) {
         var children = getBranches();
         var resultItems = new ArrayList<MapResult.MapResultItem<O>>(Collections.nCopies(items.size(), null));
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
@@ -65,7 +65,7 @@ public class ParallelOperation extends ConcurrencyOperation<ParallelResult> impl
     }
 
     @Override
-    protected void handleSuccess(ConcurrencyCompletionStatus concurrencyCompletionStatus) {
+    protected void handleCompletion(ConcurrencyCompletionStatus concurrencyCompletionStatus) {
         var items = getBranches();
         int succeededCount = Math.toIntExact(items.stream()
                 .filter(item -> item.getOperation().status() == OperationStatus.SUCCEEDED)

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/ConcurrencyOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/ConcurrencyOperationTest.java
@@ -218,7 +218,7 @@ class ConcurrencyOperationTest {
         }
 
         @Override
-        protected void handleSuccess(ConcurrencyCompletionStatus completionStatus) {
+        protected void handleCompletion(ConcurrencyCompletionStatus completionStatus) {
             successHandled = true;
             // Simulate the checkpoint ACK that a real subclass would receive after sendOperationUpdate.
             // This drives completionFuture to completion so waitForOperationCompletion() unblocks.


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fixes: https://github.com/aws/aws-durable-execution-sdk-java/issues/253

### Description

Wrong exception type was thrown when deserialization of the error fails.

Fix:
- created specific types for map iteration and parallel branch

### Demo/Screenshots

added examples and tests for them

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable) created examples and tests 
