### PR TITLE
[testing]: make local runner checkpoint API return only updated operations

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
@@ -76,7 +76,7 @@ class ParallelIntegrationTest {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("partial-fail", config);
+            ParallelDurableFuture parallel = context.parallel("partial-fail", config);
 
             try (parallel) {
                 futures.add(parallel.branch("branch-a", String.class, ctx -> "A"));
@@ -322,7 +322,7 @@ class ParallelIntegrationTest {
     void testSequentialParallelBlocks() {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var futures1 = new ArrayList<DurableFuture<String>>();
-            var parallel1 =
+            ParallelDurableFuture parallel1 =
                     context.parallel("parallel-1", ParallelConfig.builder().build());
             try (parallel1) {
                 futures1.add(parallel1.branch("branch-a", String.class, ctx -> "A"));
@@ -330,7 +330,7 @@ class ParallelIntegrationTest {
             }
 
             var futures2 = new ArrayList<DurableFuture<String>>();
-            var parallel2 =
+            ParallelDurableFuture parallel2 =
                     context.parallel("parallel-2", ParallelConfig.builder().build());
             try (parallel2) {
                 futures2.add(parallel2.branch("branch-x", String.class, ctx -> "x!"));
@@ -354,7 +354,7 @@ class ParallelIntegrationTest {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("replay-fail-parallel", config);
+            ParallelDurableFuture parallel = context.parallel("replay-fail-parallel", config);
 
             try (parallel) {
                 futures.add(parallel.branch("branch-ok", String.class, ctx -> {
@@ -371,7 +371,7 @@ class ParallelIntegrationTest {
                 }));
             }
 
-            var result = parallel.get();
+            parallel.get();
             assertEquals("OK", futures.get(0).get());
             assertEquals("OK2", futures.get(2).get());
             return "done";
@@ -392,7 +392,7 @@ class ParallelIntegrationTest {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("single-branch", config);
+            ParallelDurableFuture parallel = context.parallel("single-branch", config);
 
             try (parallel) {
                 futures.add(parallel.branch(
@@ -418,7 +418,7 @@ class ParallelIntegrationTest {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("wait-replay-parallel", config);
+            ParallelDurableFuture parallel = context.parallel("wait-replay-parallel", config);
 
             try (parallel) {
                 for (var item : List.of("a", "b")) {
@@ -546,7 +546,7 @@ class ParallelIntegrationTest {
                     .completionConfig(CompletionConfig.toleratedFailureCount(1))
                     .build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("tolerated-fail", config);
+            ParallelDurableFuture parallel = context.parallel("tolerated-fail", config);
 
             try (parallel) {
                 futures.add(parallel.branch("branch-ok", String.class, ctx -> "OK"));
@@ -617,7 +617,7 @@ class ParallelIntegrationTest {
                     .completionConfig(CompletionConfig.allSuccessful())
                     .build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("all-successful", config);
+            ParallelDurableFuture parallel = context.parallel("all-successful", config);
 
             try (parallel) {
                 futures.add(parallel.branch("branch-ok1", String.class, ctx -> "OK1"));

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
@@ -580,7 +580,7 @@ class ParallelIntegrationTest {
                     .completionConfig(CompletionConfig.minSuccessful(2))
                     .build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("min-successful", config);
+            ParallelDurableFuture parallel = context.parallel("min-successful", config);
 
             try (parallel) {
                 for (var item : List.of("a", "b", "c", "d", "e")) {

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
@@ -340,8 +340,7 @@ public class LocalDurableTestRunner<I, O> {
                 .build();
 
         // Load previous operations and include them in InitialExecutionState
-        var existingOps =
-                storage.getExecutionState(executionArn, "test-token", null).operations();
+        var existingOps = storage.getAllOperations();
         var allOps = new ArrayList<>(List.of(executionOp));
         allOps.addAll(existingOps);
 

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/EventProcessor.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/EventProcessor.java
@@ -36,6 +36,49 @@ class EventProcessor {
         allEvents.add(event);
     }
 
+    // process new status of an operation without an OperationUpdate
+    void processUpdate(Operation updatedOperation) {
+        var builder = Event.builder()
+                .eventId(eventId.getAndIncrement())
+                .eventTimestamp(Instant.now())
+                .id(updatedOperation.id())
+                .name(updatedOperation.name());
+        // support the statuses that don't have a corresponding OperationAction
+        switch (updatedOperation.status()) {
+            case STARTED -> {
+                // used by resetCheckpointToStarted
+                return;
+            }
+            case READY -> {
+                if (updatedOperation.type() == OperationType.STEP) {
+                    // no event type for this case
+                    return;
+                } else {
+                    throw new IllegalArgumentException("Unsupported operation type: " + updatedOperation.type());
+                }
+            }
+            case TIMED_OUT -> {
+                switch (updatedOperation.type()) {
+                    case EXECUTION -> builder.eventType(EXECUTION_TIMED_OUT);
+                    case CHAINED_INVOKE -> builder.eventType(CHAINED_INVOKE_TIMED_OUT);
+                    case CALLBACK -> builder.eventType(CALLBACK_TIMED_OUT);
+                    default ->
+                        throw new IllegalArgumentException("Unsupported operation type: " + updatedOperation.type());
+                }
+            }
+            case STOPPED -> {
+                switch (updatedOperation.type()) {
+                    case EXECUTION -> builder.eventType(EXECUTION_STOPPED);
+                    case CHAINED_INVOKE -> builder.eventType(CHAINED_INVOKE_STOPPED);
+                    default ->
+                        throw new IllegalArgumentException("Unsupported operation type: " + updatedOperation.type());
+                }
+            }
+            default -> throw new IllegalArgumentException("Unsupported operation status: " + updatedOperation.status());
+        }
+        allEvents.add(builder.build());
+    }
+
     List<Event> getAllEvents() {
         return List.copyOf(allEvents);
     }

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/EventProcessor.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/EventProcessor.java
@@ -5,29 +5,43 @@ package software.amazon.lambda.durable.testing.local;
 import static software.amazon.awssdk.services.lambda.model.EventType.*;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import software.amazon.awssdk.services.lambda.model.*;
 
 /** Generates Event objects from OperationUpdate for local testing. */
 class EventProcessor {
     private final AtomicInteger eventId = new AtomicInteger(1);
+    private final List<Event> allEvents = new CopyOnWriteArrayList<>();
 
-    Event processUpdate(OperationUpdate update, Operation operation) {
+    void processUpdate(OperationUpdate update, Operation operation) {
         var builder = Event.builder()
                 .eventId(eventId.getAndIncrement())
                 .eventTimestamp(Instant.now())
                 .id(update.id())
                 .name(update.name());
 
-        return switch (update.type()) {
-            case STEP -> buildStepEvent(builder, update, operation);
-            case WAIT -> buildWaitEvent(builder, update, operation);
-            case CHAINED_INVOKE -> buildInvokeEvent(builder, update, operation);
-            case EXECUTION -> buildExecutionEvent(builder, update);
-            case CALLBACK -> buildCallbackEvent(builder, update);
-            case CONTEXT -> buildContextEvent(builder, update);
-            default -> throw new IllegalArgumentException("Unsupported operation type: " + update.type());
-        };
+        Event event =
+                switch (update.type()) {
+                    case STEP -> buildStepEvent(builder, update, operation);
+                    case WAIT -> buildWaitEvent(builder, update, operation);
+                    case CHAINED_INVOKE -> buildInvokeEvent(builder, update, operation);
+                    case EXECUTION -> buildExecutionEvent(builder, update);
+                    case CALLBACK -> buildCallbackEvent(builder, update);
+                    case CONTEXT -> buildContextEvent(builder, update);
+                    default -> throw new IllegalArgumentException("Unsupported operation type: " + update.type());
+                };
+
+        allEvents.add(event);
+    }
+
+    List<Event> getAllEvents() {
+        return List.copyOf(allEvents);
+    }
+
+    public List<Event> getEventsForOperation(String operationId) {
+        return allEvents.stream().filter(e -> e.id().equals(operationId)).toList();
     }
 
     private Event buildStepEvent(Event.Builder builder, OperationUpdate update, Operation operation) {

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/LocalMemoryExecutionClient.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/LocalMemoryExecutionClient.java
@@ -4,11 +4,11 @@ package software.amazon.lambda.durable.testing.local;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import software.amazon.awssdk.services.lambda.model.*;
@@ -28,7 +28,7 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
     private final Map<String, Operation> existingOperations = Collections.synchronizedMap(new LinkedHashMap<>());
     private final EventProcessor eventProcessor = new EventProcessor();
     private final List<OperationUpdate> operationUpdates = new CopyOnWriteArrayList<>();
-    private final Map<String, Operation> updatedOperations = new ConcurrentHashMap<>();
+    private final Map<String, Operation> updatedOperations = new HashMap<>();
 
     @Override
     public CheckpointDurableExecutionResponse checkpoint(String arn, String token, List<OperationUpdate> updates) {
@@ -36,15 +36,19 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
         updates.forEach(this::applyUpdate);
 
         var newToken = UUID.randomUUID().toString();
-        var response = CheckpointDurableExecutionResponse.builder()
-                .checkpointToken(newToken)
-                .newExecutionState(CheckpointUpdatedExecutionState.builder()
-                        .operations(updatedOperations.values())
-                        .build())
-                .build();
 
-        // updatedOperations was copied into response, so clearing it is safe here
-        updatedOperations.clear();
+        CheckpointDurableExecutionResponse response;
+        synchronized (updatedOperations) {
+            response = CheckpointDurableExecutionResponse.builder()
+                    .checkpointToken(newToken)
+                    .newExecutionState(CheckpointUpdatedExecutionState.builder()
+                            .operations(updatedOperations.values())
+                            .build())
+                    .build();
+
+            // updatedOperations was copied into response, so clearing it is safe here
+            updatedOperations.clear();
+        }
         return response;
     }
 
@@ -65,14 +69,14 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
      * @return true if any operations were advanced, false otherwise
      */
     public boolean advanceTime() {
-        var replaced = new AtomicBoolean(false);
-        existingOperations.replaceAll((key, op) -> {
+        var hasOperationsAdvanced = new AtomicBoolean(false);
+        // forEach is safe as we're not adding or removing keys here
+        existingOperations.forEach((key, op) -> {
             // advance pending retries
             if (op.status() == OperationStatus.PENDING) {
-                replaced.set(true);
+                hasOperationsAdvanced.set(true);
                 var readyOp = op.toBuilder().status(OperationStatus.READY).build();
-                updatedOperations.put(op.id(), readyOp);
-                return readyOp;
+                updateOperation(readyOp);
             }
 
             // advance waits
@@ -87,13 +91,11 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
                         .action(OperationAction.SUCCEED)
                         .build();
                 eventProcessor.processUpdate(update, succeededOp);
-                replaced.set(true);
-                updatedOperations.put(op.id(), succeededOp);
-                return succeededOp;
+                hasOperationsAdvanced.set(true);
+                updateOperation(succeededOp);
             }
-            return op;
         });
-        return replaced.get();
+        return hasOperationsAdvanced.get();
     }
 
     /** Completes a chained invoke operation with the given result, simulating a child Lambda response. */
@@ -172,7 +174,9 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
             throw new IllegalStateException("Operation not found: " + stepName);
         }
         existingOperations.remove(op.id());
-        updatedOperations.remove(op.id());
+        synchronized (updatedOperations) {
+            updatedOperations.remove(op.id());
+        }
     }
 
     private void applyUpdate(OperationUpdate update) {
@@ -319,6 +323,8 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
 
     private void updateOperation(Operation op) {
         existingOperations.put(op.id(), op);
-        updatedOperations.put(op.id(), op);
+        synchronized (updatedOperations) {
+            updatedOperations.put(op.id(), op);
+        }
     }
 }

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/LocalMemoryExecutionClient.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/LocalMemoryExecutionClient.java
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.testing.local;
 
-import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -11,7 +10,14 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
-import software.amazon.awssdk.services.lambda.model.*;
+import software.amazon.awssdk.services.lambda.model.CheckpointDurableExecutionResponse;
+import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
+import software.amazon.awssdk.services.lambda.model.GetDurableExecutionStateResponse;
+import software.amazon.awssdk.services.lambda.model.Operation;
+import software.amazon.awssdk.services.lambda.model.OperationAction;
+import software.amazon.awssdk.services.lambda.model.OperationStatus;
+import software.amazon.awssdk.services.lambda.model.OperationType;
+import software.amazon.awssdk.services.lambda.model.OperationUpdate;
 import software.amazon.lambda.durable.TypeToken;
 import software.amazon.lambda.durable.client.DurableExecutionClient;
 import software.amazon.lambda.durable.model.DurableExecutionOutput;
@@ -72,27 +78,14 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
         var hasOperationsAdvanced = new AtomicBoolean(false);
         // forEach is safe as we're not adding or removing keys here
         existingOperations.forEach((key, op) -> {
-            // advance pending retries
-            if (op.status() == OperationStatus.PENDING) {
+            if (op.type() == OperationType.STEP && op.status() == OperationStatus.PENDING) {
+                applyResult(op, OperationResult.ready());
                 hasOperationsAdvanced.set(true);
-                var readyOp = op.toBuilder().status(OperationStatus.READY).build();
-                updateOperation(readyOp);
             }
 
-            // advance waits
-            if (op.status() == OperationStatus.STARTED && op.type() == OperationType.WAIT) {
-                var succeededOp =
-                        op.toBuilder().status(OperationStatus.SUCCEEDED).build();
-                // Generate WaitSucceeded event
-                var update = OperationUpdate.builder()
-                        .id(op.id())
-                        .name(op.name())
-                        .type(OperationType.WAIT)
-                        .action(OperationAction.SUCCEED)
-                        .build();
-                eventProcessor.processUpdate(update, succeededOp);
+            if (op.type() == OperationType.WAIT && op.status() == OperationStatus.STARTED) {
+                applyResult(op, OperationResult.succeeded(null));
                 hasOperationsAdvanced.set(true);
-                updateOperation(succeededOp);
             }
         });
         return hasOperationsAdvanced.get();
@@ -104,28 +97,10 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
         if (op == null) {
             throw new IllegalStateException("Operation not found: " + name);
         }
-        if (op.type() == OperationType.CHAINED_INVOKE
-                && op.status() == OperationStatus.STARTED
-                && op.name().equals(name)) {
-            var newOp = op.toBuilder()
-                    .status(result.operationStatus())
-                    .chainedInvokeDetails(ChainedInvokeDetails.builder()
-                            .result(result.result())
-                            .error(result.error())
-                            .build())
-                    .build();
-            var update = OperationUpdate.builder()
-                    .id(op.id())
-                    .name(op.name())
-                    .type(OperationType.CHAINED_INVOKE)
-                    .action(
-                            result.operationStatus() == OperationStatus.SUCCEEDED
-                                    ? OperationAction.SUCCEED
-                                    : OperationAction.FAIL)
-                    .build();
-            eventProcessor.processUpdate(update, newOp);
-            updateOperation(newOp);
+        if (op.type() != OperationType.CHAINED_INVOKE || op.status() != OperationStatus.STARTED) {
+            throw new IllegalStateException("Operation is not a CHAINED_INVOKE or not in STARTED state");
         }
+        applyResult(op, result);
     }
 
     /** Returns the operation with the given name, or null if not found. */
@@ -164,7 +139,7 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
             throw new IllegalStateException("Operation not found: " + stepName);
         }
         var startedOp = op.toBuilder().status(OperationStatus.STARTED).build();
-        updateOperation(startedOp);
+        updateOperation(null, startedOp);
     }
 
     /** Simulate fire-and-forget checkpoint loss by removing the operation entirely */
@@ -180,101 +155,9 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
     }
 
     private void applyUpdate(OperationUpdate update) {
-        var operation = toOperation(update);
-        updateOperation(operation);
-
-        eventProcessor.processUpdate(update, operation);
-    }
-
-    private Operation toOperation(OperationUpdate update) {
-        var builder = Operation.builder()
-                .id(update.id())
-                .name(update.name())
-                .type(update.type())
-                .subType(update.subType())
-                .parentId(update.parentId())
-                .status(deriveStatus(update.action()));
-
-        switch (update.type()) {
-            case WAIT -> builder.waitDetails(buildWaitDetails(update));
-            case STEP -> builder.stepDetails(buildStepDetails(update));
-            case CALLBACK -> builder.callbackDetails(buildCallbackDetails(update));
-            case EXECUTION -> {} // No details needed for EXECUTION operations
-            case CHAINED_INVOKE -> builder.chainedInvokeDetails(buildChainedInvokeDetails(update));
-            case CONTEXT -> builder.contextDetails(buildContextDetails(update));
-            case UNKNOWN_TO_SDK_VERSION ->
-                throw new UnsupportedOperationException("UNKNOWN_TO_SDK_VERSION not supported");
-        }
-
-        return builder.build();
-    }
-
-    private ChainedInvokeDetails buildChainedInvokeDetails(OperationUpdate update) {
-        if (update.chainedInvokeOptions() == null) {
-            return null;
-        }
-        return ChainedInvokeDetails.builder()
-                .result(update.payload())
-                .error(update.error())
-                .build();
-    }
-
-    private ContextDetails buildContextDetails(OperationUpdate update) {
-        var detailsBuilder = ContextDetails.builder().result(update.payload()).error(update.error());
-
-        if (update.contextOptions() != null
-                && Boolean.TRUE.equals(update.contextOptions().replayChildren())) {
-            detailsBuilder.replayChildren(true);
-        }
-
-        return detailsBuilder.build();
-    }
-
-    private WaitDetails buildWaitDetails(OperationUpdate update) {
-        if (update.waitOptions() == null) return null;
-
-        var scheduledEnd = Instant.now().plusSeconds(update.waitOptions().waitSeconds());
-        return WaitDetails.builder().scheduledEndTimestamp(scheduledEnd).build();
-    }
-
-    private StepDetails buildStepDetails(OperationUpdate update) {
         var existingOp = existingOperations.get(update.id());
-        var existing = existingOp != null ? existingOp.stepDetails() : null;
-
-        var detailsBuilder = existing != null ? existing.toBuilder() : StepDetails.builder();
-        var attempt = existing != null && existing.attempt() != null ? existing.attempt() + 1 : 1;
-
-        if (update.action() == OperationAction.FAIL) {
-            detailsBuilder.attempt(attempt).error(update.error());
-        }
-
-        if (update.action() == OperationAction.RETRY) {
-            detailsBuilder
-                    .attempt(attempt)
-                    .error(update.error())
-                    .nextAttemptTimestamp(
-                            Instant.now().plusSeconds(update.stepOptions().nextAttemptDelaySeconds()));
-        }
-
-        if (update.payload() != null) {
-            detailsBuilder.result(update.payload());
-        }
-
-        return detailsBuilder.build();
-    }
-
-    private CallbackDetails buildCallbackDetails(OperationUpdate update) {
-        var existingOp = existingOperations.get(update.id());
-        var existing = existingOp != null ? existingOp.callbackDetails() : null;
-
-        // Preserve existing callbackId, or generate new one on START
-        var callbackId =
-                existing != null ? existing.callbackId() : UUID.randomUUID().toString();
-
-        return CallbackDetails.builder()
-                .callbackId(callbackId)
-                .result(existing != null ? existing.result() : null)
-                .build();
+        var updatedOp = OperationProcessor.applyUpdate(update, existingOp);
+        updateOperation(update, updatedOp);
     }
 
     /** Get callback ID for a named callback operation. */
@@ -292,14 +175,47 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
         if (op == null) {
             throw new IllegalStateException("Callback not found: " + callbackId);
         }
-        var updated = op.toBuilder()
-                .status(result.operationStatus())
-                .callbackDetails(op.callbackDetails().toBuilder()
-                        .result(result.result())
-                        .error(result.error())
-                        .build())
-                .build();
-        updateOperation(updated);
+        if (op.type() != OperationType.CALLBACK || op.status() != OperationStatus.STARTED) {
+            throw new IllegalStateException("Operation is not a CALLBACK or not in STARTED state");
+        }
+
+        applyResult(op, result);
+    }
+
+    private void applyResult(Operation op, OperationResult result) {
+        // derive a possible action from the target status
+        OperationAction action = deriveAction(result.operationStatus());
+        if (action != null) {
+            var update = OperationUpdate.builder()
+                    .id(op.id())
+                    .name(op.name())
+                    .type(op.type())
+                    .action(action)
+                    .parentId(op.parentId())
+                    .payload(result.result())
+                    .error(result.error())
+                    .build();
+            applyUpdate(update);
+        } else if (result.operationStatus() == OperationStatus.TIMED_OUT
+                || result.operationStatus() == OperationStatus.STOPPED
+                || result.operationStatus() == OperationStatus.READY) {
+            var newOp = OperationProcessor.applyResult(op, result);
+            updateOperation(null, newOp);
+        } else {
+            throw new IllegalStateException("Unsupported OperationStatus in result: " + result.operationStatus());
+        }
+    }
+
+    private static OperationAction deriveAction(OperationStatus status) {
+        return switch (status) {
+            case STARTED -> OperationAction.START;
+            case SUCCEEDED -> OperationAction.SUCCEED;
+            case FAILED -> OperationAction.FAIL;
+            case PENDING -> OperationAction.RETRY;
+            case CANCELLED -> OperationAction.CANCEL;
+            case READY, TIMED_OUT, STOPPED -> null; // no action for these operation statuses
+            case UNKNOWN_TO_SDK_VERSION -> OperationAction.UNKNOWN_TO_SDK_VERSION; // Todo: Check this
+        };
     }
 
     private Operation findOperationByCallbackId(String callbackId) {
@@ -310,18 +226,13 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
                 .orElse(null);
     }
 
-    private OperationStatus deriveStatus(OperationAction action) {
-        return switch (action) {
-            case START -> OperationStatus.STARTED;
-            case SUCCEED -> OperationStatus.SUCCEEDED;
-            case FAIL -> OperationStatus.FAILED;
-            case RETRY -> OperationStatus.PENDING;
-            case CANCEL -> OperationStatus.CANCELLED;
-            case UNKNOWN_TO_SDK_VERSION -> OperationStatus.UNKNOWN_TO_SDK_VERSION; // Todo: Check this
-        };
-    }
-
-    private void updateOperation(Operation op) {
+    private void updateOperation(OperationUpdate update, Operation op) {
+        // update can be null when an operation is updated without an OperationUpdate
+        if (update == null) {
+            eventProcessor.processUpdate(op);
+        } else {
+            eventProcessor.processUpdate(update, op);
+        }
         existingOperations.put(op.id(), op);
         synchronized (updatedOperations) {
             updatedOperations.put(op.id(), op);

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/LocalMemoryExecutionClient.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/LocalMemoryExecutionClient.java
@@ -3,7 +3,8 @@
 package software.amazon.lambda.durable.testing.local;
 
 import java.time.Instant;
-import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -23,10 +24,11 @@ import software.amazon.lambda.durable.testing.TestResult;
  * in memory, simulating the durable execution backend without AWS infrastructure.
  */
 public class LocalMemoryExecutionClient implements DurableExecutionClient {
-    private final Map<String, Operation> operations = new ConcurrentHashMap<>();
-    private final List<Event> allEvents = new CopyOnWriteArrayList<>();
+    // use LinkedHashMap to keep insertion order
+    private final Map<String, Operation> existingOperations = Collections.synchronizedMap(new LinkedHashMap<>());
     private final EventProcessor eventProcessor = new EventProcessor();
     private final List<OperationUpdate> operationUpdates = new CopyOnWriteArrayList<>();
+    private final Map<String, Operation> updatedOperations = new ConcurrentHashMap<>();
 
     @Override
     public CheckpointDurableExecutionResponse checkpoint(String arn, String token, List<OperationUpdate> updates) {
@@ -34,35 +36,27 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
         updates.forEach(this::applyUpdate);
 
         var newToken = UUID.randomUUID().toString();
-
-        return CheckpointDurableExecutionResponse.builder()
+        var response = CheckpointDurableExecutionResponse.builder()
                 .checkpointToken(newToken)
                 .newExecutionState(CheckpointUpdatedExecutionState.builder()
-                        .operations(operations.values())
+                        .operations(updatedOperations.values())
                         .build())
                 .build();
+
+        // updatedOperations was copied into response, so clearing it is safe here
+        updatedOperations.clear();
+        return response;
     }
 
     @Override
     public GetDurableExecutionStateResponse getExecutionState(String arn, String checkpointToken, String marker) {
-        return GetDurableExecutionStateResponse.builder()
-                .operations(operations.values())
-                .build();
+        // local runner doesn't use this API at all
+        throw new UnsupportedOperationException("getExecutionState is not supported");
     }
 
     /** Get all operation updates that have been sent to this client. Useful for testing and verification. */
     public List<OperationUpdate> getOperationUpdates() {
         return List.copyOf(operationUpdates);
-    }
-
-    /** Get all events in order. */
-    public List<Event> getAllEvents() {
-        return List.copyOf(allEvents);
-    }
-
-    /** Get events for a specific operation. */
-    public List<Event> getEventsForOperation(String operationId) {
-        return allEvents.stream().filter(e -> operationId.equals(e.id())).toList();
     }
 
     /**
@@ -72,12 +66,15 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
      */
     public boolean advanceTime() {
         var replaced = new AtomicBoolean(false);
-        operations.replaceAll((key, op) -> {
+        existingOperations.replaceAll((key, op) -> {
             // advance pending retries
             if (op.status() == OperationStatus.PENDING) {
                 replaced.set(true);
-                return op.toBuilder().status(OperationStatus.READY).build();
+                var readyOp = op.toBuilder().status(OperationStatus.READY).build();
+                updatedOperations.put(op.id(), readyOp);
+                return readyOp;
             }
+
             // advance waits
             if (op.status() == OperationStatus.STARTED && op.type() == OperationType.WAIT) {
                 var succeededOp =
@@ -89,9 +86,9 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
                         .type(OperationType.WAIT)
                         .action(OperationAction.SUCCEED)
                         .build();
-                var event = eventProcessor.processUpdate(update, succeededOp);
-                allEvents.add(event);
+                eventProcessor.processUpdate(update, succeededOp);
                 replaced.set(true);
+                updatedOperations.put(op.id(), succeededOp);
                 return succeededOp;
             }
             return op;
@@ -124,15 +121,14 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
                                     ? OperationAction.SUCCEED
                                     : OperationAction.FAIL)
                     .build();
-            var event = eventProcessor.processUpdate(update, newOp);
-            allEvents.add(event);
-            operations.put(compositeKey(op.parentId(), op.id()), newOp);
+            eventProcessor.processUpdate(update, newOp);
+            updateOperation(newOp);
         }
     }
 
     /** Returns the operation with the given name, or null if not found. */
     public Operation getOperationByName(String name) {
-        return operations.values().stream()
+        return existingOperations.values().stream()
                 .filter(op -> name.equals(op.name()))
                 .findFirst()
                 .orElse(null);
@@ -140,27 +136,21 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
 
     /** Returns all operations currently stored. */
     public List<Operation> getAllOperations() {
-        return operations.values().stream().toList();
-    }
-
-    /** Clears all operations and events, resetting the client to its initial state. */
-    public void reset() {
-        operations.clear();
-        allEvents.clear();
+        return existingOperations.values().stream().toList();
     }
 
     /** Build TestResult from current state. */
     public <O> TestResult<O> toTestResult(DurableExecutionOutput output, TypeToken<O> resultType, SerDes serDes) {
-        var testOperations = operations.values().stream()
+        var testOperations = existingOperations.values().stream()
                 .filter(op -> op.type() != OperationType.EXECUTION)
-                .map(op -> new TestOperation(op, getEventsForOperation(op.id()), serDes))
+                .map(op -> new TestOperation(op, eventProcessor.getEventsForOperation(op.id()), serDes))
                 .toList();
         return new TestResult<>(
                 output.status(),
                 output.result(),
                 output.error(),
                 testOperations,
-                new ArrayList<>(allEvents),
+                eventProcessor.getAllEvents(),
                 resultType,
                 serDes);
     }
@@ -172,7 +162,7 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
             throw new IllegalStateException("Operation not found: " + stepName);
         }
         var startedOp = op.toBuilder().status(OperationStatus.STARTED).build();
-        operations.put(compositeKey(op.parentId(), op.id()), startedOp);
+        updateOperation(startedOp);
     }
 
     /** Simulate fire-and-forget checkpoint loss by removing the operation entirely */
@@ -181,20 +171,15 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
         if (op == null) {
             throw new IllegalStateException("Operation not found: " + stepName);
         }
-        operations.remove(compositeKey(op.parentId(), op.id()));
+        existingOperations.remove(op.id());
+        updatedOperations.remove(op.id());
     }
 
     private void applyUpdate(OperationUpdate update) {
         var operation = toOperation(update);
-        var key = compositeKey(update.parentId(), update.id());
-        operations.put(key, operation);
+        updateOperation(operation);
 
-        var event = eventProcessor.processUpdate(update, operation);
-        allEvents.add(event);
-    }
-
-    private static String compositeKey(String parentId, String operationId) {
-        return (parentId != null ? parentId : "") + ":" + operationId;
+        eventProcessor.processUpdate(update, operation);
     }
 
     private Operation toOperation(OperationUpdate update) {
@@ -249,8 +234,7 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
     }
 
     private StepDetails buildStepDetails(OperationUpdate update) {
-        var key = compositeKey(update.parentId(), update.id());
-        var existingOp = operations.get(key);
+        var existingOp = existingOperations.get(update.id());
         var existing = existingOp != null ? existingOp.stepDetails() : null;
 
         var detailsBuilder = existing != null ? existing.toBuilder() : StepDetails.builder();
@@ -276,8 +260,7 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
     }
 
     private CallbackDetails buildCallbackDetails(OperationUpdate update) {
-        var key = compositeKey(update.parentId(), update.id());
-        var existingOp = operations.get(key);
+        var existingOp = existingOperations.get(update.id());
         var existing = existingOp != null ? existingOp.callbackDetails() : null;
 
         // Preserve existing callbackId, or generate new one on START
@@ -312,11 +295,11 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
                         .error(result.error())
                         .build())
                 .build();
-        operations.put(compositeKey(op.parentId(), op.id()), updated);
+        updateOperation(updated);
     }
 
     private Operation findOperationByCallbackId(String callbackId) {
-        return operations.values().stream()
+        return existingOperations.values().stream()
                 .filter(op -> op.callbackDetails() != null
                         && callbackId.equals(op.callbackDetails().callbackId()))
                 .findFirst()
@@ -332,5 +315,10 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
             case CANCEL -> OperationStatus.CANCELLED;
             case UNKNOWN_TO_SDK_VERSION -> OperationStatus.UNKNOWN_TO_SDK_VERSION; // Todo: Check this
         };
+    }
+
+    private void updateOperation(Operation op) {
+        existingOperations.put(op.id(), op);
+        updatedOperations.put(op.id(), op);
     }
 }

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/OperationProcessor.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/OperationProcessor.java
@@ -1,0 +1,176 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.testing.local;
+
+import java.time.Instant;
+import java.util.UUID;
+import software.amazon.awssdk.services.lambda.model.CallbackDetails;
+import software.amazon.awssdk.services.lambda.model.ChainedInvokeDetails;
+import software.amazon.awssdk.services.lambda.model.ContextDetails;
+import software.amazon.awssdk.services.lambda.model.Operation;
+import software.amazon.awssdk.services.lambda.model.OperationAction;
+import software.amazon.awssdk.services.lambda.model.OperationStatus;
+import software.amazon.awssdk.services.lambda.model.OperationUpdate;
+import software.amazon.awssdk.services.lambda.model.StepDetails;
+import software.amazon.awssdk.services.lambda.model.WaitDetails;
+
+public class OperationProcessor {
+    /** Applies the update to the existing operation, returning a new operation. */
+    static Operation applyUpdate(OperationUpdate update, Operation existingOp) {
+        var builder = Operation.builder()
+                .id(update.id())
+                .name(update.name())
+                .type(update.type())
+                .subType(update.subType())
+                .parentId(update.parentId())
+                .status(deriveStatus(update.action()));
+
+        switch (update.type()) {
+            case WAIT -> builder.waitDetails(buildWaitDetails(update));
+            case STEP -> builder.stepDetails(buildStepDetails(update, existingOp));
+            case CALLBACK -> builder.callbackDetails(buildCallbackDetails(update, existingOp));
+            case EXECUTION -> {} // No details needed for EXECUTION operations
+            case CHAINED_INVOKE -> builder.chainedInvokeDetails(buildChainedInvokeDetails(update));
+            case CONTEXT -> builder.contextDetails(buildContextDetails(update));
+            case UNKNOWN_TO_SDK_VERSION ->
+                throw new UnsupportedOperationException("UNKNOWN_TO_SDK_VERSION not supported");
+        }
+
+        return builder.build();
+    }
+
+    /** Applies the result of an operation to the existing operation, returning a new operation. */
+    public static Operation applyResult(Operation op, OperationResult result) {
+        var builder = Operation.builder()
+                .id(op.id())
+                .name(op.name())
+                .type(op.type())
+                .subType(op.subType())
+                .parentId(op.parentId())
+                .status(result.operationStatus());
+
+        switch (op.type()) {
+            case WAIT -> builder.waitDetails(buildWaitDetails(result, op));
+            case STEP -> builder.stepDetails(buildStepDetails(result, op));
+            case CALLBACK -> builder.callbackDetails(buildCallbackDetails(result, op));
+            case EXECUTION -> {} // No details needed for EXECUTION operations
+            case CHAINED_INVOKE -> builder.chainedInvokeDetails(buildChainedInvokeDetails(result, op));
+            case CONTEXT -> builder.contextDetails(buildContextDetails(result, op));
+            case UNKNOWN_TO_SDK_VERSION ->
+                throw new UnsupportedOperationException("UNKNOWN_TO_SDK_VERSION not supported");
+        }
+        return builder.build();
+    }
+
+    private static ContextDetails buildContextDetails(OperationResult result, Operation op) {
+        throw new IllegalArgumentException("Context operation type is not supported");
+    }
+
+    private static ChainedInvokeDetails buildChainedInvokeDetails(OperationResult result, Operation op) {
+        if (result.operationStatus() == OperationStatus.STOPPED
+                || result.operationStatus() == OperationStatus.TIMED_OUT) {
+            return op.chainedInvokeDetails().toBuilder().error(result.error()).build();
+        }
+        throw new IllegalArgumentException("Operation status not supported: " + result.operationStatus());
+    }
+
+    private static ChainedInvokeDetails buildChainedInvokeDetails(OperationUpdate update) {
+        if (update.action() == OperationAction.START) {
+            return ChainedInvokeDetails.builder().build();
+        } else {
+            return ChainedInvokeDetails.builder()
+                    .result(update.payload())
+                    .error(update.error())
+                    .build();
+        }
+    }
+
+    private static ContextDetails buildContextDetails(OperationUpdate update) {
+        var detailsBuilder = ContextDetails.builder().result(update.payload()).error(update.error());
+
+        if (update.contextOptions() != null
+                && Boolean.TRUE.equals(update.contextOptions().replayChildren())) {
+            detailsBuilder.replayChildren(true);
+        }
+
+        return detailsBuilder.build();
+    }
+
+    private static WaitDetails buildWaitDetails(OperationResult result, Operation op) {
+        if (result.operationStatus() != OperationStatus.SUCCEEDED) {
+            throw new IllegalArgumentException("Operation status is not SUCCEEDED");
+        }
+        return op.waitDetails().toBuilder().build();
+    }
+
+    private static WaitDetails buildWaitDetails(OperationUpdate update) {
+        if (update.waitOptions() == null) return null;
+
+        var scheduledEnd = Instant.now().plusSeconds(update.waitOptions().waitSeconds());
+        return WaitDetails.builder().scheduledEndTimestamp(scheduledEnd).build();
+    }
+
+    private static StepDetails buildStepDetails(OperationUpdate update, Operation existingOp) {
+        var existing = existingOp != null ? existingOp.stepDetails() : null;
+
+        var detailsBuilder = existing != null ? existing.toBuilder() : StepDetails.builder();
+        var attempt = existing != null && existing.attempt() != null ? existing.attempt() + 1 : 1;
+
+        if (update.action() == OperationAction.FAIL) {
+            detailsBuilder.attempt(attempt).error(update.error());
+        }
+
+        if (update.action() == OperationAction.RETRY) {
+            detailsBuilder
+                    .attempt(attempt)
+                    .error(update.error())
+                    .nextAttemptTimestamp(
+                            Instant.now().plusSeconds(update.stepOptions().nextAttemptDelaySeconds()));
+        }
+
+        if (update.payload() != null) {
+            detailsBuilder.result(update.payload());
+        }
+
+        return detailsBuilder.build();
+    }
+
+    private static StepDetails buildStepDetails(OperationResult result, Operation op) {
+        if (result.operationStatus() == OperationStatus.READY) {
+            return op.stepDetails().toBuilder().build();
+        }
+        throw new IllegalArgumentException("Operation status is not READY");
+    }
+
+    private static CallbackDetails buildCallbackDetails(OperationResult result, Operation op) {
+        if (result.operationStatus() == OperationStatus.TIMED_OUT) {
+            return op.callbackDetails().toBuilder().error(result.error()).build();
+        }
+        return null;
+    }
+
+    private static CallbackDetails buildCallbackDetails(OperationUpdate update, Operation existingOp) {
+        var existing = existingOp != null ? existingOp.callbackDetails() : null;
+
+        // Preserve existing callbackId, or generate new one on START
+        var callbackId =
+                existing != null ? existing.callbackId() : UUID.randomUUID().toString();
+
+        return CallbackDetails.builder()
+                .callbackId(callbackId)
+                .result(existing != null ? update.payload() : null)
+                .error(existing != null ? update.error() : null)
+                .build();
+    }
+
+    private static OperationStatus deriveStatus(OperationAction action) {
+        return switch (action) {
+            case START -> OperationStatus.STARTED;
+            case SUCCEED -> OperationStatus.SUCCEEDED;
+            case FAIL -> OperationStatus.FAILED;
+            case RETRY -> OperationStatus.PENDING;
+            case CANCEL -> OperationStatus.CANCELLED;
+            case UNKNOWN_TO_SDK_VERSION -> OperationStatus.UNKNOWN_TO_SDK_VERSION; // Todo: Check this
+        };
+    }
+}

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/OperationResult.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/OperationResult.java
@@ -22,4 +22,8 @@ public record OperationResult(OperationStatus operationStatus, String result, Er
     public static OperationResult timedout() {
         return new OperationResult(OperationStatus.TIMED_OUT, null, null);
     }
+
+    public static OperationResult ready() {
+        return new OperationResult(OperationStatus.READY, null, null);
+    }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fixes: #81 

Related: #313

### Description

- Updated checkpoint API in local runner to return only updated operations
- Moved events storage to EventProcessor
- Removed unused `getExecutionState` API from local runner
- Updated `ParallelIntegrationTest.java` to not show warnings in IDE
- Moved specific operation related logic from `LocalMemoryExecutionClient` to `OperationProcessor`

### Demo/Screenshots

Before
```autowrap
{"@timestamp":"2026-04-07T22:58:36.015Z","ecs.version":"1.2.0","log.level":"DEBUG","message":"Durable checkpoint API called (latency=17750ns): CheckpointDurableExecutionResponse(CheckpointToken=e9b7cddd-f388-43f4-8787-43adef5dd7c0, NewExecutionState=CheckpointUpdatedExecutionState(Operations=[
Operation(Id=815e884f603b6a7830b83bdf214d1916313f47abbcbeb0cc362861d97baa32ea, ParentId=4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce, Name=regional-adjustment, Type=CONTEXT, SubType=RunInChildContext, Status=SUCCEEDED, ContextDetails=ContextDetails(Result=*** Sensitive Data Redacted ***)), 
Operation(Id=77eab15df378ef23fe74769ba8dcae8e78f14e3f11d318f3c88400c88601ed47, ParentId=815e884f603b6a7830b83bdf214d1916313f47abbcbeb0cc362861d97baa32ea, Name=lookup-region, Type=STEP, Status=SUCCEEDED, StepDetails=StepDetails(Result=*** Sensitive Data Redacted ***)),
 Operation(Id=75fa9902e12defcc35af96d78bb44dd2e18fc1b6048543397ed29dc48b525c34, ParentId=d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35, Name=confirmation-delay, Type=WAIT, Status=SUCCEEDED, WaitDetails=WaitDetails(ScheduledEndTimestamp=2026-04-07T22:58:39.011204Z)),
 Operation(Id=216922f7fb504d2177c32e4f234f8ee8a17acce62cbf43e8db61d4a04b2b9ac2, ParentId=4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce, Name=calculate-base-rate, Type=STEP, Status=SUCCEEDED, StepDetails=StepDetails(Result=*** Sensitive Data Redacted ***)),
 Operation(Id=6e6c5ead72e4def46285135ab059ed928a387c4da0c8215d26575a1e2e0b0ca6, ParentId=d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35, Name=confirm-inventory, Type=STEP, Status=SUCCEEDED, StepDetails=StepDetails(Result=*** Sensitive Data Redacted ***)),
 Operation(Id=a2b1919528d81d47916e0dba0364ae756582a2e7a2cb08ff212b62bebaa93c0c, ParentId=6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b, Name=validate-order, Type=STEP, Status=SUCCEEDED, StepDetails=StepDetails(Result=*** Sensitive Data Redacted ***)),
 Operation(Id=02639542652da51af1ee1b734ee5663c43baae11fdef37a46a5c463c9dccbbe0, ParentId=6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b, Name=validation-delay, Type=WAIT, Status=SUCCEEDED, WaitDetails=WaitDetails(ScheduledEndTimestamp=2026-04-07T22:58:41.011568Z)),
 Operation(Id=1df9abb5d4ea62110422aa3a00e504bf4b8a17157750fa43451c26dda199706e, ParentId=d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35, Name=check-stock, Type=STEP, Status=SUCCEEDED, StepDetails=StepDetails(Result=*** Sensitive Data Redacted ***)),
 Operation(Id=4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce, Name=shipping-estimate, Type=CONTEXT, SubType=RunInChildContext, Status=SUCCEEDED, ContextDetails=ContextDetails(Result=*** Sensitive Data Redacted ***)),
 Operation(Id=d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35, Name=inventory-check, Type=CONTEXT, SubType=RunInChildContext, Status=SUCCEEDED, ContextDetails=ContextDetails(Result=*** Sensitive Data Redacted ***)),
 Operation(Id=2ac06c59dbc2f95f867ebb0f4e986076465c3dfd08e9353610dcf46b8b030df6, ParentId=6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b, Name=prepare-order, Type=STEP, Status=SUCCEEDED, StepDetails=StepDetails(Result=*** Sensitive Data Redacted ***)),
 Operation(Id=a284279648aefdf597596b232660aa27c02f01d3fcdfc0ddf1fbd4a3400e2603, ParentId=4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce, Name=finalize-shipping, Type=STEP, Status=SUCCEEDED, StepDetails=StepDetails(Result=*** Sensitive Data Redacted ***)),
 Operation(Id=6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b, Name=order-validation, Type=CONTEXT, SubType=RunInChildContext, Status=SUCCEEDED, ContextDetails=ContextDetails(Result=*** Sensitive Data Redacted ***))])).","process.thread.name":"durable-sdk-internal-0","log.logger":"software.amazon.lambda.durable.execution.CheckpointManager"}
```

after

```
{"@timestamp":"2026-04-07T23:01:14.708Z","ecs.version":"1.2.0","log.level":"DEBUG","message":"Durable checkpoint API called (latency=20125ns): CheckpointDurableExecutionResponse(CheckpointToken=15deaf62-69af-42ae-ae21-c8fecd1c06ea, NewExecutionState=CheckpointUpdatedExecutionState(Operations=[
Operation(Id=d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35, Name=inventory-check, Type=CONTEXT, SubType=RunInChildContext, Status=SUCCEEDED, ContextDetails=ContextDetails(Result=*** Sensitive Data Redacted ***)), 
Operation(Id=6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b, Name=order-validation, Type=CONTEXT, SubType=RunInChildContext, Status=SUCCEEDED, ContextDetails=ContextDetails(Result=*** Sensitive Data Redacted ***))])).","process.thread.name":"durable-sdk-internal-0","log.logger":"software.amazon.lambda.durable.execution.CheckpointManager"}

```

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
