### PR TITLE
[test]: add a negative case for WaitForCallback

### DIFF
--- a/examples/src/main/java/software/amazon/lambda/durable/examples/callback/WaitForCallbackFailedExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/callback/WaitForCallbackFailedExample.java
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples.callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.config.WaitForCallbackConfig;
+import software.amazon.lambda.durable.examples.types.ApprovalRequest;
+import software.amazon.lambda.durable.exception.SerDesException;
+import software.amazon.lambda.durable.serde.JacksonSerDes;
+
+public class WaitForCallbackFailedExample extends DurableHandler<ApprovalRequest, String> {
+
+    @Override
+    public String handleRequest(ApprovalRequest input, DurableContext context) {
+
+        String approvalResult;
+
+        try {
+            approvalResult = context.waitForCallback(
+                    "preapproval",
+                    String.class,
+                    (callbackId, ctx) -> {
+                        ctx.getLogger().info("Sending callback {} to preapproval system", callbackId);
+                        throw new RuntimeException("Submitter failed with an exception");
+                    },
+                    WaitForCallbackConfig.builder()
+                            .stepConfig(StepConfig.builder()
+                                    .serDes(new FailedSerDes())
+                                    .build())
+                            .build());
+        } catch (Exception ex) {
+            return ex.getClass().getSimpleName() + ":" + ex.getMessage();
+        }
+
+        return approvalResult;
+    }
+
+    private static class FailedSerDes extends JacksonSerDes {
+        @Override
+        public <T> T deserialize(String json, TypeToken<T> typeToken) {
+            T result = super.deserialize(json, typeToken);
+            if (result instanceof RuntimeException ex) {
+                throw new SerDesException("Deserialization failed", ex);
+            }
+            return result;
+        }
+    }
+}

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/callback/WaitForCallbackFailedExampleTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/callback/WaitForCallbackFailedExampleTest.java
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples.callback;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.examples.types.ApprovalRequest;
+import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
+
+class WaitForCallbackFailedExampleTest {
+
+    @Test
+    void testWaitForCallbackFailedExample() {
+        var handler = new WaitForCallbackFailedExample();
+        var runner = LocalDurableTestRunner.create(ApprovalRequest.class, handler);
+
+        var input = new ApprovalRequest("New laptop", 1500.00);
+
+        // First run - prepares request and creates callback, then suspends
+        var result = runner.runUntilComplete(input);
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+
+        // Verify the callback was created
+        assertEquals(
+                "CallbackSubmitterException:Step failed with error of type java.lang.RuntimeException. Message: Submitter failed with an exception",
+                result.getResult(String.class));
+    }
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

add a negative case to cover deserialization failures in WaitForCallback operation

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
