### PR TITLE
[bugfix]: fix polling

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
@@ -293,6 +293,14 @@ public class ExecutionManager implements AutoCloseable {
         throw ex;
     }
 
+    /**
+     * returns {@code true} if the execution is terminated exceptionally (with a {@link SuspendExecutionException} or an
+     * unrecoverable error).
+     */
+    public boolean isExecutionCompletedExceptionally() {
+        return executionExceptionFuture.isCompletedExceptionally();
+    }
+
     private void stopAllOperations(Exception cause) {
         registeredOperations.values().forEach(op -> op.getCompletionFuture().completeExceptionally(cause));
     }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -229,6 +229,11 @@ public abstract class BaseDurableOperation {
             executionManager.setCurrentThreadContext(new ThreadContext(contextId, threadType));
             try {
                 runnable.run();
+            } catch (Throwable throwable) {
+                // Operations always wrap the user's function and handles all possible exceptions.
+                logger.error("An unhandled exception is thrown from user function: ", throwable);
+                throw terminateExecutionWithIllegalDurableOperationException(
+                        "An unhandled exception is thrown from user function: " + throwable);
             } finally {
                 if (contextId != null) {
                     try {

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -230,10 +230,14 @@ public abstract class BaseDurableOperation {
             try {
                 runnable.run();
             } catch (Throwable throwable) {
-                // Operations always wrap the user's function and handles all possible exceptions.
-                logger.error("An unhandled exception is thrown from user function: ", throwable);
-                throw terminateExecutionWithIllegalDurableOperationException(
-                        "An unhandled exception is thrown from user function: " + throwable);
+                // Operations always wrap the user's function and handles all possible exceptions except for
+                // SuspendExecutionException.
+                if (!executionManager.isExecutionCompletedExceptionally()
+                        && !(throwable instanceof SuspendExecutionException)) {
+                    logger.error("An unhandled exception is thrown from user function: ", throwable);
+                    throw terminateExecutionWithIllegalDurableOperationException(
+                            "An unhandled exception is thrown from user function: " + throwable);
+                }
             } finally {
                 if (contextId != null) {
                     try {

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.operation;
 
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
@@ -74,7 +75,7 @@ public class StepOperation<T> extends SerializableDurableOperation<T> {
                 }
             }
             // Step is pending retry - Start polling for PENDING -> READY transition
-            case PENDING -> pollReadyAndExecuteStepLogic(existing, attempt);
+            case PENDING -> pollReadyAndExecuteStepLogic(existing.stepDetails().nextAttemptTimestamp(), attempt);
             // Execute with current attempt
             case READY -> executeStepLogic(attempt);
             default ->
@@ -83,9 +84,8 @@ public class StepOperation<T> extends SerializableDurableOperation<T> {
         }
     }
 
-    private CompletableFuture<Void> pollReadyAndExecuteStepLogic(Operation existing, int attempt) {
-        var nextAttemptInstant = existing.stepDetails().nextAttemptTimestamp();
-        return pollForOperationUpdates(nextAttemptInstant)
+    private void pollReadyAndExecuteStepLogic(Instant nextAttemptInstant, int attempt) {
+        pollForOperationUpdates(nextAttemptInstant)
                 .thenCompose(op -> op.status() == OperationStatus.READY
                         ? CompletableFuture.completedFuture(op)
                         : pollForOperationUpdates(nextAttemptInstant))
@@ -163,19 +163,19 @@ public class StepOperation<T> extends SerializableDurableOperation<T> {
 
         if (isRetryable && retryDecision.shouldRetry()) {
             // Send RETRY
+            var retryDelayInSeconds = Math.toIntExact(retryDecision.delay().toSeconds());
             var retryUpdate = OperationUpdate.builder()
                     .action(OperationAction.RETRY)
                     .error(errorObject)
                     .stepOptions(StepOptions.builder()
                             // RetryDecisions always produce integer number of seconds greater or equals to
                             // 1 (no sub-second numbers)
-                            .nextAttemptDelaySeconds(
-                                    Math.toIntExact(retryDecision.delay().toSeconds()))
+                            .nextAttemptDelaySeconds(retryDelayInSeconds)
                             .build());
             sendOperationUpdate(retryUpdate);
 
             // Poll for READY status and then execute the step again
-            pollReadyAndExecuteStepLogic(getOperation(), attempt + 1);
+            pollReadyAndExecuteStepLogic(Instant.now().plusSeconds(retryDelayInSeconds), attempt + 1);
         } else {
             // Send FAIL - retries exhausted
             var failUpdate =


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fixes #295 

### Description

The step operation throws a `NullPointerException` when it fails and polls for the next attempt.

The exception is thrown because the `nextAttemptTimestamp` parameter is null when setting up the polling.

The exception was swallowed, leaving the polling unset.

Fix:

- catch the unhandled exception thrown from operations (including step operation in this case) and terminate the execution. This will help us detect this issue as well as similar issues in future
- fix the null pointer exception in Step operation when handling a failed step attempt

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
