### PR TITLE
[feature]: add virtual to child context config

### DIFF
--- a/examples/src/main/java/software/amazon/lambda/durable/examples/child/VirtualChildContextExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/child/VirtualChildContextExample.java
@@ -70,7 +70,8 @@ public class VirtualChildContextExample extends DurableHandler<GreetingRequest, 
                             "regional-adjustment",
                             String.class,
                             nested -> nested.step(
-                                    "lookup-region", String.class, stepCtx -> baseRate + " + regional adjustment"));
+                                    "lookup-region", String.class, stepCtx -> baseRate + " + regional adjustment"),
+                            RunInChildContextConfig.builder().isVirtual(true).build());
 
                     return child.step("finalize-shipping", String.class, stepCtx -> adjustment + " [shipping ready]");
                 },

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/child/VirtualChildContextExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/child/VirtualChildContextExample.java
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples.child;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableFuture;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.RunInChildContextConfig;
+import software.amazon.lambda.durable.examples.types.GreetingRequest;
+
+/**
+ * Example demonstrating virtual child context workflows with the Durable Execution SDK.
+ *
+ * <p>This handler runs three concurrent child contexts using {@code runInChildContextAsync}:
+ *
+ * <ol>
+ *   <li><b>Order validation</b> — performs a step then suspends via {@code wait()} before completing
+ *   <li><b>Inventory check</b> — performs a step then suspends via {@code wait()} before completing
+ *   <li><b>Shipping estimate</b> — nests another child context inside it to demonstrate hierarchical contexts
+ * </ol>
+ *
+ * <p>All three child contexts run concurrently. Results are collected with {@link DurableFuture#allOf} and combined
+ * into a summary string.
+ */
+public class VirtualChildContextExample extends DurableHandler<GreetingRequest, String> {
+
+    @Override
+    public String handleRequest(GreetingRequest input, DurableContext context) {
+        var name = input.getName();
+        context.getLogger().info("Starting child context workflow for {}", name);
+
+        // Child context 1: Order validation — step + wait + step
+        var orderFuture = context.runInChildContextAsync(
+                "order-validation",
+                String.class,
+                child -> {
+                    var prepared = child.step("prepare-order", String.class, stepCtx -> "Order for " + name);
+                    child.getLogger().info("Order prepared, waiting for validation");
+
+                    child.wait("validation-delay", Duration.ofSeconds(5));
+
+                    return child.step("validate-order", String.class, stepCtx -> prepared + " [validated]");
+                },
+                RunInChildContextConfig.builder().isVirtual(true).build());
+
+        // Child context 2: Inventory check — step + wait + step
+        var inventoryFuture = context.runInChildContextAsync(
+                "inventory-check",
+                String.class,
+                child -> {
+                    var stock = child.step("check-stock", String.class, stepCtx -> "Stock available for " + name);
+                    child.getLogger().info("Stock checked, waiting for confirmation");
+
+                    child.wait("confirmation-delay", Duration.ofSeconds(3));
+
+                    return child.step("confirm-inventory", String.class, stepCtx -> stock + " [confirmed]");
+                },
+                RunInChildContextConfig.builder().isVirtual(true).build());
+
+        // Child context 3: Shipping estimate — nests a child context inside it
+        var shippingFuture = context.runInChildContextAsync(
+                "shipping-estimate",
+                String.class,
+                child -> {
+                    var baseRate = child.step("calculate-base-rate", String.class, stepCtx -> "Base rate for " + name);
+
+                    // Nested child context: calculate regional adjustment
+                    var adjustment = child.runInChildContext(
+                            "regional-adjustment",
+                            String.class,
+                            nested -> nested.step(
+                                    "lookup-region", String.class, stepCtx -> baseRate + " + regional adjustment"));
+
+                    return child.step("finalize-shipping", String.class, stepCtx -> adjustment + " [shipping ready]");
+                },
+                RunInChildContextConfig.builder().isVirtual(true).build());
+
+        // Collect all results using allOf
+        context.getLogger().info("Waiting for all child contexts to complete");
+        var results = DurableFuture.allOf(orderFuture, inventoryFuture, shippingFuture);
+
+        // Combine into summary
+        var summary = String.join(" | ", results);
+        context.getLogger().info("All child contexts complete: {}", summary);
+
+        return summary;
+    }
+}

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/CloudBasedIntegrationTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/CloudBasedIntegrationTest.java
@@ -530,6 +530,23 @@ class CloudBasedIntegrationTest {
         assertNotNull(runner.getOperation("shipping-estimate"));
     }
 
