### PR TITLE
[bugfix]: avoid checkpoint when replay in large result mode

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
@@ -862,12 +862,14 @@ class MapIntegrationTest {
 
         var result1 = runner.runUntilComplete("test");
         assertEquals(ExecutionStatus.SUCCEEDED, result1.getStatus());
+        assertEquals(202, result1.getHistoryEvents().size());
         var firstRunCount = executionCount.get();
         assertTrue(firstRunCount >= 100);
 
         // Replay — large result path: replayChildren=true, children replay from cache
         var result2 = runner.run("test");
         assertEquals(ExecutionStatus.SUCCEEDED, result2.getStatus());
+        assertEquals(202, result2.getHistoryEvents().size());
         assertEquals(firstRunCount, executionCount.get(), "Map functions should not re-execute on replay");
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
@@ -5,6 +5,7 @@ package software.amazon.lambda.durable.operation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import software.amazon.awssdk.services.lambda.model.ContextOptions;
 import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationAction;
@@ -42,7 +43,8 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
     private final DurableContext.MapFunction<I, O> function;
     private final TypeToken<O> itemResultType;
     private final SerDes serDes;
-    private boolean replayFromPayload;
+    private final AtomicBoolean replayFromPayload = new AtomicBoolean(false);
+    private final AtomicBoolean replayForLargeResult = new AtomicBoolean(false);
     private volatile MapResult<O> cachedResult;
 
     public MapOperation(
@@ -133,10 +135,11 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                 if (existing.contextDetails() != null
                         && Boolean.TRUE.equals(existing.contextDetails().replayChildren())) {
                     // Large result: re-execute children to reconstruct MapResult
+                    replayForLargeResult.set(true);
                     executeItems();
                 } else {
                     // Small result: MapResult is in the payload, skip child replay
-                    replayFromPayload = true;
+                    replayFromPayload.set(true);
                     markAlreadyCompleted();
                 }
             }
@@ -181,6 +184,10 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
         }
 
         this.cachedResult = new MapResult<>(resultItems, concurrencyCompletionStatus);
+        if (replayForLargeResult.get()) {
+            markAlreadyCompleted();
+            return;
+        }
         var serialized = serializeResult(cachedResult);
         var serializedBytes = serialized.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
@@ -205,7 +212,7 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
         if (items.isEmpty()) {
             return MapResult.empty();
         }
-        if (replayFromPayload) {
+        if (replayFromPayload.get()) {
             // Small result replay: deserialize MapResult directly from checkpoint payload
             var op = waitForOperationCompletion();
             var result = (op.contextDetails() != null) ? op.contextDetails().result() : null;


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fixes https://github.com/aws/aws-durable-execution-sdk-java/issues/338

### Description

When the map operation is replayed with large result, it checkpoints the result again even if the operation has already succeeded. 

Fix:
Skip checkpoint if the operation is completed. 


### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
