### PR TITLE
[fix]: use 1-based attempt number

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/WaitForConditionIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/WaitForConditionIntegrationTest.java
@@ -269,7 +269,7 @@ class WaitForConditionIntegrationTest {
             // Check function returns state + 1, starting from 0
             // So after check i, state = i + 1, and strategy receives that value
             assertEquals(i + 1, observedStates.get(i), "State at strategy call " + (i + 1));
-            assertEquals(i, observedAttempts.get(i), "Attempt at strategy call " + (i + 1));
+            assertEquals(i + 1, observedAttempts.get(i), "Attempt at strategy call " + (i + 1));
         }
     }
 }

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/TestOperation.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/TestOperation.java
@@ -88,6 +88,6 @@ public class TestOperation {
     /** Returns the current retry attempt number (0-based), defaulting to 0 if not available. */
     public int getAttempt() {
         var details = operation.stepDetails();
-        return details != null && details.attempt() != null ? details.attempt() : 0;
+        return details != null && details.attempt() != null ? details.attempt() : 1;
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/CheckpointManager.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/CheckpointManager.java
@@ -30,6 +30,7 @@ import software.amazon.lambda.durable.retry.PollingStrategy;
 class CheckpointManager {
     private static final int MAX_BATCH_SIZE_BYTES = 750 * 1024; // 750KB
     private static final int MAX_ITEM_COUNT = 200; // max updates in one batch
+    private static final int FIRST_ATTEMPT = 1;
     private static final Logger logger = LoggerFactory.getLogger(CheckpointManager.class);
 
     private final Consumer<List<Operation>> callback;
@@ -96,7 +97,7 @@ class CheckpointManager {
                     .computeIfAbsent(operationId, k -> Collections.synchronizedList(new ArrayList<>()))
                     .add(future);
         }
-        pollForUpdateInternal(future, 0, Instant.now(), pollingStrategy);
+        pollForUpdateInternal(future, FIRST_ATTEMPT, Instant.now(), pollingStrategy);
         return future;
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
@@ -33,7 +33,7 @@ import software.amazon.lambda.durable.util.ExceptionHelper;
  * @param <T> the result type of the step function
  */
 public class StepOperation<T> extends SerializableDurableOperation<T> {
-    private static final Integer FIRST_ATTEMPT = 0;
+    private static final Integer FIRST_ATTEMPT = 1;
 
     private final Function<StepContext, T> function;
     private final StepConfig config;
@@ -60,7 +60,7 @@ public class StepOperation<T> extends SerializableDurableOperation<T> {
     @Override
     protected void replay(Operation existing) {
         var attempt = existing.stepDetails() != null && existing.stepDetails().attempt() != null
-                ? existing.stepDetails().attempt()
+                ? existing.stepDetails().attempt() + 1
                 : FIRST_ATTEMPT;
         switch (existing.status()) {
             case SUCCEEDED, FAILED -> markAlreadyCompleted();

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitForConditionOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitForConditionOperation.java
@@ -36,6 +36,7 @@ import software.amazon.lambda.durable.util.ExceptionHelper;
  * @param <T> the type of state being polled
  */
 public class WaitForConditionOperation<T> extends SerializableDurableOperation<T> {
+    private static final Integer FIRST_ATTEMPT = 1;
 
     private final BiFunction<T, StepContext, WaitForConditionResult<T>> checkFunc;
     private final WaitForConditionConfig<T> config;
@@ -61,7 +62,7 @@ public class WaitForConditionOperation<T> extends SerializableDurableOperation<T
 
     @Override
     protected void start() {
-        executeCheckLogic(config.initialState(), 0);
+        executeCheckLogic(config.initialState(), FIRST_ATTEMPT);
     }
 
     @Override
@@ -99,7 +100,8 @@ public class WaitForConditionOperation<T> extends SerializableDurableOperation<T
 
     private void resumeCheckLoop(Operation existing) {
         var stepDetails = existing.stepDetails();
-        int attempt = (stepDetails != null && stepDetails.attempt() != null) ? stepDetails.attempt() : 0;
+        int attempt =
+                (stepDetails != null && stepDetails.attempt() != null) ? stepDetails.attempt() + 1 : FIRST_ATTEMPT;
         var checkpointData = stepDetails != null ? stepDetails.result() : null;
         T currentState; // Get current state
         if (checkpointData != null) {

--- a/sdk/src/main/java/software/amazon/lambda/durable/retry/PollingStrategies.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/retry/PollingStrategies.java
@@ -23,7 +23,7 @@ public class PollingStrategies {
     /**
      * Creates an exponential backoff polling strategy.
      *
-     * <p>The delay calculation follows the formula: delay = jitter(baseInterval × backoffRate^attempt)
+     * <p>The delay calculation follows the formula: delay = jitter(baseInterval × backoffRate^(attempt-1))
      *
      * @param baseInterval Base delay before first poll
      * @param backoffRate Multiplier for exponential backoff (must be positive)
@@ -49,7 +49,8 @@ public class PollingStrategies {
         }
 
         return (attempt) -> {
-            double delayMs = baseInterval.toMillis() * Math.pow(backoffRate, attempt);
+            // attempt is 1-based
+            double delayMs = baseInterval.toMillis() * Math.pow(backoffRate, attempt - 1);
             delayMs = Math.min(jitter.apply(delayMs), maxInterval.toMillis());
             return Duration.ofMillis(Math.round(delayMs));
         };

--- a/sdk/src/main/java/software/amazon/lambda/durable/retry/PollingStrategy.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/retry/PollingStrategy.java
@@ -11,7 +11,7 @@ public interface PollingStrategy {
     /**
      * Computes the delay before the next polling attempt.
      *
-     * @param attempt The current attempt number (0-based)
+     * @param attempt The current attempt number (1-based)
      * @return Duration to wait before the next poll
      */
     Duration computeDelay(int attempt);

--- a/sdk/src/main/java/software/amazon/lambda/durable/retry/RetryStrategies.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/retry/RetryStrategies.java
@@ -29,13 +29,13 @@ public class RetryStrategies {
                 );
 
         /** No retry strategy - fails immediately on first error. Use this for operations that should not be retried. */
-        public static final RetryStrategy NO_RETRY = (error, attemptNumber) -> RetryDecision.fail();
+        public static final RetryStrategy NO_RETRY = (error, attempt) -> RetryDecision.fail();
     }
 
     /**
      * Creates an exponential backoff retry strategy.
      *
-     * <p>The delay calculation follows the formula: baseDelay = min(initialDelay × backoffRate^attemptNumber, maxDelay)
+     * <p>The delay calculation follows the formula: baseDelay = min(initialDelay × backoffRate^(attempt-1), maxDelay)
      *
      * @param maxAttempts Maximum number of attempts (including initial attempt)
      * @param initialDelay Initial delay before first retry
@@ -56,9 +56,9 @@ public class RetryStrategies {
             throw new IllegalArgumentException("backoffRate must be positive");
         }
 
-        return (error, attemptNumber) -> {
-            // Check if we've exceeded max attempts (attemptNumber is 0-based)
-            if (attemptNumber + 1 >= maxAttempts) {
+        return (error, attempt) -> {
+            // Check if we've exceeded max attempts (attemptNumber is 1-based)
+            if (attempt >= maxAttempts) {
                 return RetryDecision.fail();
             }
 
@@ -66,7 +66,7 @@ public class RetryStrategies {
             double initialDelaySeconds = initialDelay.toSeconds();
             double maxDelaySeconds = maxDelay.toSeconds();
 
-            double baseDelay = Math.min(initialDelaySeconds * Math.pow(backoffRate, attemptNumber), maxDelaySeconds);
+            double baseDelay = Math.min(initialDelaySeconds * Math.pow(backoffRate, attempt - 1), maxDelaySeconds);
 
             // Apply jitter
             double delayWithJitter = jitter.apply(baseDelay);
@@ -92,8 +92,8 @@ public class RetryStrategies {
         }
         ParameterValidator.validateDuration(fixedDelay, "fixedDelay");
 
-        return (error, attemptNumber) -> {
-            if (attemptNumber + 1 >= maxAttempts) {
+        return (error, attempt) -> {
+            if (attempt >= maxAttempts) {
                 return RetryDecision.fail();
             }
             return RetryDecision.retry(fixedDelay);

--- a/sdk/src/main/java/software/amazon/lambda/durable/retry/RetryStrategy.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/retry/RetryStrategy.java
@@ -15,8 +15,8 @@ public interface RetryStrategy {
      * Determines whether to retry a failed operation and calculates the retry delay.
      *
      * @param error The error that occurred during the operation
-     * @param attemptNumber The current attempt number (0-based, so first attempt is 0)
+     * @param attempt The current attempt number (1-based, so first attempt is 1)
      * @return RetryDecision indicating whether to retry and the delay before next attempt
      */
-    RetryDecision makeRetryDecision(Throwable error, int attemptNumber);
+    RetryDecision makeRetryDecision(Throwable error, int attempt);
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/retry/WaitForConditionWaitStrategy.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/retry/WaitForConditionWaitStrategy.java
@@ -23,7 +23,7 @@ public interface WaitForConditionWaitStrategy<T> {
      * Computes the delay before the next polling attempt based on the current state and attempt number.
      *
      * @param state the current state returned by the check function
-     * @param attempt the attempt number
+     * @param attempt the attempt number (1-based)
      * @return a {@link Duration} representing the delay before the next polling attempt
      * @throws WaitForConditionFailedException if the maximum number of attempts has been exceeded
      */

--- a/sdk/src/main/java/software/amazon/lambda/durable/retry/WaitStrategies.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/retry/WaitStrategies.java
@@ -40,7 +40,7 @@ public final class WaitStrategies {
     /**
      * Creates an exponential backoff wait strategy.
      *
-     * <p>The delay calculation follows the formula: baseDelay = min(initialDelay × backoffRate^attempt, maxDelay)
+     * <p>The delay calculation follows the formula: baseDelay = min(initialDelay × backoffRate^(attempt-1), maxDelay)
      *
      * @param maxAttempts maximum number of attempts before throwing {@link WaitForConditionFailedException}
      * @param initialDelay initial delay before first retry
@@ -65,14 +65,15 @@ public final class WaitStrategies {
         }
 
         return (state, attempt) -> {
-            if (attempt + 1 >= maxAttempts) {
+            // attempt is 1-based
+            if (attempt >= maxAttempts) {
                 throw new WaitForConditionFailedException(
                         "waitForCondition exceeded maximum attempts (" + maxAttempts + ")");
             }
 
             double initialDelaySeconds = initialDelay.toSeconds();
             double maxDelaySeconds = maxDelay.toSeconds();
-            double baseDelay = Math.min(initialDelaySeconds * Math.pow(backoffRate, attempt), maxDelaySeconds);
+            double baseDelay = Math.min(initialDelaySeconds * Math.pow(backoffRate, attempt - 1), maxDelaySeconds);
             double delayWithJitter = jitter.apply(baseDelay);
             long finalDelaySeconds = Math.max(1, Math.round(delayWithJitter));
 
@@ -95,7 +96,7 @@ public final class WaitStrategies {
         ParameterValidator.validateDuration(fixedDelay, "fixedDelay");
 
         return (state, attempt) -> {
-            if (attempt + 1 >= maxAttempts) {
+            if (attempt >= maxAttempts) {
                 throw new WaitForConditionFailedException(
                         "waitForCondition exceeded maximum attempts (" + maxAttempts + ")");
             }

--- a/sdk/src/test/java/software/amazon/lambda/durable/retry/PollingStrategiesTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/retry/PollingStrategiesTest.java
@@ -18,7 +18,7 @@ class PollingStrategiesTest {
         // Default: base=1000ms, rate=2.0, jitter=FULL, maxInterval=10s
         // With FULL jitter, delay should be between 0 and base*rate^attempt
         for (int i = 0; i < 10; i++) {
-            var delay = strategy.computeDelay(0);
+            var delay = strategy.computeDelay(1);
             assertTrue(
                     delay.toMillis() >= 0 && delay.toMillis() <= 1000,
                     "Attempt 0 delay should be in [0, 1000]ms, got " + delay.toMillis());
@@ -29,10 +29,10 @@ class PollingStrategiesTest {
     void fixedDelay_computesFixedDelay() {
         var strategy = PollingStrategies.fixedDelay(Duration.ofMillis(500));
 
-        assertEquals(Duration.ofMillis(500), strategy.computeDelay(0));
         assertEquals(Duration.ofMillis(500), strategy.computeDelay(1));
         assertEquals(Duration.ofMillis(500), strategy.computeDelay(2));
         assertEquals(Duration.ofMillis(500), strategy.computeDelay(3));
+        assertEquals(Duration.ofMillis(500), strategy.computeDelay(4));
     }
 
     @Test
@@ -41,11 +41,11 @@ class PollingStrategiesTest {
                 PollingStrategies.exponentialBackoff(Duration.ofMillis(100), 2.0, JitterStrategy.NONE, DEFAULT_MAX);
 
         // delay = base * rate^attempt
-        assertEquals(100, strategy.computeDelay(0).toMillis()); // 100 * 2^0
-        assertEquals(200, strategy.computeDelay(1).toMillis()); // 100 * 2^1
-        assertEquals(400, strategy.computeDelay(2).toMillis()); // 100 * 2^2
-        assertEquals(800, strategy.computeDelay(3).toMillis()); // 100 * 2^3
-        assertEquals(1600, strategy.computeDelay(4).toMillis()); // 100 * 2^4
+        assertEquals(100, strategy.computeDelay(1).toMillis()); // 100 * 2^0
+        assertEquals(200, strategy.computeDelay(2).toMillis()); // 100 * 2^1
+        assertEquals(400, strategy.computeDelay(3).toMillis()); // 100 * 2^2
+        assertEquals(800, strategy.computeDelay(4).toMillis()); // 100 * 2^3
+        assertEquals(1600, strategy.computeDelay(5).toMillis()); // 100 * 2^4
     }
 
     @Test
@@ -53,10 +53,10 @@ class PollingStrategiesTest {
         var strategy =
                 PollingStrategies.exponentialBackoff(Duration.ofMillis(50), 3.0, JitterStrategy.NONE, DEFAULT_MAX);
 
-        assertEquals(50, strategy.computeDelay(0).toMillis()); // 50 * 3^0
-        assertEquals(150, strategy.computeDelay(1).toMillis()); // 50 * 3^1
-        assertEquals(450, strategy.computeDelay(2).toMillis()); // 50 * 3^2
-        assertEquals(1350, strategy.computeDelay(3).toMillis()); // 50 * 3^3
+        assertEquals(50, strategy.computeDelay(1).toMillis()); // 50 * 3^0
+        assertEquals(150, strategy.computeDelay(2).toMillis()); // 50 * 3^1
+        assertEquals(450, strategy.computeDelay(3).toMillis()); // 50 * 3^2
+        assertEquals(1350, strategy.computeDelay(4).toMillis()); // 50 * 3^3
     }
 
     @Test
@@ -65,11 +65,11 @@ class PollingStrategiesTest {
                 PollingStrategies.exponentialBackoff(Duration.ofMillis(100), 2.0, JitterStrategy.FULL, DEFAULT_MAX);
 
         for (int i = 0; i < 20; i++) {
-            var delay0 = strategy.computeDelay(0).toMillis();
+            var delay0 = strategy.computeDelay(1).toMillis();
             assertTrue(
                     delay0 >= 0 && delay0 <= 100, "Attempt 0 with FULL jitter should be in [0, 100]ms, got " + delay0);
 
-            var delay2 = strategy.computeDelay(2).toMillis();
+            var delay2 = strategy.computeDelay(3).toMillis();
             assertTrue(
                     delay2 >= 0 && delay2 <= 400, "Attempt 2 with FULL jitter should be in [0, 400]ms, got " + delay2);
         }
@@ -81,12 +81,12 @@ class PollingStrategiesTest {
                 PollingStrategies.exponentialBackoff(Duration.ofMillis(100), 2.0, JitterStrategy.HALF, DEFAULT_MAX);
 
         for (int i = 0; i < 20; i++) {
-            var delay0 = strategy.computeDelay(0).toMillis();
+            var delay0 = strategy.computeDelay(1).toMillis();
             assertTrue(
                     delay0 >= 50 && delay0 <= 100,
                     "Attempt 0 with HALF jitter should be in [50, 100]ms, got " + delay0);
 
-            var delay2 = strategy.computeDelay(2).toMillis();
+            var delay2 = strategy.computeDelay(3).toMillis();
             assertTrue(
                     delay2 >= 200 && delay2 <= 400,
                     "Attempt 2 with HALF jitter should be in [200, 400]ms, got " + delay2);
@@ -102,12 +102,12 @@ class PollingStrategiesTest {
         var strategy = PollingStrategies.exponentialBackoff(
                 Duration.ofMillis(100), 2.0, JitterStrategy.NONE, Duration.ofMillis(500));
 
-        assertEquals(100, strategy.computeDelay(0).toMillis()); // 100 < 500
-        assertEquals(200, strategy.computeDelay(1).toMillis()); // 200 < 500
-        assertEquals(400, strategy.computeDelay(2).toMillis()); // 400 < 500
-        assertEquals(500, strategy.computeDelay(3).toMillis()); // 800 → capped to 500
-        assertEquals(500, strategy.computeDelay(4).toMillis()); // 1600 → capped to 500
-        assertEquals(500, strategy.computeDelay(10).toMillis()); // huge → capped to 500
+        assertEquals(100, strategy.computeDelay(1).toMillis()); // 100 < 500
+        assertEquals(200, strategy.computeDelay(2).toMillis()); // 200 < 500
+        assertEquals(400, strategy.computeDelay(3).toMillis()); // 400 < 500
+        assertEquals(500, strategy.computeDelay(4).toMillis()); // 800 → capped to 500
+        assertEquals(500, strategy.computeDelay(5).toMillis()); // 1600 → capped to 500
+        assertEquals(500, strategy.computeDelay(11).toMillis()); // huge → capped to 500
     }
 
     @Test
@@ -120,7 +120,7 @@ class PollingStrategiesTest {
         for (int i = 0; i < 50; i++) {
             // At attempt 5, uncapped range would be [0, 3200]ms
             // After maxInterval cap, should never exceed 300ms
-            var delay = strategy.computeDelay(i).toMillis();
+            var delay = strategy.computeDelay(i + 1).toMillis();
             assertTrue(delay >= 0 && delay <= 300, "Delay should be capped at maxInterval=300ms, got " + delay + "ms");
         }
     }
@@ -132,7 +132,7 @@ class PollingStrategiesTest {
         // Default: base=1000ms, rate=2.0, FULL jitter, maxInterval=10s
         // At high attempts, uncapped delay would be huge, but should cap at 10s
         for (int i = 0; i < 20; i++) {
-            var delay = strategy.computeDelay(i).toMillis();
+            var delay = strategy.computeDelay(i + 1).toMillis();
             assertTrue(delay <= 10_000, "Default preset should cap at 10s maxInterval, got " + delay + "ms");
         }
     }

--- a/sdk/src/test/java/software/amazon/lambda/durable/retry/RetryStrategiesTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/retry/RetryStrategiesTest.java
@@ -15,9 +15,9 @@ class RetryStrategiesTest {
         var strategy = RetryStrategies.Presets.NO_RETRY;
 
         // Should never retry regardless of attempt number
-        var decision1 = strategy.makeRetryDecision(new RuntimeException("test"), 0);
-        var decision2 = strategy.makeRetryDecision(new RuntimeException("test"), 1);
-        var decision3 = strategy.makeRetryDecision(new RuntimeException("test"), 5);
+        var decision1 = strategy.makeRetryDecision(new RuntimeException("test"), 1);
+        var decision2 = strategy.makeRetryDecision(new RuntimeException("test"), 2);
+        var decision3 = strategy.makeRetryDecision(new RuntimeException("test"), 6);
 
         assertFalse(decision1.shouldRetry());
         assertFalse(decision2.shouldRetry());
@@ -29,14 +29,14 @@ class RetryStrategiesTest {
         var strategy = RetryStrategies.Presets.DEFAULT;
 
         // Should retry for first 5 attempts (0-4), fail on 6th (5)
-        for (int attempt = 0; attempt < 5; attempt++) {
+        for (int attempt = 1; attempt <= 5; attempt++) {
             var decision = strategy.makeRetryDecision(new RuntimeException("test"), attempt);
             assertTrue(decision.shouldRetry(), "Should retry on attempt " + attempt);
             assertTrue(decision.delay().toSeconds() >= 1, "Delay should be at least 1 second");
         }
 
         // Should not retry on 6th attempt (attempt number 5)
-        var finalDecision = strategy.makeRetryDecision(new RuntimeException("test"), 5);
+        var finalDecision = strategy.makeRetryDecision(new RuntimeException("test"), 6);
         assertFalse(finalDecision.shouldRetry());
     }
 
@@ -52,16 +52,16 @@ class RetryStrategiesTest {
                 );
 
         // Verify delay calculation: initialDelay * backoffRate^attemptNumber
-        var decision0 = strategy.makeRetryDecision(new RuntimeException("test"), 0);
+        var decision0 = strategy.makeRetryDecision(new RuntimeException("test"), 1);
         assertEquals(2, decision0.delay().toSeconds()); // 2 * 2^0 = 2
 
-        var decision1 = strategy.makeRetryDecision(new RuntimeException("test"), 1);
+        var decision1 = strategy.makeRetryDecision(new RuntimeException("test"), 2);
         assertEquals(4, decision1.delay().toSeconds()); // 2 * 2^1 = 4
 
-        var decision2 = strategy.makeRetryDecision(new RuntimeException("test"), 2);
+        var decision2 = strategy.makeRetryDecision(new RuntimeException("test"), 3);
         assertEquals(8, decision2.delay().toSeconds()); // 2 * 2^2 = 8
 
-        var decision3 = strategy.makeRetryDecision(new RuntimeException("test"), 3);
+        var decision3 = strategy.makeRetryDecision(new RuntimeException("test"), 4);
         assertEquals(16, decision3.delay().toSeconds()); // 2 * 2^3 = 16
     }
 
@@ -76,7 +76,7 @@ class RetryStrategiesTest {
                 );
 
         // Should be capped at maxDelay
-        var decision = strategy.makeRetryDecision(new RuntimeException("test"), 5);
+        var decision = strategy.makeRetryDecision(new RuntimeException("test"), 6);
         assertEquals(20, decision.delay().toSeconds()); // Would be 5 * 2^5 = 160, but capped at 20
     }
 
@@ -93,9 +93,9 @@ class RetryStrategiesTest {
 
         // Test multiple times due to randomness
         for (int i = 0; i < 10; i++) {
-            var noneDecision = noneStrategy.makeRetryDecision(new RuntimeException("test"), 1);
-            var fullDecision = fullStrategy.makeRetryDecision(new RuntimeException("test"), 1);
-            var halfDecision = halfStrategy.makeRetryDecision(new RuntimeException("test"), 1);
+            var noneDecision = noneStrategy.makeRetryDecision(new RuntimeException("test"), 2);
+            var fullDecision = fullStrategy.makeRetryDecision(new RuntimeException("test"), 2);
+            var halfDecision = halfStrategy.makeRetryDecision(new RuntimeException("test"), 2);
 
             // NONE should always be exactly 20 (10 * 2^1)
             assertEquals(20, noneDecision.delay().toSeconds());
@@ -116,7 +116,7 @@ class RetryStrategiesTest {
         var strategy = RetryStrategies.exponentialBackoff(
                 5, Duration.ofSeconds(1), Duration.ofSeconds(60), 1.0, JitterStrategy.FULL);
 
-        var decision = strategy.makeRetryDecision(new RuntimeException("test"), 0);
+        var decision = strategy.makeRetryDecision(new RuntimeException("test"), 1);
         assertTrue(decision.delay().toSeconds() >= 1, "Delay should be at least 1 second");
     }
 
@@ -125,8 +125,8 @@ class RetryStrategiesTest {
         var strategy = RetryStrategies.fixedDelay(3, Duration.ofSeconds(5));
 
         // Should retry with fixed delay for first 2 attempts
-        var decision1 = strategy.makeRetryDecision(new RuntimeException("test"), 0);
-        var decision2 = strategy.makeRetryDecision(new RuntimeException("test"), 1);
+        var decision1 = strategy.makeRetryDecision(new RuntimeException("test"), 1);
+        var decision2 = strategy.makeRetryDecision(new RuntimeException("test"), 2);
 
         assertTrue(decision1.shouldRetry());
         assertTrue(decision2.shouldRetry());
@@ -134,7 +134,7 @@ class RetryStrategiesTest {
         assertEquals(5, decision2.delay().toSeconds());
 
         // Should not retry on 3rd attempt
-        var decision3 = strategy.makeRetryDecision(new RuntimeException("test"), 2);
+        var decision3 = strategy.makeRetryDecision(new RuntimeException("test"), 3);
         assertFalse(decision3.shouldRetry());
     }
 
@@ -243,9 +243,9 @@ class RetryStrategiesTest {
         assertNotNull(config2.retryStrategy());
         assertNotNull(config3.retryStrategy());
 
-        var decision1 = config1.retryStrategy().makeRetryDecision(new RuntimeException("test"), 0);
-        var decision2 = config2.retryStrategy().makeRetryDecision(new RuntimeException("test"), 0);
-        var decision3 = config3.retryStrategy().makeRetryDecision(new RuntimeException("test"), 0);
+        var decision1 = config1.retryStrategy().makeRetryDecision(new RuntimeException("test"), 1);
+        var decision2 = config2.retryStrategy().makeRetryDecision(new RuntimeException("test"), 1);
+        var decision3 = config3.retryStrategy().makeRetryDecision(new RuntimeException("test"), 1);
 
         assertTrue(decision1.shouldRetry());
         assertFalse(decision2.shouldRetry());
@@ -257,11 +257,11 @@ class RetryStrategiesTest {
         var strategy = RetryStrategies.exponentialBackoff(
                 5, Duration.ofSeconds(2), Duration.ofSeconds(60), 2.0, JitterStrategy.NONE);
 
-        var decision0 = strategy.makeRetryDecision(new RuntimeException("test"), 0);
-        var decision1 = strategy.makeRetryDecision(new RuntimeException("test"), 1);
-        var decision2 = strategy.makeRetryDecision(new RuntimeException("test"), 2);
-        var decision3 = strategy.makeRetryDecision(new RuntimeException("test"), 3);
-        var decision4 = strategy.makeRetryDecision(new RuntimeException("test"), 4);
+        var decision0 = strategy.makeRetryDecision(new RuntimeException("test"), 1);
+        var decision1 = strategy.makeRetryDecision(new RuntimeException("test"), 2);
+        var decision2 = strategy.makeRetryDecision(new RuntimeException("test"), 3);
+        var decision3 = strategy.makeRetryDecision(new RuntimeException("test"), 4);
+        var decision4 = strategy.makeRetryDecision(new RuntimeException("test"), 5);
 
         assertTrue(decision0.shouldRetry());
         assertEquals(2, decision0.delay().toSeconds());

--- a/sdk/src/test/java/software/amazon/lambda/durable/retry/WaitStrategiesTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/retry/WaitStrategiesTest.java
@@ -37,10 +37,10 @@ class WaitStrategiesTest {
         var strategy = WaitStrategies.<String>exponentialBackoff(
                 60, Duration.ofSeconds(2), Duration.ofSeconds(60), 2.0, JitterStrategy.NONE);
 
-        assertEquals(Duration.ofSeconds(2), strategy.evaluate("x", 0));
-        assertEquals(Duration.ofSeconds(4), strategy.evaluate("x", 1));
-        assertEquals(Duration.ofSeconds(8), strategy.evaluate("x", 2));
-        assertEquals(Duration.ofSeconds(16), strategy.evaluate("x", 3));
+        assertEquals(Duration.ofSeconds(2), strategy.evaluate("x", 1));
+        assertEquals(Duration.ofSeconds(4), strategy.evaluate("x", 2));
+        assertEquals(Duration.ofSeconds(8), strategy.evaluate("x", 3));
+        assertEquals(Duration.ofSeconds(16), strategy.evaluate("x", 4));
     }
 
     @Test
@@ -57,10 +57,10 @@ class WaitStrategiesTest {
         var strategy = WaitStrategies.<String>exponentialBackoff(
                 3, Duration.ofSeconds(5), Duration.ofSeconds(300), 1.5, JitterStrategy.NONE);
 
-        assertEquals(Duration.ofSeconds(5), strategy.evaluate("x", 0));
-        assertEquals(Duration.ofSeconds(8), strategy.evaluate("x", 1));
+        assertEquals(Duration.ofSeconds(5), strategy.evaluate("x", 1));
+        assertEquals(Duration.ofSeconds(8), strategy.evaluate("x", 2));
 
-        var exception = assertThrows(WaitForConditionFailedException.class, () -> strategy.evaluate("x", 2));
+        var exception = assertThrows(WaitForConditionFailedException.class, () -> strategy.evaluate("x", 3));
         assertTrue(exception.getMessage().contains("maximum attempts"));
         assertTrue(exception.getMessage().contains("3"));
     }
@@ -81,7 +81,7 @@ class WaitStrategiesTest {
                 60, Duration.ofSeconds(10), Duration.ofSeconds(60), 2.0, JitterStrategy.HALF);
 
         // attempt 1: base = 20, HALF jitter -> [10, 20]
-        var delay = strategy.evaluate("x", 1).toSeconds();
+        var delay = strategy.evaluate("x", 2).toSeconds();
         assertTrue(delay >= 10 && delay <= 20, "HALF jitter delay should be in [10, 20], got: " + delay);
     }
 
@@ -97,7 +97,7 @@ class WaitStrategiesTest {
     @Test
     void fixedDelay_maxAttemptsExceeded_throwsException() {
         var strategy = WaitStrategies.<String>fixedDelay(3, Duration.ofSeconds(5));
-        assertThrows(WaitForConditionFailedException.class, () -> strategy.evaluate("x", 2));
+        assertThrows(WaitForConditionFailedException.class, () -> strategy.evaluate("x", 3));
     }
 
     // ---- Validation ----
@@ -135,7 +135,7 @@ class WaitStrategiesTest {
         long initialDelaySeconds = 1 + random.nextInt(30);
         double backoffRate = 1.0 + random.nextDouble() * 4.0;
         long maxDelaySeconds = initialDelaySeconds + random.nextInt(600);
-        int attempt = random.nextInt(20);
+        int attempt = random.nextInt(20) + 1;
 
         var strategy = WaitStrategies.<String>exponentialBackoff(
                 100,
@@ -146,7 +146,7 @@ class WaitStrategiesTest {
 
         var delay = strategy.evaluate("x", attempt);
         var actualDelay = delay.toSeconds();
-        double expectedRaw = Math.min(initialDelaySeconds * Math.pow(backoffRate, attempt), maxDelaySeconds);
+        double expectedRaw = Math.min(initialDelaySeconds * Math.pow(backoffRate, attempt - 1), maxDelaySeconds);
         long expectedDelay = Math.max(1, Math.round(expectedRaw));
 
         assertEquals(
@@ -164,7 +164,7 @@ class WaitStrategiesTest {
         var random = new Random();
 
         int maxAttempts = 1 + random.nextInt(50);
-        int attemptOverMax = maxAttempts - 1 + random.nextInt(20);
+        int attemptOverMax = maxAttempts + random.nextInt(20);
 
         var strategy = WaitStrategies.<String>exponentialBackoff(
                 maxAttempts, Duration.ofSeconds(5), Duration.ofSeconds(300), 1.5, JitterStrategy.NONE);
@@ -187,7 +187,7 @@ class WaitStrategiesTest {
         var strategy = WaitStrategies.<String>exponentialBackoff(
                 100, Duration.ofSeconds(delaySeconds), Duration.ofSeconds(300), 1.0, JitterStrategy.NONE);
 
-        var delay = strategy.evaluate("x", 0);
+        var delay = strategy.evaluate("x", 1);
         assertEquals(delaySeconds, delay.toSeconds(), "NONE jitter should produce exact delay");
     }
 
@@ -199,7 +199,7 @@ class WaitStrategiesTest {
         var strategy = WaitStrategies.<String>exponentialBackoff(
                 100, Duration.ofSeconds(delaySeconds), Duration.ofSeconds(300), 1.0, JitterStrategy.FULL);
 
-        var delay = strategy.evaluate("x", 0);
+        var delay = strategy.evaluate("x", 1);
         var actualDelay = delay.toSeconds();
         assertTrue(
                 actualDelay >= 1 && actualDelay <= delaySeconds,
@@ -214,7 +214,7 @@ class WaitStrategiesTest {
         var strategy = WaitStrategies.<String>exponentialBackoff(
                 100, Duration.ofSeconds(delaySeconds), Duration.ofSeconds(300), 1.0, JitterStrategy.HALF);
 
-        var delay = strategy.evaluate("x", 0);
+        var delay = strategy.evaluate("x", 1);
         var actualDelay = delay.toSeconds();
         long minExpected = Math.max(1, Math.round(delaySeconds / 2.0));
         assertTrue(


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

Currently all the attempt parameter is 0-based, which doesn't align with backend (users see in execution history) or the javascript SDK.

Fix:
use 1-based attempt parameter

Impact:
- retry strategies used in step operation
- wait strategy used in waitForCondition operation
- polling strategy used in background polling mechanism

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