+    @Test
+    void testVirtualChildContextExample() {
+        var runner = CloudDurableTestRunner.create(
+                arn("virtual-child-context-example"), GreetingRequest.class, String.class, lambdaClient);
+        var result = runner.run(new GreetingRequest("Alice"));
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(
+                "Order for Alice [validated] | Stock available for Alice [confirmed] | Base rate for Alice + regional adjustment [shipping ready]",
+                result.getResult());
+
+        // Verify step operations in child context were tracked
+        assertNotNull(runner.getOperation("validate-order"));
+        assertNotNull(runner.getOperation("confirm-inventory"));
+        assertNotNull(runner.getOperation("finalize-shipping"));
+    }
+
     @ParameterizedTest
     @CsvSource({"100, 1000, 20", "500, 2000, 30", "1000, 3000, 50"})
     void testManyAsyncStepsExample(int steps, long maxExecutionTime, long maxReplayTime) {

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/child/VirtualChildContextExampleTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/child/VirtualChildContextExampleTest.java
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples.child;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.examples.types.GreetingRequest;
+import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
+
+class VirtualChildContextExampleTest {
+
+    @Test
+    void testVirtualChildContextExampleRunsToCompletion() {
+        var handler = new VirtualChildContextExample();
+        var runner = LocalDurableTestRunner.create(GreetingRequest.class, handler);
+
+        var input = new GreetingRequest("Alice");
+        var result = runner.runUntilComplete(input);
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(
+                "Order for Alice [validated] | Stock available for Alice [confirmed] | Base rate for Alice + regional adjustment [shipping ready]",
+                result.getResult(String.class));
+    }
+
+    @Test
+    void testVirtualChildContextExampleSuspendsOnFirstRun() {
+        var handler = new VirtualChildContextExample();
+        var runner = LocalDurableTestRunner.create(GreetingRequest.class, handler);
+
+        var input = new GreetingRequest("Bob");
+
+        // First run should suspend due to wait operations inside child contexts
+        var result = runner.run(input);
+        assertEquals(ExecutionStatus.PENDING, result.getStatus());
+    }
+
+    @Test
+    void testVirtualChildContextExampleReplay() {
+        var handler = new VirtualChildContextExample();
+        var runner = LocalDurableTestRunner.create(GreetingRequest.class, handler);
+
+        var input = new GreetingRequest("Alice");
+
+        // First full execution
+        var result1 = runner.runUntilComplete(input);
+        assertEquals(ExecutionStatus.SUCCEEDED, result1.getStatus());
+
+        // Replay — should return cached results
+        var result2 = runner.run(input);
+        assertEquals(ExecutionStatus.SUCCEEDED, result2.getStatus());
+        assertEquals(result1.getResult(String.class), result2.getResult(String.class));
+    }
+}

--- a/examples/template.yaml
+++ b/examples/template.yaml
@@ -296,6 +296,23 @@ Resources:
                 - lambda:GetDurableExecutionState
               Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:child-context-example-${JavaVersion}-runtime"
 
+  VirtualChildContextExampleFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Join
+        - '-'
+        - - 'virtual-child-context-example'
+          - !Ref JavaVersion
+          - runtime
+      Handler: "software.amazon.lambda.durable.examples.child.VirtualChildContextExample"
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - lambda:CheckpointDurableExecutions
+                - lambda:GetDurableExecutionState
+              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:virtual-child-context-example-${JavaVersion}-runtime"
+
   WaitAsyncExampleFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ChildContextIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ChildContextIntegrationTest.java
@@ -91,7 +91,7 @@ class ChildContextIntegrationTest {
         assertEquals(ExecutionStatus.FAILED, result.getStatus());
         assertEquals(1, childExecutionCount.get());
 
-        // Second run - replays, should throw same exception without re-executing
+        // Second run - replays, should throw same exception with re-executing
         result = runner.run("test");
         assertEquals(ExecutionStatus.FAILED, result.getStatus());
         assertTrue(result.getError().isPresent());
@@ -121,7 +121,7 @@ class ChildContextIntegrationTest {
         assertEquals(ExecutionStatus.FAILED, result.getStatus());
         assertEquals(1, childExecutionCount.get());
 
-        // Second run - replays, should throw same exception without re-executing
+        // Second run - replays, should throw same exception with re-executing
         result = runner.run("test");
         assertEquals(ExecutionStatus.FAILED, result.getStatus());
         assertTrue(result.getError().isPresent());

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ChildContextIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ChildContextIntegrationTest.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.OperationType;
+import software.amazon.lambda.durable.config.RunInChildContextConfig;
 import software.amazon.lambda.durable.model.ExecutionStatus;
 import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
 
@@ -42,6 +43,34 @@ class ChildContextIntegrationTest {
         assertEquals(1, childExecutionCount.get(), "Child function should not re-execute on replay");
     }
 
+    @Test
+    void virtualChildContextResultSurvivesReplay() {
+        var childExecutionCount = new AtomicInteger(0);
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, ctx) -> ctx.runInChildContext(
+                        "compute",
+                        TypeToken.get(String.class),
+                        child -> {
+                            childExecutionCount.incrementAndGet();
+                            return child.step("work", String.class, stepCtx -> "result-" + input);
+                        },
+                        RunInChildContextConfig.builder().isVirtual(true).build()));
+
+        // First run - executes child context
+        var result = runner.runUntilComplete("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("result-test", result.getResult(String.class));
+        assertEquals(1, childExecutionCount.get());
+
+        // Second run - replays, should return cached result without re-executing
+        result = runner.run("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("result-test", result.getResult(String.class));
+        assertEquals(2, childExecutionCount.get(), "Child function should re-execute on replay");
+    }
+
     /**
      * A child context that fails with a reconstructable exception SHALL preserve the exception type, message, and error
      * details through the checkpoint-and-replay cycle.
@@ -70,6 +99,36 @@ class ChildContextIntegrationTest {
         assertEquals("java.lang.IllegalArgumentException", error.errorType());
         assertEquals("bad input: test", error.errorMessage());
         assertEquals(1, childExecutionCount.get(), "Child function should not re-execute on failed replay");
+    }
+
+    @Test
+    void virtualChildContextExceptionPreservedOnReplay() {
+        var childExecutionCount = new AtomicInteger(0);
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, ctx) -> ctx.runInChildContext(
+                        "failing",
+                        String.class,
+                        child -> {
+                            childExecutionCount.incrementAndGet();
+                            throw new IllegalArgumentException("bad input: " + input);
+                        },
+                        RunInChildContextConfig.builder().isVirtual(true).build()));
+
+        // First run - child context fails
+        var result = runner.run("test");
+        assertEquals(ExecutionStatus.FAILED, result.getStatus());
+        assertEquals(1, childExecutionCount.get());
+
+        // Second run - replays, should throw same exception without re-executing
+        result = runner.run("test");
+        assertEquals(ExecutionStatus.FAILED, result.getStatus());
+        assertTrue(result.getError().isPresent());
+        var error = result.getError().get();
+        assertEquals("java.lang.IllegalArgumentException", error.errorType());
+        assertEquals("bad input: test", error.errorMessage());
+        assertEquals(2, childExecutionCount.get(), "Child function should re-execute on failed replay");
     }
 
     /** Operations checkpointed from within a child context SHALL have the child context's ID as their parentId. */

--- a/sdk/src/main/java/software/amazon/lambda/durable/config/RunInChildContextConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/config/RunInChildContextConfig.java
@@ -68,7 +68,7 @@ public class RunInChildContextConfig {
         }
 
         /**
-         * Sets whether the context operation will be checkpointed (default: false).
+         * Sets whether the context is virtual (not checkpointed) or not.
          *
          * @param isVirtual true if the context is virtual (no checkpointing), false otherwise
          * @return this builder for method chaining

--- a/sdk/src/main/java/software/amazon/lambda/durable/config/RunInChildContextConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/config/RunInChildContextConfig.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.config;
 
+import java.util.Objects;
 import software.amazon.lambda.durable.serde.SerDes;
 
 /**
@@ -11,9 +12,11 @@ import software.amazon.lambda.durable.serde.SerDes;
  */
 public class RunInChildContextConfig {
     private final SerDes serDes;
+    private final Boolean isVirtual;
 
     private RunInChildContextConfig(Builder builder) {
         this.serDes = builder.serDes;
+        this.isVirtual = Objects.requireNonNullElse(builder.isVirtual, false);
     }
 
     /**
@@ -24,8 +27,13 @@ public class RunInChildContextConfig {
         return serDes;
     }
 
+    /** Returns true if the context operation will not be checkpointed, false otherwise. */
+    public Boolean isVirtual() {
+        return isVirtual;
+    }
+
     public Builder toBuilder() {
-        return new Builder(serDes);
+        return new Builder().serDes(serDes).isVirtual(isVirtual);
     }
 
     /**
@@ -34,16 +42,15 @@ public class RunInChildContextConfig {
      * @return a new Builder instance
      */
     public static Builder builder() {
-        return new Builder(null);
+        return new Builder();
     }
 
     /** Builder for creating StepConfig instances. */
     public static class Builder {
         private SerDes serDes;
+        private Boolean isVirtual;
 
-        public Builder(SerDes serDes) {
-            this.serDes = serDes;
-        }
+        private Builder() {}
 
         /**
          * Sets a custom serializer for the step.
@@ -57,6 +64,17 @@ public class RunInChildContextConfig {
          */
         public Builder serDes(SerDes serDes) {
             this.serDes = serDes;
+            return this;
+        }
+
+        /**
+         * Sets whether the context operation will be checkpointed (default: false).
+         *
+         * @param isVirtual true if the context is virtual (no checkpointing), false otherwise
+         * @return this builder for method chaining
+         */
+        public Builder isVirtual(Boolean isVirtual) {
+            this.isVirtual = isVirtual;
             return this;
         }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/context/DurableContextImpl.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/context/DurableContextImpl.java
@@ -407,6 +407,6 @@ public class DurableContextImpl extends BaseContextImpl implements DurableContex
      * @return the parent of this context if virtual, otherwise this context id
      */
     public String getParentId() {
-        return isVirtual ? parentContext.getContextId() : getContextId();
+        return isVirtual ? parentContext.getParentId() : getContextId();
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -68,6 +68,7 @@ public abstract class BaseDurableOperation {
      * @param operationIdentifier the unique identifier for this operation
      * @param durableContext the parent context this operation belongs to
      * @param parentOperation the parent operation if this is a branch/iteration of a ConcurrencyOperation
+     * @param isVirtual whether this is a virtual operation that should not be persisted
      */
     protected BaseDurableOperation(
             OperationIdentifier operationIdentifier,

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
@@ -61,7 +61,7 @@ public class ChildContextOperation<T> extends SerializableDurableOperation<T> {
             TypeToken<T> resultTypeToken,
             RunInChildContextConfig config,
             DurableContextImpl durableContext) {
-        this(operationIdentifier, function, resultTypeToken, config, durableContext, false, null);
+        this(operationIdentifier, function, resultTypeToken, config, durableContext, null);
     }
 
     // child context for a ConcurrencyOperation branch
@@ -71,9 +71,14 @@ public class ChildContextOperation<T> extends SerializableDurableOperation<T> {
             TypeToken<T> resultTypeToken,
             RunInChildContextConfig config,
             DurableContextImpl durableContext,
-            boolean isVirtual,
             ConcurrencyOperation<?> parentOperation) {
-        super(operationIdentifier, resultTypeToken, config.serDes(), durableContext, parentOperation, isVirtual);
+        super(
+                operationIdentifier,
+                resultTypeToken,
+                config.serDes(),
+                durableContext,
+                parentOperation,
+                config.isVirtual());
         this.function = function;
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ConcurrencyOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ConcurrencyOperation.java
@@ -119,9 +119,11 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
                 OperationIdentifier.of(operationId, name, OperationType.CONTEXT, branchSubType),
                 function,
                 resultType,
-                RunInChildContextConfig.builder().serDes(serDes).build(),
+                RunInChildContextConfig.builder()
+                        .serDes(serDes)
+                        .isVirtual(nestingType == NestingType.FLAT)
+                        .build(),
                 rootContext,
-                nestingType == NestingType.FLAT,
                 this);
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/SerializableDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/SerializableDurableOperation.java
@@ -55,6 +55,16 @@ public abstract class SerializableDurableOperation<T> extends BaseDurableOperati
         this(operationIdentifier, resultTypeToken, resultSerDes, durableContext, null, false);
     }
 
+    /**
+     * Constructs a new durable operation.
+     *
+     * @param operationIdentifier the unique identifier for this operation
+     * @param resultTypeToken the type token for deserializing the result
+     * @param resultSerDes the serializer/deserializer for the result
+     * @param durableContext the parent context this operation belongs to
+     * @param isVirtual whether this is a virtual operation that should not be persisted
+     * @param parentOperation the parent operation if this is a branch/iteration of a ConcurrencyOperation
+     */
     protected SerializableDurableOperation(
             OperationIdentifier operationIdentifier,
             TypeToken<T> resultTypeToken,

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/ChildContextOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/ChildContextOperationTest.java
@@ -66,6 +66,15 @@ class ChildContextOperationTest {
                 durableContext);
     }
 
+    private ChildContextOperation<String> createVirtualOperation(Function<DurableContext, String> func) {
+        return new ChildContextOperation<>(
+                OPERATION_IDENTIFIER,
+                func,
+                TypeToken.get(String.class),
+                RunInChildContextConfig.builder().serDes(SERDES).isVirtual(true).build(),
+                durableContext);
+    }
+
     private ChildContextOperation<String> createOperationWithParent(
             Function<DurableContext, String> func, ConcurrencyOperation<?> parent) {
         return new ChildContextOperation<>(
@@ -105,6 +114,22 @@ class ChildContextOperationTest {
 
         assertEquals("cached-value", result);
         assertFalse(functionCalled.get(), "Function should not be called during SUCCEEDED replay");
+    }
+
+    /** Virtual contexts are always executed, even during SUCCEEDED replay. */
+    @Test
+    void executeVirtualContext() {
+        var functionCalled = new AtomicBoolean(false);
+        var operation = createVirtualOperation(ctx -> {
+            functionCalled.set(true);
+            return "should-execute";
+        });
+
+        operation.execute();
+        var result = operation.get();
+
+        assertEquals("should-execute", result);
+        assertTrue(functionCalled.get(), "Function should be called during SUCCEEDED replay");
     }
 
     // ===== FAILED replay =====

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/ChildContextOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/ChildContextOperationTest.java
@@ -74,7 +74,6 @@ class ChildContextOperationTest {
                 TypeToken.get(String.class),
                 RunInChildContextConfig.builder().serDes(SERDES).build(),
                 durableContext,
-                false,
                 parent);
     }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

- fixes: #360 

### Description

- added `isVirtual` to `RunInChildContextConfig` so that users can start a virtual context with no checkpoint overhead.
- recursively get the parent operation id until it's non-virtual. Currently it's always getting the direct parent for a virtual context because in map/parallel the direct parent is always non-virtual.

### Demo/Screenshots

<img width="686" height="517" alt="image" src="https://github.com/user-attachments/assets/ef0c6f18-5306-4643-b8c3-0fb89fb183a8" />


### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
