### PR TITLE
feat(sdk): Add DurableExecutionPlugin interface and plugin runner

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
@@ -21,6 +21,7 @@ import software.amazon.awssdk.services.lambda.model.GetDurableExecutionStateRequ
 import software.amazon.lambda.durable.client.DurableExecutionClient;
 import software.amazon.lambda.durable.client.LambdaDurableFunctionsClient;
 import software.amazon.lambda.durable.logging.LoggerConfig;
+import software.amazon.lambda.durable.plugin.PluginRunner;
 import software.amazon.lambda.durable.retry.PollingStrategies;
 import software.amazon.lambda.durable.retry.PollingStrategy;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
@@ -94,6 +95,7 @@ public final class DurableConfig {
     private final LoggerConfig loggerConfig;
     private final PollingStrategy pollingStrategy;
     private final Duration checkpointDelay;
+    private final PluginRunner pluginRunner;
 
     private DurableConfig(Builder builder) {
         this.durableExecutionClient = Objects.requireNonNullElseGet(
@@ -104,6 +106,7 @@ public final class DurableConfig {
         this.loggerConfig = Objects.requireNonNullElseGet(builder.loggerConfig, LoggerConfig::defaults);
         this.pollingStrategy = Objects.requireNonNullElse(builder.pollingStrategy, PollingStrategies.Presets.DEFAULT);
         this.checkpointDelay = Objects.requireNonNullElseGet(builder.checkpointDelay, () -> Duration.ofSeconds(0));
+        this.pluginRunner = PluginRunner.noOp();
 
         validateConfiguration();
     }
@@ -178,6 +181,20 @@ public final class DurableConfig {
      */
     public Duration getCheckpointDelay() {
         return checkpointDelay;
+    }
+
+    /**
+     * Gets the plugin runner that dispatches lifecycle events to registered plugins.
+     *
+     * <p>Currently returns a no-op runner. Plugin registration via config will be added when the plugin system is fully
+     * wired.
+     *
+     * @return PluginRunner instance (always no-op until plugin wiring is complete)
+     * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+     */
+    @Deprecated
+    public PluginRunner getPluginRunner() {
+        return pluginRunner;
     }
 
     public void validateConfiguration() {

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPlugin.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPlugin.java
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+/**
+ * Plugin interface for instrumenting durable execution lifecycle events.
+ *
+ * <p>Implement this interface to integrate observability tools (OpenTelemetry, Datadog, etc.) with the durable
+ * execution SDK. The SDK calls these hooks at key lifecycle points without requiring modifications to core SDK code.
+ *
+ * <p>All methods have default no-op implementations, allowing plugins to override only the hooks they need.
+ *
+ * <p>Plugin errors are isolated — exceptions thrown by plugin methods are caught and logged but never disrupt SDK
+ * execution.
+ *
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public interface DurableExecutionPlugin {
+
+    // ─── Invocation-level hooks ──────────────────────────────────────────
+
+    /**
+     * Called at the start of each Lambda invocation. Use to set up per-invocation state (trace ID, invocation span).
+     *
+     * <p>Check {@link InvocationInfo#isFirstInvocation()} to detect the first invocation of an execution (useful for
+     * sampling decisions or execution-level span creation).
+     */
+    default void onInvocationStart(InvocationInfo info) {}
+
+    /**
+     * Called at the end of each Lambda invocation. Use to flush spans/metrics before Lambda freezes.
+     *
+     * <p>This hook is awaited — the SDK blocks until it returns. This is the only safe flush point before Lambda
+     * freezes the execution environment.
+     *
+     * <p>Check {@link InvocationEndInfo#invocationStatus()} to detect if the execution reached a terminal state in this
+     * invocation (useful for writing summary records or flushing final data).
+     */
+    default void onInvocationEnd(InvocationEndInfo info) {}
+
+    // ─── Operation-level hooks ───────────────────────────────────────────
+
+    /** Called when an operation starts (including replay). Use for logging/metrics that want replay visibility. */
+    default void onOperationStart(OperationInfo info) {}
+
+    /**
+     * Called when an operation reaches a terminal status for the first time (not on replay).
+     *
+     * <p>The OTel plugin creates operation spans here with backfilled start/end timestamps.
+     */
+    default void onOperationEnd(OperationEndInfo info) {}
+
+    // ─── User function hooks ─────────────────────────────────────────────
+
+    /**
+     * Called when a user-provided function starts executing. This fires for both step attempts (with {@code attempt}
+     * set) and child context functions (with {@code attempt} null).
+     *
+     * <p>This hook fires on the same thread as user code, so plugins can set OTel context via
+     * {@code Context.makeCurrent()} here.
+     */
+    default void onUserFunctionStart(UserFunctionStartInfo info) {}
+
+    /**
+     * Called when a user-provided function finishes executing. This fires for both step attempts and child context
+     * functions.
+     *
+     * <p>This hook fires on the same thread as user code, so plugins can close OTel scopes here.
+     */
+    default void onUserFunctionEnd(UserFunctionEndInfo info) {}
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationEndInfo.java
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+/**
+ * Information provided at the end of a Lambda invocation.
+ *
+ * @param requestId the Lambda request ID for this invocation
+ * @param executionArn the durable execution ARN
+ * @param isFirstInvocation true if this is the first invocation of the execution
+ * @param invocationStatus the invocation outcome (SUCCEEDED, FAILED, or PENDING)
+ * @param executionError non-null if the execution failed
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public record InvocationEndInfo(
+        String requestId,
+        String executionArn,
+        boolean isFirstInvocation,
+        InvocationStatus invocationStatus,
+        Throwable executionError) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+/**
+ * Invocation-level information available to plugin hooks.
+ *
+ * @param requestId the Lambda request ID for this invocation
+ * @param executionArn the durable execution ARN
+ * @param isFirstInvocation true if this is the first invocation of the execution (not a replay invocation)
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public record InvocationInfo(String requestId, String executionArn, boolean isFirstInvocation) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationStatus.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationStatus.java
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+/**
+ * Status of a Lambda invocation at the end of its execution.
+ *
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public enum InvocationStatus {
+    /** Execution completed successfully in this invocation. */
+    SUCCEEDED,
+    /** Execution failed in this invocation. */
+    FAILED,
+    /** Execution suspended — will resume in a future invocation. */
+    PENDING
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationEndInfo.java
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+import java.time.Instant;
+
+/**
+ * Extended operation information for operation end events.
+ *
+ * @param id operation ID — hashed
+ * @param rawId operation ID — unhashed
+ * @param name human-readable operation name (may be null)
+ * @param type operation type
+ * @param subType operation sub-type (may be null)
+ * @param parentId parent operation ID — hashed (null for root-level operations)
+ * @param rawParentId parent operation ID — unhashed (null for root-level operations)
+ * @param startTimestamp when the operation started
+ * @param endTimestamp when the operation ended
+ * @param error non-null if the operation failed
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public record OperationEndInfo(
+        String id,
+        String rawId,
+        String name,
+        String type,
+        String subType,
+        String parentId,
+        String rawParentId,
+        Instant startTimestamp,
+        Instant endTimestamp,
+        Throwable error) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationInfo.java
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+import java.time.Instant;
+
+/**
+ * Operation-level information available to plugin hooks.
+ *
+ * <p>Field names mirror the {@code Operation} type from the AWS SDK for consistency.
+ *
+ * @param id operation ID — hashed (unique within the execution)
+ * @param rawId operation ID — unhashed (e.g. "1", "2", "hash(1)-1" for child contexts)
+ * @param name human-readable operation name (may be null)
+ * @param type operation type (STEP, WAIT, CONTEXT, CHAINED_INVOKE, CALLBACK)
+ * @param subType operation sub-type (Map, Parallel, RunInChildContext, WaitForCondition, etc.) — may be null
+ * @param parentId parent operation ID — hashed (null for root-level operations)
+ * @param rawParentId parent operation ID — unhashed (null for root-level operations)
+ * @param startTimestamp when the operation started (may be from a prior invocation)
+ * @param endTimestamp when the operation ended (null if still running)
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public record OperationInfo(
+        String id,
+        String rawId,
+        String name,
+        String type,
+        String subType,
+        String parentId,
+        String rawParentId,
+        Instant startTimestamp,
+        Instant endTimestamp) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
@@ -1,0 +1,176 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+import java.time.Instant;
+import software.amazon.awssdk.services.lambda.model.Operation;
+import software.amazon.awssdk.services.lambda.model.OperationType;
+import software.amazon.lambda.durable.model.OperationSubType;
+
+/**
+ * Utility methods for converting SDK internal types to plugin info records.
+ *
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public final class PluginInfoConverter {
+
+    private PluginInfoConverter() {}
+
+    /**
+     * Converts an SDK {@link Operation} to an {@link OperationInfo} for plugin hooks.
+     *
+     * @param operation the SDK operation (may be null for first-start scenarios)
+     * @param operationId the hashed operation ID
+     * @param rawId the unhashed operation ID (e.g. "1", "2", "1-1")
+     * @param name the operation name
+     * @param type the operation type
+     * @param subType the operation sub-type (may be null)
+     * @param parentId the hashed parent operation ID (may be null for root operations)
+     * @param rawParentId the unhashed parent ID (may be null for root operations)
+     * @return an OperationInfo record
+     */
+    public static OperationInfo toOperationInfo(
+            Operation operation,
+            String operationId,
+            String rawId,
+            String name,
+            OperationType type,
+            OperationSubType subType,
+            String parentId,
+            String rawParentId) {
+        return new OperationInfo(
+                operationId,
+                rawId,
+                name,
+                type != null ? type.toString() : null,
+                subType != null ? subType.getValue() : null,
+                parentId,
+                rawParentId,
+                operation != null ? operation.startTimestamp() : null,
+                operation != null ? operation.endTimestamp() : null);
+    }
+
+    /**
+     * Converts an SDK {@link Operation} to an {@link OperationInfo} using the operation's own fields. Raw IDs are not
+     * available from the Operation object alone, so they are set to null.
+     *
+     * @param operation the SDK operation
+     * @return an OperationInfo record
+     */
+    public static OperationInfo toOperationInfo(Operation operation) {
+        if (operation == null) {
+            return new OperationInfo(null, null, null, null, null, null, null, null, null);
+        }
+        return new OperationInfo(
+                operation.id(),
+                null,
+                operation.name(),
+                operation.type() != null ? operation.type().toString() : null,
+                operation.subType(),
+                operation.parentId(),
+                null,
+                operation.startTimestamp(),
+                operation.endTimestamp());
+    }
+
+    /**
+     * Creates an {@link OperationEndInfo} from an SDK {@link Operation} and an optional error.
+     *
+     * @param operation the completed SDK operation
+     * @param operationId the hashed operation ID
+     * @param rawId the unhashed operation ID
+     * @param name the operation name
+     * @param type the operation type
+     * @param subType the operation sub-type (may be null)
+     * @param parentId the hashed parent operation ID (may be null)
+     * @param rawParentId the unhashed parent ID (may be null)
+     * @param error the error if the operation failed (may be null)
+     * @return an OperationEndInfo record
+     */
+    public static OperationEndInfo toOperationEndInfo(
+            Operation operation,
+            String operationId,
+            String rawId,
+            String name,
+            OperationType type,
+            OperationSubType subType,
+            String parentId,
+            String rawParentId,
+            Throwable error) {
+        return new OperationEndInfo(
+                operationId,
+                rawId,
+                name,
+                type != null ? type.toString() : null,
+                subType != null ? subType.getValue() : null,
+                parentId,
+                rawParentId,
+                operation != null ? operation.startTimestamp() : null,
+                operation != null ? operation.endTimestamp() : null,
+                error);
+    }
+
+    /**
+     * Creates a {@link UserFunctionStartInfo} for when a user function starts executing.
+     *
+     * @param operationId the hashed operation ID
+     * @param rawId the unhashed operation ID
+     * @param name the operation name
+     * @param type the operation type
+     * @param subType the operation sub-type (may be null)
+     * @param parentId the hashed parent operation ID (may be null)
+     * @param rawParentId the unhashed parent ID (may be null)
+     * @param isReplay true if the user function is called during replay (context operations)
+     * @param attempt the 1-based attempt number (null for context operations)
+     * @return a UserFunctionStartInfo record
+     */
+    public static UserFunctionStartInfo toUserFunctionStartInfo(
+            String operationId,
+            String rawId,
+            String name,
+            OperationType type,
+            OperationSubType subType,
+            String parentId,
+            String rawParentId,
+            boolean isReplay,
+            Integer attempt) {
+        return new UserFunctionStartInfo(
+                operationId,
+                rawId,
+                name,
+                type != null ? type.toString() : null,
+                subType != null ? subType.getValue() : null,
+                parentId,
+                rawParentId,
+                Instant.now(),
+                isReplay,
+                attempt);
+    }
+
+    /**
+     * Creates a {@link UserFunctionEndInfo} from a start info and outcome.
+     *
+     * @param startInfo the start info from when the function began
+     * @param succeeded true if the function completed without error
+     * @param error the error if the function failed (may be null)
+     * @return a UserFunctionEndInfo record
+     */
+    public static UserFunctionEndInfo toUserFunctionEndInfo(
+            UserFunctionStartInfo startInfo, boolean succeeded, Throwable error) {
+        return new UserFunctionEndInfo(
+                startInfo.id(),
+                startInfo.rawId(),
+                startInfo.name(),
+                startInfo.type(),
+                startInfo.subType(),
+                startInfo.parentId(),
+                startInfo.rawParentId(),
+                startInfo.startTimestamp(),
+                Instant.now(),
+                startInfo.isReplay(),
+                startInfo.attempt(),
+                succeeded,
+                error);
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginRunner.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginRunner.java
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Composes multiple {@link DurableExecutionPlugin} instances into a single dispatcher.
+ *
+ * <p>Event hooks are fire-and-forget: each plugin is called in order, errors are swallowed.
+ *
+ * <p>{@code onInvocationEnd} is awaited (the SDK blocks until it returns) to allow plugins to flush data before Lambda
+ * freezes.
+ *
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public class PluginRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(PluginRunner.class);
+    private static final PluginRunner NO_OP = new PluginRunner(Collections.emptyList());
+
+    private final List<DurableExecutionPlugin> plugins;
+
+    public PluginRunner(List<DurableExecutionPlugin> plugins) {
+        this.plugins = plugins != null ? List.copyOf(plugins) : Collections.emptyList();
+    }
+
+    /** Returns a no-op runner that does nothing. */
+    public static PluginRunner noOp() {
+        return NO_OP;
+    }
+
+    /** Returns true if no plugins are registered. */
+    public boolean isEmpty() {
+        return plugins.isEmpty();
+    }
+
+    // ─── Event hooks ─────────────────────────────────────────────────────
+
+    /** Calls a void hook on all plugins, swallowing any errors. */
+    private void run(Consumer<DurableExecutionPlugin> hook) {
+        for (var plugin : plugins) {
+            try {
+                hook.accept(plugin);
+            } catch (Exception e) {
+                logger.warn("Plugin hook threw exception", e);
+            }
+        }
+    }
+
+    public void onInvocationStart(InvocationInfo info) {
+        run(p -> p.onInvocationStart(info));
+    }
+
+    /**
+     * Called at the end of each invocation. Awaited — the SDK blocks until all plugins return, allowing plugins to
+     * flush spans/metrics before Lambda freezes.
+     */
+    public void onInvocationEnd(InvocationEndInfo info) {
+        run(p -> p.onInvocationEnd(info));
+    }
+
+    public void onOperationStart(OperationInfo info) {
+        run(p -> p.onOperationStart(info));
+    }
+
+    public void onOperationEnd(OperationEndInfo info) {
+        run(p -> p.onOperationEnd(info));
+    }
+
+    public void onUserFunctionStart(UserFunctionStartInfo info) {
+        run(p -> p.onUserFunctionStart(info));
+    }
+
+    public void onUserFunctionEnd(UserFunctionEndInfo info) {
+        run(p -> p.onUserFunctionEnd(info));
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionEndInfo.java
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+import java.time.Instant;
+
+/**
+ * Information provided when a user function finishes executing.
+ *
+ * <p>This fires for both step attempts and child context functions, on the same thread as the user code.
+ *
+ * @param id operation ID — hashed
+ * @param rawId operation ID — unhashed
+ * @param name human-readable operation name (may be null)
+ * @param type operation type (STEP, CONTEXT, etc.)
+ * @param subType operation sub-type (Map, Parallel, WaitForCondition, etc.) — may be null
+ * @param parentId parent operation ID — hashed (null for root-level operations)
+ * @param rawParentId parent operation ID — unhashed (null for root-level operations)
+ * @param startTimestamp when the user function started
+ * @param endTimestamp when the user function ended
+ * @param isReplay true if the user function was called during replay (context operations)
+ * @param attempt 1-based attempt number for steps/waitForCondition, null for context operations
+ * @param succeeded true if the user function completed without error
+ * @param error non-null if the user function failed
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public record UserFunctionEndInfo(
+        String id,
+        String rawId,
+        String name,
+        String type,
+        String subType,
+        String parentId,
+        String rawParentId,
+        Instant startTimestamp,
+        Instant endTimestamp,
+        boolean isReplay,
+        Integer attempt,
+        boolean succeeded,
+        Throwable error) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionStartInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionStartInfo.java
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+import java.time.Instant;
+
+/**
+ * Information provided when a user function starts executing.
+ *
+ * <p>This fires for both step attempts and child context functions, on the same thread as the user code. For steps,
+ * {@code attempt} is non-null (1-based). For context operations, {@code attempt} is null.
+ *
+ * @param id operation ID — hashed
+ * @param rawId operation ID — unhashed
+ * @param name human-readable operation name (may be null)
+ * @param type operation type (STEP, CONTEXT, etc.)
+ * @param subType operation sub-type (Map, Parallel, WaitForCondition, etc.) — may be null
+ * @param parentId parent operation ID — hashed (null for root-level operations)
+ * @param rawParentId parent operation ID — unhashed (null for root-level operations)
+ * @param startTimestamp when the user function started
+ * @param isReplay true if the user function is being called during replay (context operations)
+ * @param attempt 1-based attempt number for steps/waitForCondition, null for context operations
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public record UserFunctionStartInfo(
+        String id,
+        String rawId,
+        String name,
+        String type,
+        String subType,
+        String parentId,
+        String rawParentId,
+        Instant startTimestamp,
+        boolean isReplay,
+        Integer attempt) {}

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginInfoConverterTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginInfoConverterTest.java
@@ -1,0 +1,276 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.lambda.model.Operation;
+import software.amazon.awssdk.services.lambda.model.OperationStatus;
+import software.amazon.awssdk.services.lambda.model.OperationType;
+import software.amazon.lambda.durable.model.OperationSubType;
+
+class PluginInfoConverterTest {
+
+    private static final String OPERATION_ID = "op-1";
+    private static final String RAW_ID = "1";
+    private static final String OPERATION_NAME = "validate-order";
+    private static final String PARENT_ID = "parent-ctx";
+    private static final String RAW_PARENT_ID = "0";
+    private static final Instant START = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Instant END = Instant.parse("2026-01-01T00:00:05Z");
+
+    // ─── toOperationInfo (from Operation) ────────────────────────────────
+
+    @Test
+    void toOperationInfo_fromOperation_mapsAllFields() {
+        var operation = Operation.builder()
+                .id(OPERATION_ID)
+                .name(OPERATION_NAME)
+                .type(OperationType.STEP)
+                .subType("WaitForCondition")
+                .parentId(PARENT_ID)
+                .status(OperationStatus.SUCCEEDED)
+                .startTimestamp(START)
+                .endTimestamp(END)
+                .build();
+
+        var info = PluginInfoConverter.toOperationInfo(operation);
+
+        assertEquals(OPERATION_ID, info.id());
+        assertNull(info.rawId());
+        assertEquals(OPERATION_NAME, info.name());
+        assertEquals("STEP", info.type());
+        assertEquals("WaitForCondition", info.subType());
+        assertEquals(PARENT_ID, info.parentId());
+        assertNull(info.rawParentId());
+        assertEquals(START, info.startTimestamp());
+        assertEquals(END, info.endTimestamp());
+    }
+
+    @Test
+    void toOperationInfo_fromNullOperation_returnsAllNulls() {
+        var info = PluginInfoConverter.toOperationInfo(null);
+
+        assertNull(info.id());
+        assertNull(info.rawId());
+        assertNull(info.name());
+        assertNull(info.type());
+        assertNull(info.subType());
+        assertNull(info.parentId());
+        assertNull(info.rawParentId());
+        assertNull(info.startTimestamp());
+        assertNull(info.endTimestamp());
+    }
+
+    @Test
+    void toOperationInfo_fromOperation_handlesNullFields() {
+        var operation = Operation.builder()
+                .id(OPERATION_ID)
+                .status(OperationStatus.STARTED)
+                .startTimestamp(START)
+                .build();
+
+        var info = PluginInfoConverter.toOperationInfo(operation);
+
+        assertEquals(OPERATION_ID, info.id());
+        assertNull(info.rawId());
+        assertNull(info.name());
+        assertNull(info.type());
+        assertNull(info.subType());
+        assertNull(info.parentId());
+        assertNull(info.rawParentId());
+        assertEquals(START, info.startTimestamp());
+        assertNull(info.endTimestamp());
+    }
+
+    // ─── toOperationInfo (from explicit params) ──────────────────────────
+
+    @Test
+    void toOperationInfo_fromParams_mapsAllFields() {
+        var operation =
+                Operation.builder().startTimestamp(START).endTimestamp(END).build();
+
+        var info = PluginInfoConverter.toOperationInfo(
+                operation,
+                OPERATION_ID,
+                RAW_ID,
+                OPERATION_NAME,
+                OperationType.STEP,
+                OperationSubType.WAIT_FOR_CONDITION,
+                PARENT_ID,
+                RAW_PARENT_ID);
+
+        assertEquals(OPERATION_ID, info.id());
+        assertEquals(RAW_ID, info.rawId());
+        assertEquals(OPERATION_NAME, info.name());
+        assertEquals("STEP", info.type());
+        assertEquals("WaitForCondition", info.subType());
+        assertEquals(PARENT_ID, info.parentId());
+        assertEquals(RAW_PARENT_ID, info.rawParentId());
+        assertEquals(START, info.startTimestamp());
+        assertEquals(END, info.endTimestamp());
+    }
+
+    @Test
+    void toOperationInfo_fromParams_nullOperation_noTimestamps() {
+        var info = PluginInfoConverter.toOperationInfo(
+                null, OPERATION_ID, RAW_ID, OPERATION_NAME, OperationType.WAIT, OperationSubType.WAIT, null, null);
+
+        assertEquals(OPERATION_ID, info.id());
+        assertEquals(RAW_ID, info.rawId());
+        assertEquals(OPERATION_NAME, info.name());
+        assertEquals("WAIT", info.type());
+        assertEquals("Wait", info.subType());
+        assertNull(info.parentId());
+        assertNull(info.rawParentId());
+        assertNull(info.startTimestamp());
+        assertNull(info.endTimestamp());
+    }
+
+    @Test
+    void toOperationInfo_fromParams_nullSubType() {
+        var info = PluginInfoConverter.toOperationInfo(
+                null, OPERATION_ID, RAW_ID, OPERATION_NAME, OperationType.STEP, null, null, null);
+
+        assertNull(info.subType());
+    }
+
+    // ─── toOperationEndInfo ──────────────────────────────────────────────
+
+    @Test
+    void toOperationEndInfo_mapsAllFields() {
+        var operation =
+                Operation.builder().startTimestamp(START).endTimestamp(END).build();
+        var error = new RuntimeException("step failed");
+
+        var info = PluginInfoConverter.toOperationEndInfo(
+                operation,
+                OPERATION_ID,
+                RAW_ID,
+                OPERATION_NAME,
+                OperationType.STEP,
+                OperationSubType.STEP,
+                PARENT_ID,
+                RAW_PARENT_ID,
+                error);
+
+        assertEquals(OPERATION_ID, info.id());
+        assertEquals(RAW_ID, info.rawId());
+        assertEquals(OPERATION_NAME, info.name());
+        assertEquals("STEP", info.type());
+        assertEquals("Step", info.subType());
+        assertEquals(PARENT_ID, info.parentId());
+        assertEquals(RAW_PARENT_ID, info.rawParentId());
+        assertEquals(START, info.startTimestamp());
+        assertEquals(END, info.endTimestamp());
+        assertEquals(error, info.error());
+    }
+
+    @Test
+    void toOperationEndInfo_nullError_forSuccess() {
+        var operation =
+                Operation.builder().startTimestamp(START).endTimestamp(END).build();
+
+        var info = PluginInfoConverter.toOperationEndInfo(
+                operation,
+                OPERATION_ID,
+                RAW_ID,
+                OPERATION_NAME,
+                OperationType.STEP,
+                OperationSubType.STEP,
+                null,
+                null,
+                null);
+
+        assertNull(info.error());
+    }
+
+    // ─── toUserFunctionStartInfo ────────────────────────────────────────
+
+    @Test
+    void toUserFunctionStartInfo_stepAttempt() {
+        var info = PluginInfoConverter.toUserFunctionStartInfo(
+                OPERATION_ID,
+                RAW_ID,
+                OPERATION_NAME,
+                OperationType.STEP,
+                OperationSubType.STEP,
+                PARENT_ID,
+                RAW_PARENT_ID,
+                false,
+                3);
+
+        assertEquals(OPERATION_ID, info.id());
+        assertEquals(RAW_ID, info.rawId());
+        assertEquals(OPERATION_NAME, info.name());
+        assertEquals("STEP", info.type());
+        assertEquals("Step", info.subType());
+        assertEquals(PARENT_ID, info.parentId());
+        assertEquals(RAW_PARENT_ID, info.rawParentId());
+        assertNotNull(info.startTimestamp());
+        assertFalse(info.isReplay());
+        assertEquals(3, info.attempt());
+    }
+
+    @Test
+    void toUserFunctionStartInfo_contextOperation() {
+        var info = PluginInfoConverter.toUserFunctionStartInfo(
+                OPERATION_ID,
+                RAW_ID,
+                OPERATION_NAME,
+                OperationType.CONTEXT,
+                OperationSubType.MAP,
+                PARENT_ID,
+                RAW_PARENT_ID,
+                true,
+                null);
+
+        assertEquals("CONTEXT", info.type());
+        assertEquals("Map", info.subType());
+        assertTrue(info.isReplay());
+        assertNull(info.attempt());
+    }
+
+    // ─── toUserFunctionEndInfo ───────────────────────────────────────────
+
+    @Test
+    void toUserFunctionEndInfo_succeeded() {
+        var startInfo = PluginInfoConverter.toUserFunctionStartInfo(
+                OPERATION_ID,
+                RAW_ID,
+                OPERATION_NAME,
+                OperationType.STEP,
+                OperationSubType.STEP,
+                PARENT_ID,
+                RAW_PARENT_ID,
+                false,
+                1);
+
+        var endInfo = PluginInfoConverter.toUserFunctionEndInfo(startInfo, true, null);
+
+        assertEquals(OPERATION_ID, endInfo.id());
+        assertEquals(RAW_ID, endInfo.rawId());
+        assertEquals(OPERATION_NAME, endInfo.name());
+        assertEquals(startInfo.startTimestamp(), endInfo.startTimestamp());
+        assertNotNull(endInfo.endTimestamp());
+        assertFalse(endInfo.isReplay());
+        assertEquals(1, endInfo.attempt());
+        assertTrue(endInfo.succeeded());
+        assertNull(endInfo.error());
+    }
+
+    @Test
+    void toUserFunctionEndInfo_failed() {
+        var error = new RuntimeException("step failed");
+        var startInfo = PluginInfoConverter.toUserFunctionStartInfo(
+                OPERATION_ID, RAW_ID, OPERATION_NAME, OperationType.STEP, null, null, null, false, 2);
+
+        var endInfo = PluginInfoConverter.toUserFunctionEndInfo(startInfo, false, error);
+
+        assertFalse(endInfo.succeeded());
+        assertEquals(error, endInfo.error());
+        assertEquals(2, endInfo.attempt());
+    }
+}

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
@@ -1,0 +1,217 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PluginRunnerTest {
+
+    // ─── No-op / empty behavior ──────────────────────────────────────────
+
+    @Test
+    void noOpRunner_doesNothing() {
+        var runner = PluginRunner.noOp();
+
+        assertTrue(runner.isEmpty());
+        assertDoesNotThrow(() -> runner.onInvocationStart(invocationInfo()));
+        assertDoesNotThrow(() -> runner.onInvocationEnd(invocationEndInfo()));
+    }
+
+    @Test
+    void emptyPluginList_behavesAsNoOp() {
+        var runner = new PluginRunner(List.of());
+
+        assertTrue(runner.isEmpty());
+        assertDoesNotThrow(() -> runner.onUserFunctionStart(attemptInfo()));
+    }
+
+    @Test
+    void nullPluginList_behavesAsNoOp() {
+        var runner = new PluginRunner(null);
+
+        assertTrue(runner.isEmpty());
+        assertDoesNotThrow(() -> runner.onOperationStart(operationInfo()));
+    }
+
+    // ─── Fire-and-forget event hooks ─────────────────────────────────────
+
+    @Test
+    void fireAndForget_callsAllPlugins() {
+        var calls = new ArrayList<String>();
+        var plugin1 = new TestPlugin("p1", calls);
+        var plugin2 = new TestPlugin("p2", calls);
+        var runner = new PluginRunner(List.of(plugin1, plugin2));
+
+        runner.onInvocationStart(invocationInfo());
+
+        assertEquals(List.of("p1:onInvocationStart", "p2:onInvocationStart"), calls);
+    }
+
+    @Test
+    void fireAndForget_swallowsExceptions() {
+        var calls = new ArrayList<String>();
+        var throwingPlugin = new ThrowingPlugin();
+        var normalPlugin = new TestPlugin("p2", calls);
+        var runner = new PluginRunner(List.of(throwingPlugin, normalPlugin));
+
+        assertDoesNotThrow(() -> runner.onInvocationStart(invocationInfo()));
+        assertEquals(List.of("p2:onInvocationStart"), calls);
+    }
+
+    @Test
+    void fireAndForget_callsAllHookTypes() {
+        var calls = new ArrayList<String>();
+        var plugin = new TestPlugin("p", calls);
+        var runner = new PluginRunner(List.of(plugin));
+
+        runner.onInvocationStart(invocationInfo());
+        runner.onInvocationEnd(invocationEndInfo());
+        runner.onOperationStart(operationInfo());
+        runner.onOperationEnd(operationEndInfo());
+        runner.onUserFunctionStart(attemptInfo());
+        runner.onUserFunctionEnd(attemptEndInfo());
+
+        assertEquals(
+                List.of(
+                        "p:onInvocationStart",
+                        "p:onInvocationEnd",
+                        "p:onOperationStart",
+                        "p:onOperationEnd",
+                        "p:onUserFunctionStart",
+                        "p:onUserFunctionEnd"),
+                calls);
+    }
+
+    // ─── Awaited hooks ───────────────────────────────────────────────────
+
+    @Test
+    void awaitedHooks_callAllPlugins() {
+        var calls = new ArrayList<String>();
+        var plugin1 = new TestPlugin("p1", calls);
+        var plugin2 = new TestPlugin("p2", calls);
+        var runner = new PluginRunner(List.of(plugin1, plugin2));
+
+        runner.onInvocationEnd(invocationEndInfo());
+
+        assertEquals(List.of("p1:onInvocationEnd", "p2:onInvocationEnd"), calls);
+    }
+
+    @Test
+    void awaitedHooks_swallowExceptions_butCallRemainingPlugins() {
+        var calls = new ArrayList<String>();
+        var throwingPlugin = new ThrowingPlugin();
+        var normalPlugin = new TestPlugin("p2", calls);
+        var runner = new PluginRunner(List.of(throwingPlugin, normalPlugin));
+
+        assertDoesNotThrow(() -> runner.onInvocationEnd(invocationEndInfo()));
+        assertEquals(List.of("p2:onInvocationEnd"), calls);
+    }
+
+    // ─── Thread safety (basic) ───────────────────────────────────────────
+
+    @Test
+    void pluginRunner_isImmutable() {
+        var calls = new ArrayList<String>();
+        var mutableList = new ArrayList<DurableExecutionPlugin>();
+        mutableList.add(new TestPlugin("p1", calls));
+        var runner = new PluginRunner(mutableList);
+
+        // Modifying the original list should not affect the runner
+        mutableList.add(new TestPlugin("p2", calls));
+
+        runner.onInvocationStart(invocationInfo());
+
+        // Only p1 should be called — p2 was added after construction
+        assertEquals(List.of("p1:onInvocationStart"), calls);
+    }
+
+    // ─── Helper methods ──────────────────────────────────────────────────
+
+    private static InvocationInfo invocationInfo() {
+        return new InvocationInfo("req-123", "arn:aws:lambda:us-east-1:123456789012:function:test", false);
+    }
+
+    private static InvocationEndInfo invocationEndInfo() {
+        return new InvocationEndInfo(
+                "req-123", "arn:aws:lambda:us-east-1:123456789012:function:test", false, null, null);
+    }
+
+    private static OperationInfo operationInfo() {
+        return new OperationInfo("op-1", "1", "test-step", "STEP", null, null, null, Instant.now(), null);
+    }
+
+    private static OperationEndInfo operationEndInfo() {
+        return new OperationEndInfo(
+                "op-1", "1", "test-step", "STEP", null, null, null, Instant.now(), Instant.now(), null);
+    }
+
+    private static UserFunctionStartInfo attemptInfo() {
+        return new UserFunctionStartInfo("op-1", "1", "test-step", "STEP", null, null, null, Instant.now(), false, 1);
+    }
+
+    private static UserFunctionEndInfo attemptEndInfo() {
+        return new UserFunctionEndInfo(
+                "op-1", "1", "test-step", "STEP", null, null, null, Instant.now(), Instant.now(), false, 1, true, null);
+    }
+
+    // ─── Test plugin implementations ─────────────────────────────────────
+
+    /** Plugin that records which hooks were called. */
+    private static class TestPlugin implements DurableExecutionPlugin {
+        private final String name;
+        private final List<String> calls;
+
+        TestPlugin(String name, List<String> calls) {
+            this.name = name;
+            this.calls = calls;
+        }
+
+        @Override
+        public void onInvocationStart(InvocationInfo info) {
+            calls.add(name + ":onInvocationStart");
+        }
+
+        @Override
+        public void onInvocationEnd(InvocationEndInfo info) {
+            calls.add(name + ":onInvocationEnd");
+        }
+
+        @Override
+        public void onOperationStart(OperationInfo info) {
+            calls.add(name + ":onOperationStart");
+        }
+
+        @Override
+        public void onOperationEnd(OperationEndInfo info) {
+            calls.add(name + ":onOperationEnd");
+        }
+
+        @Override
+        public void onUserFunctionStart(UserFunctionStartInfo info) {
+            calls.add(name + ":onUserFunctionStart");
+        }
+
+        @Override
+        public void onUserFunctionEnd(UserFunctionEndInfo info) {
+            calls.add(name + ":onUserFunctionEnd");
+        }
+    }
+
+    /** Plugin that throws on every hook. */
+    private static class ThrowingPlugin implements DurableExecutionPlugin {
+        @Override
+        public void onInvocationStart(InvocationInfo info) {
+            throw new RuntimeException("boom");
+        }
+
+        @Override
+        public void onInvocationEnd(InvocationEndInfo info) {
+            throw new RuntimeException("boom");
+        }
+    }
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
https://github.com/aws/aws-durable-execution-sdk-java/issues/364

### Description

Introduce the plugin system foundation for the durable execution SDK:
- DurableInstrumentationPlugin interface with lifecycle hooks for execution, invocation, operation, and attempt-level events
- PluginRunner that composes multiple plugins with fire-and-forget and callback-wrapping execution semantics
- Info records (InvocationInfo, OperationInfo, AttemptInfo, AttemptEndInfo, OperationEndInfo, ExecutionEndInfo, OperationChangeInfo)
- withPlugins(List<DurableInstrumentationPlugin>) config field in DurableConfig.Builder

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Yes

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
