### PR TITLE
Update UserAgent header format

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
@@ -72,7 +72,7 @@ public final class DurableConfig {
 
     private static final String VERSION_FILE = "/version.prop";
     private static final String PROJECT_VERSION = getProjectVersion(VERSION_FILE);
-    private static final String USER_AGENT_SUFFIX = "@aws/durable-execution-sdk-java/" + PROJECT_VERSION;
+    private static final String USER_AGENT_SUFFIX = "aws-durable-execution-sdk-java/" + PROJECT_VERSION;
 
     /**
      * A default ExecutorService for running user-defined operations. Uses a cached thread pool with daemon threads by

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
@@ -272,7 +272,7 @@ class DurableConfigTest {
         var userAgentSuffix = overrideConfig.advancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX);
         assertTrue(userAgentSuffix.isPresent(), "USER_AGENT_SUFFIX should be set");
         assertTrue(
-                userAgentSuffix.get().contains("@aws/durable-execution-sdk-java/"),
+                userAgentSuffix.get().contains("aws-durable-execution-sdk-java/"),
                 "User agent suffix should contain SDK identifier, got: " + userAgentSuffix.get());
     }
 
@@ -286,7 +286,7 @@ class DurableConfigTest {
         var overrideConfig = result.overrideConfiguration();
         var userAgentSuffix = overrideConfig.advancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX);
         assertTrue(userAgentSuffix.isPresent());
-        assertTrue(userAgentSuffix.get().contains("@aws/durable-execution-sdk-java/"));
+        assertTrue(userAgentSuffix.get().contains("aws-durable-execution-sdk-java/"));
     }
 
     @Test


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

N/A

### Description

- Update the UserAgent header format to match a new format being used in the other language SDKs.
- The new format is `aws-durable-execution-sdk-java/{version}`.

### Demo/Screenshots

N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

Updated unit tests.

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
