### PR TITLE
Retry interrupted at-most-once steps

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/StepSemanticsIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/StepSemanticsIntegrationTest.java
@@ -4,6 +4,7 @@ package software.amazon.lambda.durable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import software.amazon.lambda.durable.config.StepConfig;
@@ -157,7 +158,7 @@ class StepSemanticsIntegrationTest {
     }
 
     @Test
-    void testAtMostOnceThrowsExceptionAfterCheckpointFailure() {
+    void testAtMostOnceNoRetryFailsAfterCheckpointFailure() {
         var executionCount = new AtomicInteger(0);
 
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
@@ -170,6 +171,7 @@ class StepSemanticsIntegrationTest {
                     },
                     StepConfig.builder()
                             .semantics(StepSemantics.AT_MOST_ONCE_PER_RETRY)
+                            .retryStrategy(RetryStrategies.Presets.NO_RETRY)
                             .build());
         });
 
@@ -182,5 +184,34 @@ class StepSemanticsIntegrationTest {
 
         assertEquals(ExecutionStatus.FAILED, result.getStatus());
         assertEquals(1, executionCount.get());
+    }
+
+    @Test
+    void testAtMostOnceRetriesAfterCheckpointFailure() {
+        var executionCount = new AtomicInteger(0);
+
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            return context.step(
+                    "step",
+                    String.class,
+                    stepCtx -> {
+                        var count = executionCount.incrementAndGet();
+                        return "Executed " + count + " times";
+                    },
+                    StepConfig.builder()
+                            .semantics(StepSemantics.AT_MOST_ONCE_PER_RETRY)
+                            .retryStrategy(RetryStrategies.fixedDelay(3, Duration.ofSeconds(1)))
+                            .build());
+        });
+
+        runner.run("test");
+        assertEquals(1, executionCount.get());
+
+        runner.resetCheckpointToStarted("step");
+        var result = runner.runUntilComplete("test");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(2, executionCount.get());
+        assertEquals("Executed 2 times", result.getResult(String.class));
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
@@ -165,10 +165,9 @@ public class StepOperation<T> extends SerializableDurableOperation<T> {
             errorObject = serializeException(exception);
         }
 
-        var isRetryable = !(exception instanceof StepInterruptedException);
         var retryDecision = config.retryStrategy().makeRetryDecision(exception, attempt);
 
-        if (isRetryable && retryDecision.shouldRetry()) {
+        if (retryDecision.shouldRetry()) {
             // Send RETRY
             var retryDelayInSeconds = Math.toIntExact(retryDecision.delay().toSeconds());
             var retryUpdate = OperationUpdate.builder()


### PR DESCRIPTION
## Summary
- let interrupted `AT_MOST_ONCE_PER_RETRY` steps use the configured retry strategy instead of failing before retry handling
- keep the no-retry checkpoint-failure path covered and add a regression for retrying after a STARTED checkpoint replay

Closes #394.

## Testing
- `docker run --rm -v ${PWD}:/workspace -w /workspace maven:3.9-eclipse-temurin-21 mvn -pl sdk-integration-tests -am -Dtest=StepSemanticsIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`