### PR TITLE
fix the result size in ParallelResult

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
@@ -1151,6 +1151,12 @@ class ParallelIntegrationTest {
 
         var result = runner.runUntilComplete("test");
         assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
-        assertEquals(events, result.getHistoryEvents().size());
+        if (nestingType == NestingType.FLAT) {
+            assertEquals(2, result.getHistoryEvents().size());
+        } else {
+            // might 4 if only 1 branch completed and at most 8 if all branches completed
+            assertTrue(4 <= result.getHistoryEvents().size());
+            assertTrue(result.getHistoryEvents().size() <= events);
+        }
     }
 }

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
@@ -1142,10 +1142,8 @@ class ParallelIntegrationTest {
             var result = parallel.get();
             assertEquals(ConcurrencyCompletionStatus.MIN_SUCCESSFUL_REACHED, result.completionStatus());
             assertTrue(result.completionStatus().isSucceeded());
-            // todo: the result is constructed when handling parallel completion,
-            // which might be earlier than the last branch is added.
-            assertTrue(result.size() <= 3);
-            assertTrue(result.succeeded() <= result.size());
+            assertEquals(3, result.size());
+            assertTrue(result.succeeded() <= 3);
             assertTrue(1 <= result.succeeded());
 
             return "done";

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
@@ -127,7 +127,11 @@ public class ParallelOperation extends ConcurrencyOperation<ParallelResult> impl
     @Override
     public ParallelResult get() {
         join();
-        return cachedResult;
+        return new ParallelResult(
+                getBranches().size(), // size might be updated after cached result is built
+                cachedResult.succeeded(),
+                cachedResult.failed(),
+                cachedResult.completionStatus());
     }
 
     /** Calls {@link #get()} if not already called. Guarantees that the context is closed. */


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

- Fixes: #332 

### Description

New branches could be added after the parallel operation has completed early due to minimal successful condition.

Fix:
- reconstruct the result with the latest branch count when users call `get()` to retrieve the result.

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes? Updated the test to catch the issue

#### Examples

Has a new example been added for the change? (if applicable)
