### PR TITLE
[bugfix]: fix inconsistency result when replay concurrency operations

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -1001,6 +1002,131 @@ class MapIntegrationTest {
         assertEquals(ExecutionStatus.SUCCEEDED, result2.getStatus());
         assertEquals(firstRunCount, executionCount.get(), "Map functions should not re-execute on replay");
         assertEquals(events, result2.getHistoryEvents().size());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"FLAT, 2", "NESTED, 9"})
+    void testMapWithMinSuccessful_replayLargePayload(NestingType nestingType, int events) {
+        var executionCount = new AtomicInteger(0);
+
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var items = List.of("a", "b", "c", "d", "e");
+            var config = MapConfig.builder()
+                    .maxConcurrency(5)
+                    .completionConfig(CompletionConfig.minSuccessful(2))
+                    .nestingType(nestingType)
+                    .build();
+            var result = context.map(
+                    "min-success-replay",
+                    items,
+                    String.class,
+                    (item, index, ctx) -> {
+                        executionCount.incrementAndGet();
+                        // add delays to first 3 items when starting, and
+                        // add delays to other 2 items when replaying
+                        try {
+                            if (executionCount.get() <= 5 && index < 3 || executionCount.get() > 5 && index > 3) {
+                                Thread.sleep(1000);
+                            }
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                        return item.toUpperCase().repeat(1000000);
+                    },
+                    config);
+
+            // always the same items get skipped when replay
+            assertEquals(
+                    MapResult.MapResultItem.Status.SKIPPED, result.getItem(0).status());
+            assertEquals(
+                    MapResult.MapResultItem.Status.SKIPPED, result.getItem(1).status());
+            assertEquals(
+                    MapResult.MapResultItem.Status.SKIPPED, result.getItem(2).status());
+            assertEquals(
+                    MapResult.MapResultItem.Status.SUCCEEDED, result.getItem(3).status());
+            assertEquals(
+                    MapResult.MapResultItem.Status.SUCCEEDED, result.getItem(4).status());
+
+            return "done";
+        });
+
+        var result1 = runner.runUntilComplete("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result1.getStatus());
+        var firstRunCount = executionCount.get();
+        assertEquals(events, result1.getHistoryEvents().size());
+
+        // Replay — small result path: deserialize MapResult from payload, no child replay
+        var result2 = runner.run("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result2.getStatus());
+        assertEquals(firstRunCount + 2, executionCount.get(), "Map functions should re-execute on replay");
+        assertEquals(events, result2.getHistoryEvents().size());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"FLAT, 2", "NESTED, 9"})
+    void testMapWithMinSuccessful_replayLargePayloadResultConsistency(NestingType nestingType, int events) {
+        var executionCount = new AtomicInteger(0);
+        var initialResult = new AtomicReference<MapResult<String>>();
+
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var items = List.of("a", "b", "c", "d", "e");
+            var config = MapConfig.builder()
+                    .maxConcurrency(5)
+                    .completionConfig(CompletionConfig.minSuccessful(2))
+                    .nestingType(nestingType)
+                    .build();
+            var result = context.map(
+                    "min-success-replay",
+                    items,
+                    String.class,
+                    (item, index, ctx) -> {
+                        executionCount.incrementAndGet();
+                        // add delays to first 2 items when starting, and
+                        // add delays to other 3 items when replaying
+                        try {
+                            if (executionCount.get() <= 5 && index < 2 || executionCount.get() > 5 && index > 2) {
+                                Thread.sleep(1000);
+                            }
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                        return item.toUpperCase().repeat(1000000);
+                    },
+                    config);
+
+            // always the same items get skipped when replay
+            if (initialResult.get() == null) {
+                initialResult.set(result);
+            } else {
+                // todo: this test would fail because 5th branch is skipped when replay
+                // assertEquals(initialResult.get(), result);
+            }
+
+            return "done";
+        });
+
+        var result1 = runner.runUntilComplete("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result1.getStatus());
+        var firstRunCount = executionCount.get();
+        if (nestingType == NestingType.FLAT) {
+            assertEquals(events, result1.getHistoryEvents().size());
+        } else {
+            // 9 events if 2 branches completed 10 if 3
+            assertTrue(events <= result1.getHistoryEvents().size());
+        }
+
+        // Replay — small result path: deserialize MapResult from payload, no child replay
+        var result2 = runner.run("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result2.getStatus());
+        // 2 or 3 more replays
+        assertTrue(firstRunCount + 2 <= executionCount.get(), "Map functions should re-execute on replay");
+        if (nestingType == NestingType.FLAT) {
+            assertEquals(events, result2.getHistoryEvents().size());
+        } else {
+            // 9 events if 2 branches completed 10 if 3
+            assertTrue(events <= result2.getHistoryEvents().size());
+            assertTrue(result2.getHistoryEvents().size() <= events + 1);
+        }
     }
 
     @ParameterizedTest

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
@@ -1098,8 +1098,7 @@ class MapIntegrationTest {
             if (initialResult.get() == null) {
                 initialResult.set(result);
             } else {
-                // todo: this test would fail because 5th branch is skipped when replay
-                // assertEquals(initialResult.get(), result);
+                assertEquals(initialResult.get(), result);
             }
 
             return "done";

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
@@ -29,7 +29,7 @@ class ParallelIntegrationTest {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().nestingType(nestingType).build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("process-items", config);
+            ParallelDurableFuture parallel = context.parallel("process-items", config);
 
             try (parallel) {
                 for (var item : List.of("a", "b", "c")) {
@@ -58,7 +58,7 @@ class ParallelIntegrationTest {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().nestingType(nestingType).build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("parallel-with-steps", config);
+            ParallelDurableFuture parallel = context.parallel("parallel-with-steps", config);
 
             try (parallel) {
                 for (var item : List.of("hello", "world")) {
@@ -600,7 +600,7 @@ class ParallelIntegrationTest {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().nestingType(nestingType).build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("50-callbacks", config);
+            ParallelDurableFuture parallel = context.parallel("50-callbacks", config);
 
             try (parallel) {
                 for (int i = 0; i < branchCount; i++) {

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import software.amazon.lambda.durable.config.CompletionConfig;
@@ -121,7 +120,7 @@ class ParallelIntegrationTest {
     void testParallelAllBranchesFail(NestingType nestingType, int events) {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().nestingType(nestingType).build();
-            var parallel = context.parallel("all-fail", config);
+            ParallelDurableFuture parallel = context.parallel("all-fail", config);
 
             try (parallel) {
                 parallel.branch("branch-x", String.class, ctx -> {
@@ -158,7 +157,7 @@ class ParallelIntegrationTest {
                     .nestingType(nestingType)
                     .build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("sequential-parallel", config);
+            ParallelDurableFuture parallel = context.parallel("sequential-parallel", config);
 
             try (parallel) {
                 for (var item : List.of("a", "b", "c", "d")) {
@@ -197,7 +196,7 @@ class ParallelIntegrationTest {
                     .nestingType(nestingType)
                     .build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("limited-parallel", config);
+            ParallelDurableFuture parallel = context.parallel("limited-parallel", config);
 
             try (parallel) {
                 for (var item : List.of("a", "b", "c", "d", "e")) {
@@ -232,7 +231,7 @@ class ParallelIntegrationTest {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().nestingType(nestingType).build();
             var futures = new ArrayList<DurableFuture<String>>();
-            var parallel = context.parallel("replay-parallel", config);
+            ParallelDurableFuture parallel = context.parallel("replay-parallel", config);
 
             try (parallel) {
                 for (var item : List.of("a", "b", "c")) {
@@ -534,7 +533,7 @@ class ParallelIntegrationTest {
     void testParallelBranchesReturnDifferentTypes(NestingType nestingType, int events) {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().nestingType(nestingType).build();
-            var parallel = context.parallel("mixed-types", config);
+            ParallelDurableFuture parallel = context.parallel("mixed-types", config);
 
             DurableFuture<String> strFuture;
             DurableFuture<Integer> intFuture;
@@ -658,7 +657,7 @@ class ParallelIntegrationTest {
                     .maxConcurrency(5)
                     .nestingType(nestingType)
                     .build();
-            var parallel = context.parallel("50-callbacks-limited", config);
+            ParallelDurableFuture parallel = context.parallel("50-callbacks-limited", config);
 
             try (parallel) {
                 for (int i = 0; i < branchCount; i++) {
@@ -708,7 +707,7 @@ class ParallelIntegrationTest {
 
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().nestingType(nestingType).build();
-            var parallel = context.parallel("50-callbacks-partial-fail", config);
+            ParallelDurableFuture parallel = context.parallel("50-callbacks-partial-fail", config);
 
             try (parallel) {
                 for (int i = 0; i < branchCount; i++) {
@@ -862,7 +861,7 @@ class ParallelIntegrationTest {
 
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().nestingType(nestingType).build();
-            var parallel = context.parallel("50-conditions-some-fail", config);
+            ParallelDurableFuture parallel = context.parallel("50-conditions-some-fail", config);
 
             try (parallel) {
                 for (int i = 0; i < branchCount; i++) {
@@ -913,7 +912,7 @@ class ParallelIntegrationTest {
 
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().nestingType(nestingType).build();
-            var parallel = context.parallel("50-conditions-replay", config);
+            ParallelDurableFuture parallel = context.parallel("50-conditions-replay", config);
 
             try (parallel) {
                 for (int i = 0; i < branchCount; i++) {
@@ -963,7 +962,7 @@ class ParallelIntegrationTest {
 
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder().nestingType(nestingType).build();
-            var parallel = context.parallel("50-mixed", config);
+            ParallelDurableFuture parallel = context.parallel("50-mixed", config);
 
             try (parallel) {
                 for (int i = 0; i < branchCount; i++) {
@@ -1128,8 +1127,7 @@ class ParallelIntegrationTest {
             if (initialResult.get() == null) {
                 initialResult.set(result);
             } else {
-                //todo: fix this
-                // assertEquals(initialResult.get(), result);
+                assertEquals(initialResult.get(), result);
             }
             assertEquals(ConcurrencyCompletionStatus.MIN_SUCCESSFUL_REACHED, result.completionStatus());
             assertTrue(result.completionStatus().isSucceeded());

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
@@ -8,6 +8,8 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import software.amazon.lambda.durable.config.CompletionConfig;
@@ -16,6 +18,7 @@ import software.amazon.lambda.durable.config.ParallelConfig;
 import software.amazon.lambda.durable.config.WaitForConditionConfig;
 import software.amazon.lambda.durable.model.ConcurrencyCompletionStatus;
 import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.model.ParallelResult;
 import software.amazon.lambda.durable.model.WaitForConditionResult;
 import software.amazon.lambda.durable.retry.WaitStrategies;
 import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
@@ -1087,6 +1090,72 @@ class ParallelIntegrationTest {
                                 .map(TestOperation::toString)
                                 .toList()));
         assertEquals(events, result.getHistoryEvents().size());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"FLAT, 2", "NESTED, 8"})
+    void testParallelWithMinSuccessful_earlyTermination_consistentResult(NestingType nestingType, int events) {
+        var executionCount = new AtomicInteger(0);
+        var initialResult = new AtomicReference<ParallelResult>();
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var config = ParallelConfig.builder()
+                    .maxConcurrency(5)
+                    .completionConfig(CompletionConfig.minSuccessful(2))
+                    .nestingType(nestingType)
+                    .build();
+            var futures = new ArrayList<DurableFuture<String>>();
+            ParallelDurableFuture parallel = context.parallel("min-successful", config);
+
+            try (parallel) {
+                for (var item : List.of("a", "b", "c", "d", "e")) {
+                    futures.add(parallel.branch("branch-" + item, String.class, ctx -> {
+                        executionCount.incrementAndGet();
+                        try {
+                            if (executionCount.get() <= 5 && (item.equals("a") || item.equals("b"))
+                                    || executionCount.get() > 5 && (item.equals("c") || item.equals("d"))) {
+                                Thread.sleep(1000);
+                            }
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+
+                        return item.toUpperCase();
+                    }));
+                }
+            }
+
+            var result = parallel.get();
+            if (initialResult.get() == null) {
+                initialResult.set(result);
+            } else {
+                //todo: fix this
+                // assertEquals(initialResult.get(), result);
+            }
+            assertEquals(ConcurrencyCompletionStatus.MIN_SUCCESSFUL_REACHED, result.completionStatus());
+            assertTrue(result.completionStatus().isSucceeded());
+            assertTrue(result.size() >= 2 && result.size() <= 5);
+            assertEquals(ParallelResult.Status.SKIPPED, result.statuses().get(0));
+            assertEquals(ParallelResult.Status.SKIPPED, result.statuses().get(1));
+
+            return "done";
+        });
+
+        var result = runner.runUntilComplete("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        if (nestingType == NestingType.FLAT) {
+            assertEquals(events, result.getHistoryEvents().size());
+        } else {
+            assertTrue(events <= result.getHistoryEvents().size());
+            assertTrue(result.getHistoryEvents().size() <= events + 2);
+        }
+
+        var result2 = runner.run("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result2.getStatus());
+        if (nestingType == NestingType.FLAT) {
+            assertEquals(events, result2.getHistoryEvents().size());
+        } else {
+            assertTrue(result2.getHistoryEvents().size() <= events + 2);
+        }
     }
 
     @ParameterizedTest

--- a/sdk/src/main/java/software/amazon/lambda/durable/model/ParallelResult.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/model/ParallelResult.java
@@ -2,10 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.model;
 
+import java.util.List;
+
 /**
  * Summary result of a parallel operation.
  *
  * <p>Captures the aggregate outcome of a parallel execution: how many branches were registered, how many succeeded, how
  * many failed, and why the operation completed.
  */
-public record ParallelResult(int size, int succeeded, int failed, ConcurrencyCompletionStatus completionStatus) {}
+public record ParallelResult(
+        int size,
+        int succeeded,
+        int failed,
+        int skipped,
+        ConcurrencyCompletionStatus completionStatus,
+        List<Status> statuses) {
+
+    /** Status of an individual parallel branch. */
+    public enum Status {
+        SUCCEEDED,
+        FAILED,
+        SKIPPED
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -51,9 +51,9 @@ public abstract class BaseDurableOperation {
     protected final CompletableFuture<BaseDurableOperation> completionFuture;
     protected final BaseDurableOperation parentOperation;
     protected final boolean isVirtual;
+    protected final AtomicBoolean replayCompletedOperation = new AtomicBoolean(false);
     private final DurableContextImpl durableContext;
     private final AtomicReference<CompletableFuture<Void>> runningUserHandler = new AtomicReference<>(null);
-    private final AtomicBoolean replayCompletedOperation = new AtomicBoolean(false);
 
     protected BaseDurableOperation(
             OperationIdentifier operationIdentifier,

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +53,7 @@ public abstract class BaseDurableOperation {
     protected final boolean isVirtual;
     private final DurableContextImpl durableContext;
     private final AtomicReference<CompletableFuture<Void>> runningUserHandler = new AtomicReference<>(null);
+    private final AtomicBoolean replayCompletedOperation = new AtomicBoolean(false);
 
     protected BaseDurableOperation(
             OperationIdentifier operationIdentifier,
@@ -126,6 +128,9 @@ public abstract class BaseDurableOperation {
 
             if (existing != null) {
                 validateReplay(existing);
+                if (ExecutionManager.isTerminalStatus(existing.status())) {
+                    replayCompletedOperation.set(true);
+                }
                 replay(existing);
             } else {
                 if (durableContext.isReplaying()) {
@@ -409,7 +414,15 @@ public abstract class BaseDurableOperation {
         if (getSubType() != null) {
             updateBuilder.subType(getSubType().getValue());
         }
-        return executionManager.sendOperationUpdate(updateBuilder.build());
+        var update = updateBuilder.build();
+        if (replayCompletedOperation.get()) {
+            // We are replaying a completed operation, so complete the completableFuture without checkpointing
+            logger.debug("Skipping send operation update for replay completed operation: {}", getOperationId());
+            onCheckpointComplete(getOperation());
+            return CompletableFuture.completedFuture(null);
+        } else {
+            return executionManager.sendOperationUpdate(update);
+        }
     }
 
     /** Validates that current operation matches checkpointed operation during replay. */

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
@@ -54,6 +54,7 @@ public class ChildContextOperation<T> extends SerializableDurableOperation<T> {
     private final AtomicBoolean replayChildren = new AtomicBoolean(false);
     private final AtomicReference<DeserializedOperationResult<T>> cachedOperationResult = new AtomicReference<>(null);
 
+    // child context for RunInChildContext
     public ChildContextOperation(
             OperationIdentifier operationIdentifier,
             Function<DurableContext, T> function,
@@ -63,6 +64,7 @@ public class ChildContextOperation<T> extends SerializableDurableOperation<T> {
         this(operationIdentifier, function, resultTypeToken, config, durableContext, false, null);
     }
 
+    // child context for a ConcurrencyOperation branch
     public ChildContextOperation(
             OperationIdentifier operationIdentifier,
             Function<DurableContext, T> function,

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ConcurrencyOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ConcurrencyOperation.java
@@ -52,6 +52,8 @@ import software.amazon.lambda.durable.util.ExceptionHelper;
  */
 public abstract class ConcurrencyOperation<T> extends SerializableDurableOperation<T> {
 
+    protected record ExpectedCompletionStatus(int completed, ConcurrencyCompletionStatus completionStatus) {}
+
     private static final Logger logger = LoggerFactory.getLogger(ConcurrencyOperation.class);
 
     private final int maxConcurrency;
@@ -129,9 +131,9 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
     // ========== Concurrency control ==========
 
     /**
-     * Creates and enqueues an item without starting execution. Use {@link #executeItems()} to begin execution after all
-     * items have been enqueued. This prevents early termination from blocking item creation when all items are known
-     * upfront (e.g., map operations).
+     * Creates and enqueues an item without starting execution. Use {@link #executeItems(ExpectedCompletionStatus)} to
+     * begin execution after all items have been enqueued. This prevents early termination from blocking item creation
+     * when all items are known upfront (e.g., map operations).
      */
     protected <R> ChildContextOperation<R> enqueueItem(
             String name,
@@ -160,6 +162,11 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
 
     /** Starts execution of all enqueued items. */
     protected void executeItems() {
+        executeItems(null);
+    }
+
+    /** Starts execution of all enqueued items until the expectedCompletionStatus is met. */
+    protected void executeItems(ExpectedCompletionStatus expectedCompletionStatus) {
         // variables accessed only by the consumer thread. Put them here to avoid accidentally used by other threads
         Set<BaseDurableOperation> runningChildren = new HashSet<>();
         AtomicInteger succeededCount = new AtomicInteger(0);
@@ -182,7 +189,8 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
                     if (isOperationCompleted()) {
                         return;
                     }
-                    var completionStatus = canComplete(succeededCount, failedCount, runningChildren);
+                    var completionStatus =
+                            canComplete(succeededCount, failedCount, runningChildren, expectedCompletionStatus);
                     if (completionStatus != null) {
                         handleCompletion(completionStatus);
                         return;
@@ -198,7 +206,8 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
 
                     // If consumerThreadListener has been completed when processing above, waitForChildCompletion will
                     // immediately return null and repeat the above again
-                    var child = waitForChildCompletion(succeededCount, failedCount, runningChildren);
+                    var child = waitForChildCompletion(
+                            succeededCount, failedCount, runningChildren, expectedCompletionStatus);
 
                     // child may be null if the consumer thread is woken up due to new items added or completion
                     // condition
@@ -235,7 +244,10 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
     }
 
     private BaseDurableOperation waitForChildCompletion(
-            AtomicInteger succeededCount, AtomicInteger failedCount, Set<BaseDurableOperation> runningChildren) {
+            AtomicInteger succeededCount,
+            AtomicInteger failedCount,
+            Set<BaseDurableOperation> runningChildren,
+            ExpectedCompletionStatus expectedCompletionStatus) {
         var threadContext = getCurrentThreadContext();
         CompletableFuture<Object> future;
 
@@ -244,7 +256,7 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
             if (isOperationCompleted()) {
                 return null;
             }
-            var completionStatus = canComplete(succeededCount, failedCount, runningChildren);
+            var completionStatus = canComplete(succeededCount, failedCount, runningChildren, expectedCompletionStatus);
             if (completionStatus != null) {
                 return null;
             }
@@ -305,9 +317,21 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
      * @return the completion status if the operation is complete, or null if it should continue
      */
     private ConcurrencyCompletionStatus canComplete(
-            AtomicInteger succeededCount, AtomicInteger failedCount, Set<BaseDurableOperation> runningChildren) {
+            AtomicInteger succeededCount,
+            AtomicInteger failedCount,
+            Set<BaseDurableOperation> runningChildren,
+            ExpectedCompletionStatus expectedCompletionStatus) {
         int succeeded = succeededCount.get();
         int failed = failedCount.get();
+
+        if (expectedCompletionStatus != null) {
+            if (succeeded + failed >= expectedCompletionStatus.completed) {
+                return expectedCompletionStatus.completionStatus;
+            }
+
+            // if expected completion status is not null, we always complete all the children previously completed
+            return null;
+        }
 
         // If we've met the minimum successful count, we're done
         if (minSuccessful != null && succeeded >= minSuccessful) {

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ConcurrencyOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ConcurrencyOperation.java
@@ -138,12 +138,15 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
             Function<DurableContext, R> function,
             TypeToken<R> resultType,
             SerDes serDes,
-            OperationSubType branchSubType) {
+            OperationSubType branchSubType,
+            boolean skipped) {
         var operationId = this.operationIdGenerator.nextOperationId();
         var childOp = createItem(operationId, name, function, resultType, serDes, branchSubType);
         branches.add(childOp);
-        pendingQueue.add(childOp);
-        logger.debug("Item enqueued {}", name);
+        if (!skipped) {
+            logger.debug("Item enqueued {}", name);
+            pendingQueue.add(childOp);
+        }
         // notify the consumer thread a new item is available
         notifyConsumerThread();
         return childOp;

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
@@ -73,10 +73,10 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
     }
 
     private void addAllItems() {
-        addAllItemsWithStatus(Collections.nCopies(items.size(), null));
+        addUnskippedItems(Collections.nCopies(items.size(), null));
     }
 
-    private void addAllItemsWithStatus(List<MapResult.MapResultItem.Status> resultItems) {
+    private void addUnskippedItems(List<MapResult.MapResultItem.Status> resultItems) {
         // Enqueue all items first.
         // If the map is completed when replaying, mapResult != null and the items that have been skipped
         // will be skipped during replay.
@@ -143,7 +143,7 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                         : null;
                 var deserializedResult = result != null ? deserializeResult(result) : null;
                 if (deserializedResult != null) {
-                    addAllItemsWithStatus(deserializedResult.items().stream()
+                    addUnskippedItems(deserializedResult.items().stream()
                             .map(MapResult.MapResultItem::status)
                             .toList());
                 } else {

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.operation;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import software.amazon.awssdk.services.lambda.model.ContextOptions;
 import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationAction;
@@ -43,8 +43,6 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
     private final DurableContext.MapFunction<I, O> function;
     private final TypeToken<O> itemResultType;
     private final SerDes serDes;
-    private final AtomicBoolean replayFromPayload = new AtomicBoolean(false);
-    private final AtomicBoolean replayForLargeResult = new AtomicBoolean(false);
     private volatile MapResult<O> cachedResult;
 
     public MapOperation(
@@ -72,24 +70,31 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
         this.function = function;
         this.itemResultType = itemResultType;
         this.serDes = config.serDes();
-
-        addAllItems();
     }
 
     private void addAllItems() {
-        // Enqueue all items first, then start execution. This prevents early termination
-        // criteria (e.g., minSuccessful) from completing the operation mid-loop on replay,
-        // which would cause subsequent enqueue calls to fail with "completed operation".
+        addAllItemsWithStatus(Collections.nCopies(items.size(), null));
+    }
+
+    private void addAllItemsWithStatus(List<MapResult.MapResultItem.Status> resultItems) {
+        // Enqueue all items first.
+        // If the map is completed when replaying, mapResult != null and the items that have been skipped
+        // will be skipped during replay.
         var branchPrefix = getName() == null ? "map-iteration-" : getName() + "-iteration-";
         for (int i = 0; i < items.size(); i++) {
             var index = i;
             var item = items.get(i);
+            var status = resultItems.get(i);
+            // the item will be skipped by ConcurrencyOperation if skip=true
+            var skip = status == MapResult.MapResultItem.Status.SKIPPED;
+
             enqueueItem(
                     branchPrefix + i,
                     childCtx -> function.apply(item, index, childCtx),
                     itemResultType,
                     serDes,
-                    OperationSubType.MAP_ITERATION);
+                    OperationSubType.MAP_ITERATION,
+                    skip);
         }
     }
 
@@ -122,31 +127,42 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                 .action(OperationAction.START)
                 .subType(getSubType().getValue()));
 
+        addAllItems();
         executeItems();
     }
 
     @Override
     protected void replay(Operation existing) {
         if (items.isEmpty()) {
-            markAlreadyCompleted();
-            return;
+            throw terminateExecutionWithIllegalDurableOperationException("Empty Map operation is not replayable");
         }
         switch (existing.status()) {
             case SUCCEEDED -> {
-                if (existing.contextDetails() != null
-                        && Boolean.TRUE.equals(existing.contextDetails().replayChildren())) {
+                var result = existing.contextDetails() != null
+                        ? existing.contextDetails().result()
+                        : null;
+                var deserializedResult = result != null ? deserializeResult(result) : null;
+                if (deserializedResult != null) {
+                    addAllItemsWithStatus(deserializedResult.items().stream()
+                            .map(MapResult.MapResultItem::status)
+                            .toList());
+                } else {
+                    throw terminateExecutionWithIllegalDurableOperationException(
+                            "Missing result in completed Map operation");
+                }
+                if (Boolean.TRUE.equals(existing.contextDetails().replayChildren())) {
                     // Large result: re-execute children to reconstruct MapResult
-                    replayForLargeResult.set(true);
                     executeItems();
                 } else {
                     // Small result: MapResult is in the payload, skip child replay
-                    replayFromPayload.set(true);
+                    cachedResult = deserializedResult;
                     markAlreadyCompleted();
                 }
             }
             case STARTED -> {
                 // Map was in progress when interrupted — re-create children without sending
                 // another START (the backend rejects duplicate START for existing operations)
+                addAllItems();
                 executeItems();
             }
             default ->
@@ -155,9 +171,32 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     protected void handleCompletion(ConcurrencyCompletionStatus concurrencyCompletionStatus) {
+        this.cachedResult = constructMapResult(concurrencyCompletionStatus, false);
+        var serialized = serializeResult(cachedResult);
+        var serializedBytes = serialized.getBytes(StandardCharsets.UTF_8);
+
+        if (serializedBytes.length < LARGE_RESULT_THRESHOLD) {
+            sendOperationUpdate(OperationUpdate.builder()
+                    .action(OperationAction.SUCCEED)
+                    .subType(getSubType().getValue())
+                    .payload(serialized));
+        } else {
+            // Large result: checkpoint with stripped payload + replayChildren flag
+            var strippedResult = serializeResult(constructMapResult(concurrencyCompletionStatus, true));
+            sendOperationUpdate(OperationUpdate.builder()
+                    .action(OperationAction.SUCCEED)
+                    .subType(getSubType().getValue())
+                    .payload(strippedResult)
+                    .contextOptions(
+                            ContextOptions.builder().replayChildren(true).build()));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private MapResult<O> constructMapResult(
+            ConcurrencyCompletionStatus concurrencyCompletionStatus, boolean stripResult) {
         var children = getBranches();
         var resultItems = new ArrayList<MapResult.MapResultItem<O>>(Collections.nCopies(items.size(), null));
 
@@ -167,7 +206,7 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                 resultItems.set(i, MapResult.MapResultItem.skipped());
             } else {
                 try {
-                    resultItems.set(i, MapResult.MapResultItem.succeeded(branch.get()));
+                    resultItems.set(i, MapResult.MapResultItem.succeeded(stripResult ? null : branch.get()));
                 } catch (Throwable exception) {
                     Throwable throwable = ExceptionHelper.unwrapCompletableFuture(exception);
                     if (throwable instanceof SuspendExecutionException suspendExecutionException) {
@@ -179,34 +218,12 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                         // terminate the execution and throw the exception if it's not recoverable
                         throw terminateExecution(unrecoverableDurableExecutionException);
                     }
-                    resultItems.set(i, MapResult.MapResultItem.failed(MapResult.MapError.of(throwable)));
+                    resultItems.set(
+                            i, MapResult.MapResultItem.failed(stripResult ? null : MapResult.MapError.of(throwable)));
                 }
             }
         }
-
-        this.cachedResult = new MapResult<>(resultItems, concurrencyCompletionStatus);
-        // avoid checkpointing because the operation has succeeded and the children are replayed for large result
-        if (replayForLargeResult.get()) {
-            markAlreadyCompleted();
-            return;
-        }
-        var serialized = serializeResult(cachedResult);
-        var serializedBytes = serialized.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-
-        if (serializedBytes.length < LARGE_RESULT_THRESHOLD) {
-            sendOperationUpdate(OperationUpdate.builder()
-                    .action(OperationAction.SUCCEED)
-                    .subType(getSubType().getValue())
-                    .payload(serialized));
-        } else {
-            // Large result: checkpoint with empty payload + replayChildren flag
-            sendOperationUpdate(OperationUpdate.builder()
-                    .action(OperationAction.SUCCEED)
-                    .subType(getSubType().getValue())
-                    .payload("")
-                    .contextOptions(
-                            ContextOptions.builder().replayChildren(true).build()));
-        }
+        return new MapResult<>(resultItems, concurrencyCompletionStatus);
     }
 
     @Override
@@ -214,14 +231,8 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
         if (items.isEmpty()) {
             return MapResult.empty();
         }
-        if (replayFromPayload.get()) {
-            // Small result replay: deserialize MapResult directly from checkpoint payload
-            var op = waitForOperationCompletion();
-            var result = (op.contextDetails() != null) ? op.contextDetails().result() : null;
-            return deserializeResult(result);
-        }
-        // First execution or large result replay: wait for children, then aggregate
         join();
+        // cachedResult is always set upon successful completion
         return cachedResult;
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
@@ -152,7 +152,11 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                 }
                 if (Boolean.TRUE.equals(existing.contextDetails().replayChildren())) {
                     // Large result: re-execute children to reconstruct MapResult
-                    executeItems();
+                    var expected = new ExpectedCompletionStatus(
+                            deserializedResult.succeeded().size()
+                                    + deserializedResult.failed().size(),
+                            deserializedResult.completionReason());
+                    executeItems(expected);
                 } else {
                     // Small result: MapResult is in the payload, skip child replay
                     cachedResult = deserializedResult;
@@ -173,7 +177,7 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
 
     @Override
     protected void handleCompletion(ConcurrencyCompletionStatus concurrencyCompletionStatus) {
-        this.cachedResult = constructMapResult(concurrencyCompletionStatus, false);
+        this.cachedResult = constructMapResult(concurrencyCompletionStatus);
         var serialized = serializeResult(cachedResult);
         var serializedBytes = serialized.getBytes(StandardCharsets.UTF_8);
 
@@ -184,7 +188,7 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                     .payload(serialized));
         } else {
             // Large result: checkpoint with stripped payload + replayChildren flag
-            var strippedResult = serializeResult(constructMapResult(concurrencyCompletionStatus, true));
+            var strippedResult = serializeResult(stripMapResult(cachedResult));
             sendOperationUpdate(OperationUpdate.builder()
                     .action(OperationAction.SUCCEED)
                     .subType(getSubType().getValue())
@@ -194,9 +198,16 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
         }
     }
 
+    private MapResult<O> stripMapResult(MapResult<O> result) {
+        return new MapResult<>(
+                result.items().stream()
+                        .map(item -> new MapResult.MapResultItem<O>(item.status(), null, null))
+                        .toList(),
+                result.completionReason());
+    }
+
     @SuppressWarnings("unchecked")
-    private MapResult<O> constructMapResult(
-            ConcurrencyCompletionStatus concurrencyCompletionStatus, boolean stripResult) {
+    private MapResult<O> constructMapResult(ConcurrencyCompletionStatus concurrencyCompletionStatus) {
         var children = getBranches();
         var resultItems = new ArrayList<MapResult.MapResultItem<O>>(Collections.nCopies(items.size(), null));
 
@@ -206,7 +217,7 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                 resultItems.set(i, MapResult.MapResultItem.skipped());
             } else {
                 try {
-                    resultItems.set(i, MapResult.MapResultItem.succeeded(stripResult ? null : branch.get()));
+                    resultItems.set(i, MapResult.MapResultItem.succeeded(branch.get()));
                 } catch (Throwable exception) {
                     Throwable throwable = ExceptionHelper.unwrapCompletableFuture(exception);
                     if (throwable instanceof SuspendExecutionException suspendExecutionException) {
@@ -218,8 +229,7 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                         // terminate the execution and throw the exception if it's not recoverable
                         throw terminateExecution(unrecoverableDurableExecutionException);
                     }
-                    resultItems.set(
-                            i, MapResult.MapResultItem.failed(stripResult ? null : MapResult.MapError.of(throwable)));
+                    resultItems.set(i, MapResult.MapResultItem.failed(MapResult.MapError.of(throwable)));
                 }
             }
         }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
@@ -126,6 +126,12 @@ public class ParallelOperation extends ConcurrencyOperation<ParallelResult> impl
             partialResult = existing.contextDetails() != null
                     ? deserializeResult(existing.contextDetails().result())
                     : null;
+            if (partialResult != null) {
+                var expected = new ExpectedCompletionStatus(
+                        partialResult.succeeded() + partialResult.failed(), partialResult.completionStatus());
+                executeItems(expected);
+                return;
+            }
         }
         executeItems();
     }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
@@ -45,8 +45,8 @@ import software.amazon.lambda.durable.serde.SerDes;
 public class ParallelOperation extends ConcurrencyOperation<ParallelResult> implements ParallelDurableFuture {
 
     // this field could be written and read in different threads
-    private volatile boolean skipCheckpoint = false;
     private volatile ParallelResult cachedResult;
+    private volatile ParallelResult partialResult;
 
     public ParallelOperation(
             OperationIdentifier operationIdentifier,
@@ -67,44 +67,45 @@ public class ParallelOperation extends ConcurrencyOperation<ParallelResult> impl
     @Override
     protected void handleCompletion(ConcurrencyCompletionStatus concurrencyCompletionStatus) {
         var items = getBranches();
-        int succeededCount = Math.toIntExact(
-                items.stream().filter(this::isOperationCompletedSuccessfully).count());
+        var statuses = items.stream().map(this::getParallelItemStatus).toList();
+        int succeededCount = Math.toIntExact(statuses.stream()
+                .filter(s -> s == ParallelResult.Status.SUCCEEDED)
+                .count());
         int failedCount = Math.toIntExact(
-                items.stream().filter(this::isOperationCompletedExceptionally).count());
-        this.cachedResult = new ParallelResult(items.size(), succeededCount, failedCount, concurrencyCompletionStatus);
-        if (skipCheckpoint) {
-            // Do not send checkpoint during replay
-            markAlreadyCompleted();
-            return;
-        }
+                statuses.stream().filter(s -> s == ParallelResult.Status.FAILED).count());
+        int skippedCount = items.size() - succeededCount - failedCount;
+        cachedResult = new ParallelResult(
+                items.size(), succeededCount, failedCount, skippedCount, concurrencyCompletionStatus, statuses);
         sendOperationUpdate(OperationUpdate.builder()
                 .action(OperationAction.SUCCEED)
                 .subType(getSubType().getValue())
+                .payload(serializeResult(cachedResult))
                 .contextOptions(ContextOptions.builder().replayChildren(true).build()));
     }
 
-    private boolean isOperationCompletedSuccessfully(ChildContextOperation<?> childContextOperation) {
+    private ParallelResult.Status getParallelItemStatus(ChildContextOperation<?> childContextOperation) {
         if (!childContextOperation.isOperationCompleted()) {
-            return false;
+            return ParallelResult.Status.SKIPPED;
         }
         try {
             childContextOperation.get();
-            return true;
+            return ParallelResult.Status.SUCCEEDED;
         } catch (Throwable t) {
-            return false;
+            return ParallelResult.Status.FAILED;
         }
     }
 
-    private boolean isOperationCompletedExceptionally(ChildContextOperation<?> childContextOperation) {
-        if (!childContextOperation.isOperationCompleted()) {
-            return false;
+    private ParallelResult rebuildParallelResult() {
+        if (cachedResult != null && cachedResult.size() != getBranches().size()) {
+            return new ParallelResult(
+                    getBranches().size(), // size might be updated after cached result is built
+                    cachedResult.succeeded(),
+                    cachedResult.failed(),
+                    cachedResult.skipped(),
+                    cachedResult.completionStatus(),
+                    cachedResult.statuses());
         }
-        try {
-            childContextOperation.get();
-            return false;
-        } catch (Throwable t) {
-            return true;
-        }
+        return cachedResult;
     }
 
     @Override
@@ -120,18 +121,19 @@ public class ParallelOperation extends ConcurrencyOperation<ParallelResult> impl
     protected void replay(Operation existing) {
         // No-op: child branches handle their own replay via ChildContextOperation.replay().
         // Set replaying=true so handleSuccess() skips re-checkpointing the already-completed parallel context.
-        skipCheckpoint = ExecutionManager.isTerminalStatus(existing.status());
+        if (ExecutionManager.isTerminalStatus(existing.status())) {
+            // the operation is already completed, extract the branch completion status from the partialResult
+            partialResult = existing.contextDetails() != null
+                    ? deserializeResult(existing.contextDetails().result())
+                    : null;
+        }
         executeItems();
     }
 
     @Override
     public ParallelResult get() {
         join();
-        return new ParallelResult(
-                getBranches().size(), // size might be updated after cached result is built
-                cachedResult.succeeded(),
-                cachedResult.failed(),
-                cachedResult.completionStatus());
+        return rebuildParallelResult();
     }
 
     /** Calls {@link #get()} if not already called. Guarantees that the context is closed. */
@@ -148,7 +150,11 @@ public class ParallelOperation extends ConcurrencyOperation<ParallelResult> impl
         if (isJoined.get()) {
             throw new IllegalStateException("Cannot add branches after join() has been called");
         }
+
+        // ConcurrencyOperation will skip this branch if skip=true
+        var skip = partialResult != null
+                && partialResult.statuses().get(getBranches().size()) == ParallelResult.Status.SKIPPED;
         var serDes = config.serDes() == null ? getContext().getDurableConfig().getSerDes() : config.serDes();
-        return enqueueItem(name, func, resultType, serDes, OperationSubType.PARALLEL_BRANCH);
+        return enqueueItem(name, func, resultType, serDes, OperationSubType.PARALLEL_BRANCH, skip);
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/model/ParallelResultTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/model/ParallelResultTest.java
@@ -4,17 +4,29 @@ package software.amazon.lambda.durable.model;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ParallelResultTest {
 
     @Test
     void allBranchesSucceed_countsAreCorrect() {
-        var result = new ParallelResult(3, 3, 0, ConcurrencyCompletionStatus.ALL_COMPLETED);
+        var result = new ParallelResult(
+                3,
+                3,
+                0,
+                0,
+                ConcurrencyCompletionStatus.ALL_COMPLETED,
+                List.of(
+                        ParallelResult.Status.SUCCEEDED,
+                        ParallelResult.Status.SUCCEEDED,
+                        ParallelResult.Status.SUCCEEDED));
 
         assertEquals(3, result.size());
         assertEquals(3, result.succeeded());
         assertEquals(0, result.failed());
+        assertEquals(0, result.skipped());
         assertEquals(ConcurrencyCompletionStatus.ALL_COMPLETED, result.completionStatus());
+        assertTrue(result.statuses().stream().allMatch(status -> status == ParallelResult.Status.SUCCEEDED));
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/ConcurrencyOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/ConcurrencyOperationTest.java
@@ -137,7 +137,8 @@ class ConcurrencyOperationTest {
                 },
                 TypeToken.get(String.class),
                 SER_DES,
-                OperationSubType.PARALLEL_BRANCH);
+                OperationSubType.PARALLEL_BRANCH,
+                false);
         op.enqueueItem(
                 "branch-2",
                 ctx -> {
@@ -146,7 +147,8 @@ class ConcurrencyOperationTest {
                 },
                 TypeToken.get(String.class),
                 SER_DES,
-                OperationSubType.PARALLEL_BRANCH);
+                OperationSubType.PARALLEL_BRANCH,
+                false);
 
         op.exposedJoin();
 
@@ -155,6 +157,63 @@ class ConcurrencyOperationTest {
         var items = op.getBranches();
         assertEquals(2, items.size());
         assertTrue(items.stream().allMatch(b -> b.getOperation().status().equals(OperationStatus.SUCCEEDED)));
+        assertFalse(functionCalled.get(), "Functions should not be called during SUCCEEDED replay");
+    }
+
+    @Test
+    void someChildrenSkipped_skippedChildrenNotExecuted() throws Exception {
+        when(executionManager.getOperationAndUpdateReplayState(CHILD_OP_1))
+                .thenReturn(Operation.builder()
+                        .id(CHILD_OP_1)
+                        .name("branch-1")
+                        .type(OperationType.CONTEXT)
+                        .subType(OperationSubType.PARALLEL_BRANCH.getValue())
+                        .status(OperationStatus.STARTED)
+                        .build());
+        when(executionManager.getOperationAndUpdateReplayState(CHILD_OP_2))
+                .thenReturn(Operation.builder()
+                        .id(CHILD_OP_2)
+                        .name("branch-2")
+                        .type(OperationType.CONTEXT)
+                        .subType(OperationSubType.PARALLEL_BRANCH.getValue())
+                        .status(OperationStatus.SUCCEEDED)
+                        .contextDetails(
+                                ContextDetails.builder().result("\"result-2\"").build())
+                        .build());
+
+        var functionCalled = new AtomicBoolean(false);
+        var op = createOperation(CompletionConfig.minSuccessful(1));
+        op.execute();
+        op.enqueueItem(
+                "branch-1",
+                ctx1 -> {
+                    functionCalled.set(true);
+                    return "result-1";
+                },
+                TypeToken.get(String.class),
+                SER_DES,
+                OperationSubType.PARALLEL_BRANCH,
+                true);
+        op.enqueueItem(
+                "branch-2",
+                ctx -> {
+                    functionCalled.set(true);
+                    return "result-2";
+                },
+                TypeToken.get(String.class),
+                SER_DES,
+                OperationSubType.PARALLEL_BRANCH,
+                false);
+
+        op.exposedJoin();
+
+        assertTrue(op.isSuccessHandled());
+        assertFalse(op.isFailureHandled());
+        var items = op.getBranches();
+        assertEquals(2, items.size());
+        assertFalse(items.get(0).isOperationCompleted());
+        assertEquals(OperationStatus.STARTED, items.get(0).getOperation().status());
+        assertEquals(OperationStatus.SUCCEEDED, items.get(1).getOperation().status());
         assertFalse(functionCalled.get(), "Functions should not be called during SUCCEEDED replay");
     }
 
@@ -181,7 +240,8 @@ class ConcurrencyOperationTest {
                 },
                 TypeToken.get(String.class),
                 SER_DES,
-                OperationSubType.PARALLEL_BRANCH);
+                OperationSubType.PARALLEL_BRANCH,
+                false);
 
         op.execute();
         op.exposedJoin();

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/ParallelOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/ParallelOperationTest.java
@@ -269,7 +269,8 @@ class ParallelOperationTest {
                         .subType(OperationSubType.PARALLEL.getValue())
                         .status(OperationStatus.SUCCEEDED)
                         .contextDetails(ContextDetails.builder()
-                                .result("{\"statuses\":[\"SKIPPED\", \"SUCCEEDED\"]}")
+                                .result(
+                                        "{\"succeeded\": 1, \"completionStatus\": \"MIN_SUCCESSFUL_REACHED\", \"statuses\":[\"SKIPPED\", \"SUCCEEDED\"]}")
                                 .build())
                         .build());
         when(executionManager.getOperationAndUpdateReplayState(CHILD_OP_2))

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/ParallelOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/ParallelOperationTest.java
@@ -8,7 +8,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
-import java.lang.reflect.Field;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -24,10 +23,10 @@ import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.TestUtils;
 import software.amazon.lambda.durable.TypeToken;
 import software.amazon.lambda.durable.config.CompletionConfig;
+import software.amazon.lambda.durable.config.ParallelBranchConfig;
 import software.amazon.lambda.durable.config.ParallelConfig;
 import software.amazon.lambda.durable.context.DurableContextImpl;
 import software.amazon.lambda.durable.execution.ExecutionManager;
-import software.amazon.lambda.durable.execution.OperationIdGenerator;
 import software.amazon.lambda.durable.execution.ThreadContext;
 import software.amazon.lambda.durable.execution.ThreadType;
 import software.amazon.lambda.durable.model.ConcurrencyCompletionStatus;
@@ -125,13 +124,6 @@ class ParallelOperationTest {
         return op;
     }
 
-    private void setOperationIdGenerator(ConcurrencyOperation<?> op, OperationIdGenerator mockGenerator)
-            throws Exception {
-        Field field = ConcurrencyOperation.class.getDeclaredField("operationIdGenerator");
-        field.setAccessible(true);
-        field.set(op, mockGenerator);
-    }
-
     // ===== Branch creation delegates to ConcurrencyOperation =====
 
     @Test
@@ -139,7 +131,12 @@ class ParallelOperationTest {
         var op = createOperation(CompletionConfig.allSuccessful());
 
         var childOp = op.enqueueItem(
-                "branch-1", ctx -> "result", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
+                "branch-1",
+                ctx -> "result",
+                TypeToken.get(String.class),
+                SER_DES,
+                OperationSubType.PARALLEL_BRANCH,
+                false);
 
         assertNotNull(childOp);
         assertEquals(OperationSubType.PARALLEL_BRANCH, childOp.getSubType());
@@ -150,10 +147,21 @@ class ParallelOperationTest {
         var op = createOperation(CompletionConfig.allSuccessful());
 
         op.enqueueItem(
-                "branch-1", ctx2 -> "r1", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
+                "branch-1",
+                ctx2 -> "r1",
+                TypeToken.get(String.class),
+                SER_DES,
+                OperationSubType.PARALLEL_BRANCH,
+                false);
         op.enqueueItem(
-                "branch-2", ctx1 -> "r2", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
-        op.enqueueItem("branch-3", ctx -> "r3", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
+                "branch-2",
+                ctx1 -> "r2",
+                TypeToken.get(String.class),
+                SER_DES,
+                OperationSubType.PARALLEL_BRANCH,
+                false);
+        op.enqueueItem(
+                "branch-3", ctx -> "r3", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH, false);
 
         assertEquals(3, op.getBranches().size());
     }
@@ -164,7 +172,12 @@ class ParallelOperationTest {
 
         // The child operation should be a ChildContextOperation with this op as parent
         var childOp = op.enqueueItem(
-                "branch-1", ctx -> "result", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
+                "branch-1",
+                ctx -> "result",
+                TypeToken.get(String.class),
+                SER_DES,
+                OperationSubType.PARALLEL_BRANCH,
+                false);
 
         assertNotNull(childOp);
         // Verify it's a ChildContextOperation (the concrete type returned by createItem)
@@ -198,8 +211,14 @@ class ParallelOperationTest {
 
         var op = createOperation(CompletionConfig.allSuccessful());
         op.enqueueItem(
-                "branch-1", ctx1 -> "r1", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
-        op.enqueueItem("branch-2", ctx -> "r2", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
+                "branch-1",
+                ctx1 -> "r1",
+                TypeToken.get(String.class),
+                SER_DES,
+                OperationSubType.PARALLEL_BRANCH,
+                false);
+        op.enqueueItem(
+                "branch-2", ctx -> "r2", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH, false);
 
         var result = op.get();
 
@@ -227,7 +246,8 @@ class ParallelOperationTest {
                         .build());
 
         var op = createOperation(CompletionConfig.minSuccessful(1));
-        op.enqueueItem("branch-1", ctx -> "r1", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
+        op.enqueueItem(
+                "branch-1", ctx -> "r1", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH, false);
 
         var result = op.get();
 
@@ -235,6 +255,53 @@ class ParallelOperationTest {
         assertEquals(1, result.size());
         assertEquals(1, result.succeeded());
         assertEquals(0, result.failed());
+        assertEquals(ConcurrencyCompletionStatus.MIN_SUCCESSFUL_REACHED, result.completionStatus());
+        assertTrue(result.completionStatus().isSucceeded());
+    }
+
+    @Test
+    void minSuccessful_notExecuteSkippedBranchWhenReplay() {
+        when(executionManager.getOperationAndUpdateReplayState(OPERATION_ID))
+                .thenReturn(Operation.builder()
+                        .id(OPERATION_ID)
+                        .name("test-parallel")
+                        .type(OperationType.CONTEXT)
+                        .subType(OperationSubType.PARALLEL.getValue())
+                        .status(OperationStatus.SUCCEEDED)
+                        .contextDetails(ContextDetails.builder()
+                                .result("{\"statuses\":[\"SKIPPED\", \"SUCCEEDED\"]}")
+                                .build())
+                        .build());
+        when(executionManager.getOperationAndUpdateReplayState(CHILD_OP_2))
+                .thenReturn(Operation.builder()
+                        .id(CHILD_OP_2)
+                        .name("branch-2")
+                        .type(OperationType.CONTEXT)
+                        .subType(OperationSubType.PARALLEL_BRANCH.getValue())
+                        .status(OperationStatus.SUCCEEDED)
+                        .contextDetails(
+                                ContextDetails.builder().result("\"r2\"").build())
+                        .build());
+
+        var op = createOperation(CompletionConfig.minSuccessful(1));
+        op.branch(
+                "branch-1",
+                TypeToken.get(String.class),
+                ctx -> "r1",
+                ParallelBranchConfig.builder().serDes(SER_DES).build());
+        op.branch(
+                "branch-2",
+                TypeToken.get(String.class),
+                ctx -> "r2",
+                ParallelBranchConfig.builder().serDes(SER_DES).build());
+
+        var result = op.get();
+
+        verify(executionManager, never()).sendOperationUpdate(any());
+        assertEquals(2, result.size());
+        assertEquals(1, result.succeeded());
+        assertEquals(0, result.failed());
+        assertEquals(1, result.skipped());
         assertEquals(ConcurrencyCompletionStatus.MIN_SUCCESSFUL_REACHED, result.completionStatus());
         assertTrue(result.completionStatus().isSucceeded());
     }
@@ -248,7 +315,12 @@ class ParallelOperationTest {
         var op = createOperation(CompletionConfig.allSuccessful());
 
         var childOp = op.enqueueItem(
-                "branch-1", ctx -> "result", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
+                "branch-1",
+                ctx -> "result",
+                TypeToken.get(String.class),
+                SER_DES,
+                OperationSubType.PARALLEL_BRANCH,
+                false);
 
         // The child operation should be registered in the execution manager
         // (BaseDurableOperation constructor calls executionManager.registerOperation)
@@ -291,8 +363,14 @@ class ParallelOperationTest {
 
         var op = createOperation(CompletionConfig.allSuccessful());
         op.enqueueItem(
-                "branch-1", ctx1 -> "r1", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
-        op.enqueueItem("branch-2", ctx -> "r2", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
+                "branch-1",
+                ctx1 -> "r1",
+                TypeToken.get(String.class),
+                SER_DES,
+                OperationSubType.PARALLEL_BRANCH,
+                false);
+        op.enqueueItem(
+                "branch-2", ctx -> "r2", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH, false);
 
         var result = op.get();
 
@@ -339,8 +417,14 @@ class ParallelOperationTest {
 
         var op = createOperation(CompletionConfig.allSuccessful());
         op.enqueueItem(
-                "branch-1", ctx1 -> "r1", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
-        op.enqueueItem("branch-2", ctx -> "r2", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
+                "branch-1",
+                ctx1 -> "r1",
+                TypeToken.get(String.class),
+                SER_DES,
+                OperationSubType.PARALLEL_BRANCH,
+                false);
+        op.enqueueItem(
+                "branch-2", ctx -> "r2", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH, false);
 
         var result = op.get();
 
@@ -375,7 +459,8 @@ class ParallelOperationTest {
                 },
                 TypeToken.get(String.class),
                 SER_DES,
-                OperationSubType.PARALLEL_BRANCH);
+                OperationSubType.PARALLEL_BRANCH,
+                false);
 
         var result = assertDoesNotThrow(op::get);
 
@@ -412,7 +497,12 @@ class ParallelOperationTest {
         // toleratedFailureCount=1 so the operation completes after both branches finish
         var op = createOperation(CompletionConfig.toleratedFailureCount(1));
         op.enqueueItem(
-                "branch-1", ctx1 -> "r1", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH);
+                "branch-1",
+                ctx1 -> "r1",
+                TypeToken.get(String.class),
+                SER_DES,
+                OperationSubType.PARALLEL_BRANCH,
+                false);
         op.enqueueItem(
                 "branch-2",
                 ctx -> {
@@ -420,7 +510,8 @@ class ParallelOperationTest {
                 },
                 TypeToken.get(String.class),
                 SER_DES,
-                OperationSubType.PARALLEL_BRANCH);
+                OperationSubType.PARALLEL_BRANCH,
+                false);
 
         var result = op.get();
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fixes: #344 

### Description


Two concurrency operation result consistent issues during replay

1. Branches/items that are skipped (neither succeeded nor failed ones) when checkpointing the results, could succeed or fail during replay. This occurs when a parallel operation or a map operation with large results has early termination conditions (min successful or max failure tolerant) and the items/branches are completed with an inconsistent order during replay. 

2. Branches/items that succeeded or failed when checkpointing the results, could be skipped during replay. This occurs when a parallel operation or a map operation with large results has early termination conditions (min successful or max failure tolerant) and more branches than specified condition are completed due to concurrency.
 
Fixes:

1. always checkpoint the status of each branch/item in the concurrency operation's result
2. skip the items/branches with SKIPPED status during replay
4. always wait until checkpointed succeeded/failed branches/items to complete during replay

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Yes

#### Integration Tests

Have integration tests been written for these changes? Yes

#### Examples

Has a new example been added for the change? (if applicable)
