### PR TITLE
feat(sdk): add user-friendly error for non-durable functions

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableHandler.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableHandler.java
@@ -130,6 +130,11 @@ public abstract class DurableHandler<I, O> implements RequestStreamHandler {
         var inputString = new String(inputStream.readAllBytes());
         logger.debug("Raw input from durable handler: {}", inputString);
         var input = serDes.deserialize(inputString, TypeToken.get(DurableExecutionInput.class));
+        // Durable function inputs must contain DurableExecutionArn and CheckpointToken
+        if (input.durableExecutionArn() == null || input.checkpointToken() == null) {
+            throw new IllegalStateException(
+                    "Unexpected payload provided to start the durable execution. DurableConfig must be set in Lambda function configuration.");
+        }
         var output = DurableExecutor.execute(input, context, inputType, this::handleRequest, config);
         outputStream.write(serDes.serialize(output).getBytes());
     }

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableHandlerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableHandlerTest.java
@@ -4,7 +4,12 @@ package software.amazon.lambda.durable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 class DurableHandlerTest {
@@ -45,6 +50,19 @@ class DurableHandlerTest {
                     "Cannot determine type from base class: class software.amazon.lambda.durable.DurableHandlerTest$1InvalidHandler",
                     e.getMessage());
         }
+    }
+
+    @Test
+    void testNonDurableFunctionThrowsUserFriendlyError() throws Exception {
+        var handler = new TestDurableHandler();
+        // Durable function inputs must contain DurableExecutionArn and CheckpointToken
+        var nonDurableInput = "{\"input\": \"non-durable\"}";
+        var inputStream = new ByteArrayInputStream(nonDurableInput.getBytes(StandardCharsets.UTF_8));
+        var outputStream = new ByteArrayOutputStream();
+
+        var exception =
+                assertThrows(IllegalStateException.class, () -> handler.handleRequest(inputStream, outputStream, null));
+        assertTrue(exception.getMessage().contains("Unexpected payload provided to start the durable execution"));
     }
 
     // Test handler implementation


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

https://github.com/aws/aws-durable-execution-sdk-java/issues/385

### Description

- Added a check for when the SDK is run in a non-durable function, and throw a more user-friendly error message.
- Also added a test for this check.

Durable functions must have `DurableConfig` set up, and their invocation payloads will always include a `DurableExecutionArn` and `CheckpointToken`. If those values are missing, then the function does not have `DurableConfig` set up, so it is non-durable.

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? YES

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
