### PR TITLE
Add ctx.parallel() to features and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Your durable function extends `DurableHandler<I, O>` and implements `handleReque
 - `ctx.invoke()` – Invoke another Lambda function and wait for the result
 - `ctx.runInChildContext()` – Run an isolated child context with its own checkpoint log
 - `ctx.map()` – Apply a function to each item in a collection concurrently
+- `ctx.parallel()` - Run multiple operations concurrently with optional concurrency control
 - `ctx.waitForCondition()` – Poll a condition function until it signals done, suspending between polls
 
 ## Quick Start
@@ -96,6 +97,7 @@ See [Deploy Lambda durable functions with Infrastructure as Code](https://docs.a
 - [<u>Invoke</u>](docs/core/invoke.md) - Call other durable functions
 - [<u>Child Contexts</u>](docs/core/child-contexts.md) - Organize complex workflows into isolated units
 - [<u>Map</u>](docs/core/map.md) - Apply a function across a collection concurrently
+- [<u>Parallel</u>](docs/core/parallel.md) - Run multiple operations concurrently with optional concurrency control
 - [<u>Wait for Condition</u>](docs/core/wait-for-condition.md) - Poll a condition until it's met, with configurable backoff
 
 **Examples**


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

Add parallel operation to README

### Demo/Screenshots

Preview: https://github.com/aws/aws-durable-execution-sdk-java/blob/f5b0859ddbdeb6be9375f5e2319d3669b822e189/README.md

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
