### PR TITLE
move SuspendExecutionException to under Error

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/CallbackIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/CallbackIntegrationTest.java
@@ -271,10 +271,9 @@ class CallbackIntegrationTest {
                 ctx.waitForCallback("approval", String.class, (callbackId, stepCtx) -> {});
                 fail();
                 return "should not reach here";
+            } catch (SuspendExecutionException e) {
+                throw e;
             } catch (Exception e) {
-                if (e instanceof SuspendExecutionException) {
-                    throw e;
-                }
                 assertInstanceOf(CallbackFailedException.class, e);
                 throw e;
             }
@@ -309,10 +308,9 @@ class CallbackIntegrationTest {
                 ctx.waitForCallback("approval", String.class, (callbackId, stepCtx) -> {});
                 fail();
                 return "should not reach here";
+            } catch (SuspendExecutionException e) {
+                throw e;
             } catch (Exception e) {
-                if (e instanceof SuspendExecutionException) {
-                    throw e;
-                }
                 assertInstanceOf(CallbackTimeoutException.class, e);
                 throw e;
             }
@@ -339,10 +337,9 @@ class CallbackIntegrationTest {
                     // original exception
                     throw new IllegalArgumentException(errorMessage);
                 });
+            } catch (SuspendExecutionException e) {
+                throw e;
             } catch (Exception e) {
-                if (e instanceof SuspendExecutionException) {
-                    throw e;
-                }
                 assertInstanceOf(IllegalArgumentException.class, e);
                 assertEquals(errorMessage, e.getMessage());
                 throw e;

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/DurableExecutionError.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/DurableExecutionError.java
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.execution;
+
+/**
+ * A throwable error that can be used internally by Durable Execution SDK. Users of the SDK should not throw this error
+ * directly or catch this error in their code.
+ */
+public class DurableExecutionError extends Error {
+    public DurableExecutionError(String message) {
+        super(message);
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
@@ -351,7 +351,7 @@ public class ExecutionManager implements AutoCloseable {
         return executionExceptionFuture.isCompletedExceptionally();
     }
 
-    private void stopAllOperations(Exception cause) {
+    private void stopAllOperations(Throwable cause) {
         registeredOperations.values().forEach(op -> op.getCompletionFuture().completeExceptionally(cause));
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/SuspendExecutionException.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/SuspendExecutionException.java
@@ -3,7 +3,7 @@
 package software.amazon.lambda.durable.execution;
 
 /** Exception thrown to suspend execution during wait operations. This is an internal control flow mechanism. */
-public class SuspendExecutionException extends RuntimeException {
+public class SuspendExecutionException extends DurableExecutionError {
     public SuspendExecutionException() {
         super("Execution suspended for wait operation");
     }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

- Fixes #369 

### Description

When users catch `Exception` in their error handling code, they'll also catch `SuspendExecutionException` which needs to be rethrown to make durable function work.

The current workaround is to explicitly handle `SuspendExecutionException` before handling `Exception` like below
```
catch (SuspendExecutionException e) {
    throw e;
}
catch (Exception e) {
    // user's logic to handle exceptions
}
```

This change is to prevent `SuspendExecutionException` is mistakenly handled by users' exception handling logic.

With this change, the following exception handler code will not see `SuspendExecutionException` 
```
catch (Exception e) {
    // user's logic to handle exceptions
}
```

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
