### PR TITLE
feat(sdk): Add UpdatedOperationIds support for replay status tracking

### DIFF
--- a/examples/src/main/java/software/amazon/lambda/durable/examples/general/PluginExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/general/PluginExample.java
@@ -17,7 +17,7 @@ import software.amazon.lambda.durable.plugin.*;
  * <p>Expected output for a successful run:
  *
  * <pre>
- * [PLUGIN] onInvocationStart: requestId=..., executionArn=..., firstInvocation=true
+ * [PLUGIN] onInvocationStart: requestId=..., durableExecutionArn=..., firstInvocation=true
  * [PLUGIN] onOperationStart: name=create-greeting, type=STEP
  * [PLUGIN] onUserFunctionStart: name=create-greeting, attempt=1
  * [PLUGIN] onUserFunctionEnd: name=create-greeting, succeeded=true
@@ -54,8 +54,8 @@ public class PluginExample extends DurableHandler<GreetingRequest, String> {
         @Override
         public void onInvocationStart(InvocationInfo info) {
             System.out.printf(
-                    "[PLUGIN] onInvocationStart: requestId=%s, executionArn=%s, firstInvocation=%s%n",
-                    info.requestId(), info.executionArn(), info.isFirstInvocation());
+                    "[PLUGIN] onInvocationStart: requestId=%s, durableExecutionArn=%s, firstInvocation=%s%n",
+                    info.requestId(), info.durableExecutionArn(), info.isFirstInvocation());
         }
 
         @Override

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
@@ -26,15 +26,15 @@ public class DeterministicIdGenerator implements IdGenerator {
 
     private final AtomicReference<String> executionTraceId = new AtomicReference<>(null);
     private final ThreadLocal<String> pendingSpanOperationId = new ThreadLocal<>();
-    private final AtomicReference<String> executionArn = new AtomicReference<>(null);
+    private final AtomicReference<String> durableExecutionArn = new AtomicReference<>(null);
 
     /**
      * Sets the execution ARN used for generating deterministic IDs.
      *
      * @param arn the durable execution ARN
      */
-    public void setExecutionArn(String arn) {
-        this.executionArn.set(arn);
+    public void setDurableExecutionArn(String arn) {
+        this.durableExecutionArn.set(arn);
         this.executionTraceId.set(generateTraceIdFromArn(arn));
     }
 
@@ -96,7 +96,7 @@ public class DeterministicIdGenerator implements IdGenerator {
      * <p>Uses SHA-256 hash truncated to 16 hex chars (64 bits) for the span ID.
      */
     private String generateSpanIdFromOperation(String operationId) {
-        var arn = executionArn.get();
+        var arn = durableExecutionArn.get();
         var input = arn != null ? arn + ":" + operationId : operationId;
         var hash = sha256(input);
         // Span ID is 16 hex chars (8 bytes)

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
@@ -37,16 +37,16 @@ public final class MdcSpanEnricher {
     /**
      * Injects the current span's trace ID and span ID into MDC.
      *
-     * @param executionArn the durable execution ARN (may be null)
+     * @param durableExecutionArn the durable execution ARN (may be null)
      */
-    public static void inject(String executionArn) {
+    public static void inject(String durableExecutionArn) {
         var span = Span.current();
         if (span.getSpanContext().isValid()) {
             MDC.put(MDC_TRACE_ID, span.getSpanContext().getTraceId());
             MDC.put(MDC_SPAN_ID, span.getSpanContext().getSpanId());
         }
-        if (executionArn != null) {
-            MDC.put(MDC_EXECUTION_ARN, executionArn);
+        if (durableExecutionArn != null) {
+            MDC.put(MDC_EXECUTION_ARN, durableExecutionArn);
         }
     }
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OpenTelemetryDurablePlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OpenTelemetryDurablePlugin.java
@@ -60,7 +60,7 @@ public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
 
     // Per-invocation state
     private volatile Span invocationSpan;
-    private volatile String executionArn;
+    private volatile String durableExecutionArn;
 
     // Thread-safe storage for operation spans (keyed by operationId) — open spans that need ending
     private final ConcurrentHashMap<String, Span> operationSpans = new ConcurrentHashMap<>();
@@ -116,8 +116,8 @@ public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
 
     @Override
     public void onInvocationStart(InvocationInfo info) {
-        this.executionArn = info.executionArn();
-        idGenerator.setExecutionArn(info.executionArn());
+        this.durableExecutionArn = info.durableExecutionArn();
+        idGenerator.setDurableExecutionArn(info.durableExecutionArn());
 
         // Extract parent context from Lambda environment (X-Ray, W3C, etc.)
         var extractedParentContext = contextExtractor.extract();
@@ -125,7 +125,7 @@ public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
         // Create invocation span as child of extracted context
         var spanBuilder = tracer.spanBuilder("durable.invocation")
                 .setParent(extractedParentContext)
-                .setAttribute(DURABLE_EXECUTION_ARN, info.executionArn())
+                .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())
                 .setAttribute(DURABLE_FIRST_INVOCATION, info.isFirstInvocation());
 
         if (info.requestId() != null) {
@@ -189,7 +189,7 @@ public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
 
         var spanBuilder = tracer.spanBuilder(spanName(info.type(), info.subType(), info.name()))
                 .setParent(parentContext)
-                .setAttribute(DURABLE_EXECUTION_ARN, executionArn)
+                .setAttribute(DURABLE_EXECUTION_ARN, durableExecutionArn)
                 .setAttribute(DURABLE_OPERATION_ID, info.id())
                 .setAttribute(DURABLE_OPERATION_TYPE, info.type());
 
@@ -239,7 +239,7 @@ public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
                 .setParent(parentContext)
                 .setStartTimestamp(info.startTimestamp() != null ? info.startTimestamp() : Instant.now());
 
-        spanBuilder.setAttribute(DURABLE_EXECUTION_ARN, executionArn);
+        spanBuilder.setAttribute(DURABLE_EXECUTION_ARN, durableExecutionArn);
         spanBuilder.setAttribute(DURABLE_OPERATION_ID, info.id());
 
         if (info.type() != null) {
@@ -261,7 +261,7 @@ public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
 
         // Inject trace context into MDC for log-trace correlation
         if (enableMdc) {
-            MdcSpanEnricher.inject(executionArn);
+            MdcSpanEnricher.inject(durableExecutionArn);
         }
     }
 

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/DeterministicIdGeneratorTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/DeterministicIdGeneratorTest.java
@@ -29,7 +29,7 @@ class DeterministicIdGeneratorTest {
 
     @Test
     void generateTraceId_withArn_returnsDeterministic() {
-        generator.setExecutionArn("arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1");
+        generator.setDurableExecutionArn("arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1");
 
         var id1 = generator.generateTraceId();
         var id2 = generator.generateTraceId();
@@ -40,10 +40,10 @@ class DeterministicIdGeneratorTest {
 
     @Test
     void generateTraceId_differentArns_produceDifferentIds() {
-        generator.setExecutionArn("arn:exec1");
+        generator.setDurableExecutionArn("arn:exec1");
         var id1 = generator.generateTraceId();
 
-        generator.setExecutionArn("arn:exec2");
+        generator.setDurableExecutionArn("arn:exec2");
         var id2 = generator.generateTraceId();
 
         assertNotEquals(id1, id2);
@@ -60,7 +60,7 @@ class DeterministicIdGeneratorTest {
 
     @Test
     void generateSpanId_withOperationId_returnsDeterministic() {
-        generator.setExecutionArn("arn:exec1");
+        generator.setDurableExecutionArn("arn:exec1");
         generator.setNextSpanOperationId("op-hash-1");
         var id1 = generator.generateSpanId();
 
@@ -73,7 +73,7 @@ class DeterministicIdGeneratorTest {
 
     @Test
     void generateSpanId_differentOperationIds_produceDifferentIds() {
-        generator.setExecutionArn("arn:exec1");
+        generator.setDurableExecutionArn("arn:exec1");
 
         generator.setNextSpanOperationId("op-1");
         var id1 = generator.generateSpanId();
@@ -96,7 +96,7 @@ class DeterministicIdGeneratorTest {
 
     @Test
     void generateSpanIdForOperation_doesNotConsumePending() {
-        generator.setExecutionArn("arn:exec1");
+        generator.setDurableExecutionArn("arn:exec1");
         generator.setNextSpanOperationId("op-1");
 
         // This should NOT consume the pending
@@ -112,7 +112,7 @@ class DeterministicIdGeneratorTest {
 
     @Test
     void generateSpanIdForOperation_isDeterministic() {
-        generator.setExecutionArn("arn:exec1");
+        generator.setDurableExecutionArn("arn:exec1");
 
         var id1 = generator.generateSpanIdForOperation("op-1");
         var id2 = generator.generateSpanIdForOperation("op-1");
@@ -122,7 +122,7 @@ class DeterministicIdGeneratorTest {
 
     @Test
     void traceId_isValidHex() {
-        generator.setExecutionArn("arn:exec1");
+        generator.setDurableExecutionArn("arn:exec1");
         var traceId = generator.generateTraceId();
 
         assertTrue(traceId.matches("[0-9a-f]{32}"), "Trace ID should be 32 hex chars: " + traceId);
@@ -130,7 +130,7 @@ class DeterministicIdGeneratorTest {
 
     @Test
     void spanId_isValidHex() {
-        generator.setExecutionArn("arn:exec1");
+        generator.setDurableExecutionArn("arn:exec1");
         generator.setNextSpanOperationId("op-1");
         var spanId = generator.generateSpanId();
 

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/OtelPluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/OtelPluginIntegrationTest.java
@@ -203,6 +203,52 @@ class OtelPluginIntegrationTest {
     }
 
     @Test
+    void invokeFailedDuringSuspension_producesErrorSpan() {
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, ctx) -> {
+                    try {
+                        ctx.invoke("call-target", "target-fn", "{}", String.class);
+                    } catch (Exception e) {
+                        // expected failure
+                    }
+                    return "handled";
+                },
+                otelConfig);
+
+        // First invocation: invoke starts, suspends waiting for target
+        var result1 = runner.run("input");
+        assertEquals(ExecutionStatus.PENDING, result1.getStatus());
+
+        // Target fails while Lambda is frozen
+        runner.failChainedInvoke(
+                "call-target",
+                software.amazon.awssdk.services.lambda.model.ErrorObject.builder()
+                        .errorType("TargetError")
+                        .errorMessage("target function failed")
+                        .build());
+
+        // Resume
+        var result2 = runner.run("input");
+        assertEquals(ExecutionStatus.SUCCEEDED, result2.getStatus());
+
+        // The invoke operation span from the second invocation should have ERROR status
+        var allSpans = spanExporter.getFinishedSpanItems();
+        var invokeSpans = allSpans.stream()
+                .filter(s -> s.getName().contains("call-target"))
+                .toList();
+        assertTrue(invokeSpans.size() >= 2, "Should have at least 2 invoke spans (one PENDING, one ended with error)");
+
+        // The span from the second invocation should be marked as error
+        var errorSpan = invokeSpans.stream()
+                .filter(s -> s.getStatus().getStatusCode() == io.opentelemetry.api.trace.StatusCode.ERROR)
+                .findFirst();
+        assertTrue(
+                errorSpan.isPresent(),
+                "Should have an invoke span with ERROR status when invoke fails during suspension");
+    }
+
+    @Test
     void childContext_producesNestedSpans() {
         var runner = LocalDurableTestRunner.create(
                 String.class,

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/OtelPluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/OtelPluginIntegrationTest.java
@@ -159,6 +159,50 @@ class OtelPluginIntegrationTest {
     }
 
     @Test
+    void waitCompletedDuringSuspension_producesOperationSpan() {
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, ctx) -> {
+                    ctx.step("before-wait", String.class, stepCtx -> "pre");
+                    ctx.wait("pause", Duration.ofMinutes(1));
+                    ctx.step("after-wait", String.class, stepCtx -> "post");
+                    return "done";
+                },
+                otelConfig);
+
+        // First invocation: step completes, wait starts, suspend
+        var result1 = runner.run("input");
+        assertEquals(ExecutionStatus.PENDING, result1.getStatus());
+
+        // The wait operation span should be open (ended with PENDING status at invocation end)
+        var spansAfterFirst = spanExporter.getFinishedSpanItems();
+        var waitSpansAfterFirst = spansAfterFirst.stream()
+                .filter(s -> s.getName().equals("durable.wait:pause"))
+                .toList();
+        assertEquals(1, waitSpansAfterFirst.size(), "Wait span should exist after first invocation (ended as PENDING)");
+
+        // Advance time (wait completes externally) and resume
+        runner.advanceTime();
+        var result2 = runner.run("input");
+        assertEquals(ExecutionStatus.SUCCEEDED, result2.getStatus());
+
+        // After second invocation, the wait should have a second operation span
+        // (fired by onOperationEnd via updatedOperationIds) showing it completed
+        var allSpans = spanExporter.getFinishedSpanItems();
+        var waitSpansTotal = allSpans.stream()
+                .filter(s -> s.getName().equals("durable.wait:pause"))
+                .toList();
+        assertEquals(
+                2,
+                waitSpansTotal.size(),
+                "Wait should have 2 spans: one PENDING from first invocation, one completed from second. Got: "
+                        + allSpans.stream()
+                                .map(SpanData::getName)
+                                .filter(n -> n.contains("pause"))
+                                .toList());
+    }
+
+    @Test
     void childContext_producesNestedSpans() {
         var runner = LocalDurableTestRunner.create(
                 String.class,

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.lambda.model.ErrorObject;
 import software.amazon.lambda.durable.config.StepConfig;
 import software.amazon.lambda.durable.model.ExecutionStatus;
 import software.amazon.lambda.durable.model.WaitForConditionResult;
@@ -233,6 +234,100 @@ class PluginIntegrationTest {
                 .filter(info -> "step1".equals(info.name()))
                 .count();
         assertEquals(1, step1EndCount, "step1 onOperationEnd should fire exactly once");
+    }
+
+    @Test
+    void plugin_operationEnd_includesError_whenInvokeFailsDuringSuspension() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    try {
+                        context.invoke("call-target", "target-fn", "{}", String.class);
+                    } catch (Exception e) {
+                        // expected
+                    }
+                    return "done";
+                },
+                config);
+
+        // First invocation: invoke starts, suspends waiting for target
+        var result1 = runner.run("input");
+        assertEquals(ExecutionStatus.PENDING, result1.getStatus());
+
+        // Target fails while Lambda is frozen
+        runner.failChainedInvoke(
+                "call-target",
+                ErrorObject.builder()
+                        .errorType("TargetError")
+                        .errorMessage("target function failed")
+                        .build());
+
+        // Clear plugin state to only track second invocation
+        plugin.operationEnds.clear();
+
+        var result2 = runner.run("input");
+        assertEquals(ExecutionStatus.SUCCEEDED, result2.getStatus());
+
+        // onOperationEnd for "call-target" should fire with error info
+        var invokeEnd = plugin.operationEnds.stream()
+                .filter(info -> "call-target".equals(info.name()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(invokeEnd, "onOperationEnd should fire for failed invoke during suspension");
+        assertNotNull(invokeEnd.error(), "error should be propagated for failed invoke");
+        assertEquals("target function failed", invokeEnd.error().getMessage());
+    }
+
+    @Test
+    void plugin_operationEnd_includesError_whenStepFailsViaCheckpoint() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> context.step(
+                        "failing-step",
+                        String.class,
+                        stepCtx -> {
+                            throw new RuntimeException("step exploded");
+                        },
+                        StepConfig.builder()
+                                .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                                .build()),
+                config);
+
+        var result = runner.run("input");
+        assertEquals(ExecutionStatus.FAILED, result.getStatus());
+
+        // onOperationEnd for "failing-step" should fire with error info
+        var stepEnd = plugin.operationEnds.stream()
+                .filter(info -> "failing-step".equals(info.name()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(stepEnd, "onOperationEnd should fire for failed step");
+        assertNotNull(stepEnd.error(), "error should be propagated for failed step");
+        assertTrue(stepEnd.error().getMessage().contains("step exploded"));
+    }
+
+    @Test
+    void plugin_operationEnd_noError_whenOperationSucceeds() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class, (input, context) -> context.step("ok-step", String.class, stepCtx -> "success"), config);
+
+        runner.runUntilComplete("input");
+
+        var stepEnd = plugin.operationEnds.stream()
+                .filter(info -> "ok-step".equals(info.name()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(stepEnd, "onOperationEnd should fire for successful step");
+        assertNull(stepEnd.error(), "error should be null for successful step");
     }
 
     // ─── User function hooks ─────────────────────────────────────────────

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -39,7 +39,7 @@ class PluginIntegrationTest {
         // Verify invocation hooks fired
         assertEquals(1, plugin.invocationStarts.size());
         assertTrue(plugin.invocationStarts.get(0).isFirstInvocation());
-        assertNotNull(plugin.invocationStarts.get(0).executionArn());
+        assertNotNull(plugin.invocationStarts.get(0).durableExecutionArn());
 
         assertEquals(1, plugin.invocationEnds.size());
         assertEquals(InvocationStatus.SUCCEEDED, plugin.invocationEnds.get(0).invocationStatus());

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -175,6 +175,66 @@ class PluginIntegrationTest {
         assertEquals(1, step1EndCount, "step1 onOperationEnd should fire only once (not on replay)");
     }
 
+    @Test
+    void plugin_operationEnd_firedForOperationCompletedDuringSuspension() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    context.step("step1", String.class, stepCtx -> "done");
+                    context.wait("pause", Duration.ofMinutes(1));
+                    context.step("step2", String.class, stepCtx -> "final");
+                    return "complete";
+                },
+                config);
+
+        // First invocation: step1 completes, then suspends at wait
+        var result1 = runner.run("input");
+        assertEquals(ExecutionStatus.PENDING, result1.getStatus());
+
+        // Advance time (wait completes externally while Lambda was frozen)
+        runner.advanceTime();
+
+        // Clear plugin state to only track second invocation
+        plugin.operationEnds.clear();
+        plugin.operationStarts.clear();
+
+        var result2 = runner.run("input");
+        assertEquals(ExecutionStatus.SUCCEEDED, result2.getStatus());
+
+        // onOperationEnd for "pause" should fire during the second invocation
+        // because the wait completed during suspension (it's in updatedOperationIds)
+        long pauseEndCount = plugin.operationEnds.stream()
+                .filter(info -> "pause".equals(info.name()))
+                .count();
+        assertEquals(1, pauseEndCount, "wait operation onOperationEnd should fire when it completes during suspension");
+    }
+
+    @Test
+    void plugin_operationEnd_firedOnceForStepCompletingInCurrentInvocation() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    context.step("step1", String.class, stepCtx -> "done");
+                    return "complete";
+                },
+                config);
+
+        // Single invocation: step1 completes within this invocation
+        var result = runner.runUntilComplete("input");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+
+        long step1EndCount = plugin.operationEnds.stream()
+                .filter(info -> "step1".equals(info.name()))
+                .count();
+        assertEquals(1, step1EndCount, "step1 onOperationEnd should fire exactly once");
+    }
+
     // ─── User function hooks ─────────────────────────────────────────────
 
     @Test

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
@@ -346,10 +346,15 @@ public class LocalDurableTestRunner<I, O> {
         var allOps = new ArrayList<>(List.of(executionOp));
         allOps.addAll(existingOps);
 
+        // Compute updatedOperationIds: all operations that were updated since the last invocation.
+        // In the test runner, this is all operations that have been modified by advanceTime/complete calls.
+        var updatedOperationIds = storage.getUpdatedOperationIdsSinceLastInvocation();
+
         return new DurableExecutionInput(
                 executionArn,
                 UUID.randomUUID().toString(),
-                CheckpointUpdatedExecutionState.builder().operations(allOps).build());
+                CheckpointUpdatedExecutionState.builder().operations(allOps).build(),
+                updatedOperationIds);
     }
 
     private Context mockLambdaContext() {

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/LocalMemoryExecutionClient.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/LocalMemoryExecutionClient.java
@@ -4,9 +4,11 @@ package software.amazon.lambda.durable.testing.local;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -35,11 +37,12 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
     private final EventProcessor eventProcessor = new EventProcessor();
     private final List<OperationUpdate> operationUpdates = new CopyOnWriteArrayList<>();
     private final Map<String, Operation> updatedOperations = new HashMap<>();
+    private final Set<String> operationIdsUpdatedSinceLastInvocation = new HashSet<>();
 
     @Override
     public CheckpointDurableExecutionResponse checkpoint(String arn, String token, List<OperationUpdate> updates) {
         operationUpdates.addAll(updates);
-        updates.forEach(this::applyUpdate);
+        updates.forEach(update -> applyUpdate(update, true));
 
         var newToken = UUID.randomUUID().toString();
 
@@ -116,6 +119,16 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
         return existingOperations.values().stream().toList();
     }
 
+    /**
+     * Returns the list of operation IDs that have been updated since the last invocation, then clears the tracking set.
+     * This simulates the backend's {@code UpdatedOperationIds} field behavior.
+     */
+    public List<String> getUpdatedOperationIdsSinceLastInvocation() {
+        var ids = List.copyOf(operationIdsUpdatedSinceLastInvocation);
+        operationIdsUpdatedSinceLastInvocation.clear();
+        return ids;
+    }
+
     /** Build TestResult from current state. */
     public <O> TestResult<O> toTestResult(DurableExecutionOutput output, TypeToken<O> resultType, SerDes serDes) {
         var testOperations = existingOperations.values().stream()
@@ -139,7 +152,7 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
             throw new IllegalStateException("Operation not found: " + stepName);
         }
         var startedOp = op.toBuilder().status(OperationStatus.STARTED).build();
-        updateOperation(null, startedOp);
+        updateOperation(null, startedOp, false);
     }
 
     /** Simulate fire-and-forget checkpoint loss by removing the operation entirely */
@@ -154,10 +167,10 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
         }
     }
 
-    private void applyUpdate(OperationUpdate update) {
+    private void applyUpdate(OperationUpdate update, boolean withinCheckpoint) {
         var existingOp = existingOperations.get(update.id());
         var updatedOp = OperationProcessor.applyUpdate(update, existingOp);
-        updateOperation(update, updatedOp);
+        updateOperation(update, updatedOp, withinCheckpoint);
     }
 
     /** Get callback ID for a named callback operation. */
@@ -196,12 +209,12 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
                     .payload(result.result())
                     .error(result.error())
                     .build();
-            applyUpdate(update);
+            applyUpdate(update, false);
         } else if (result.operationStatus() == OperationStatus.TIMED_OUT
                 || result.operationStatus() == OperationStatus.STOPPED
                 || result.operationStatus() == OperationStatus.READY) {
             var newOp = OperationProcessor.applyResult(op, result);
-            updateOperation(null, newOp);
+            updateOperation(null, newOp, false);
         } else {
             throw new IllegalStateException("Unsupported OperationStatus in result: " + result.operationStatus());
         }
@@ -227,7 +240,7 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
                 .orElse(null);
     }
 
-    private void updateOperation(OperationUpdate update, Operation op) {
+    private void updateOperation(OperationUpdate update, Operation op, boolean withinCheckpoint) {
         // update can be null when an operation is updated without an OperationUpdate
         if (update == null) {
             eventProcessor.processUpdate(op);
@@ -237,6 +250,12 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
         existingOperations.put(op.id(), op);
         synchronized (updatedOperations) {
             updatedOperations.put(op.id(), op);
+        }
+        // Only track operations updated outside of a checkpoint call (i.e., between invocations)
+        // for the updatedOperationIds field. Operations updated during a checkpoint are already
+        // visible to the SDK via the checkpoint response.
+        if (!withinCheckpoint) {
+            operationIdsUpdatedSinceLastInvocation.add(op.id());
         }
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
@@ -57,6 +57,7 @@ public class ExecutionManager implements AutoCloseable {
     private final String durableExecutionArn;
     private final AtomicReference<ExecutionMode> executionMode;
     private final DurableConfig durableConfig;
+    private final Set<String> updatedOperationIdsSinceLastInvocation;
 
     // ===== Thread Coordination =====
     private final Map<String, BaseDurableOperation> registeredOperations = new ConcurrentHashMap<>();
@@ -70,6 +71,10 @@ public class ExecutionManager implements AutoCloseable {
     public ExecutionManager(DurableExecutionInput input, DurableConfig config) {
         durableConfig = config;
         this.durableExecutionArn = input.durableExecutionArn();
+
+        // Store the set of operation IDs updated since the last successful invocation
+        this.updatedOperationIdsSinceLastInvocation =
+                input.updatedOperationIds() != null ? Set.copyOf(input.updatedOperationIds()) : Collections.emptySet();
 
         // Create checkpoint batcher for internal coordination
         this.checkpointManager =
@@ -107,6 +112,18 @@ public class ExecutionManager implements AutoCloseable {
     /** Returns {@code true} if the execution is currently replaying completed operations. */
     public boolean isReplaying() {
         return executionMode.get() == ExecutionMode.REPLAY;
+    }
+
+    /**
+     * Returns {@code true} if the given operation was updated since the last successful invocation. This is used by the
+     * OTel plugin to determine whether a replayed completed operation should emit a span — only operations that
+     * transitioned during suspension should be traced on reinvocation.
+     *
+     * @param operationId the operation ID to check
+     * @return true if the operation was updated since the last successful invocation
+     */
+    public boolean isOperationUpdatedSinceLastInvocation(String operationId) {
+        return updatedOperationIdsSinceLastInvocation.contains(operationId);
     }
 
     /** Registers an operation so it can receive checkpoint completion notifications. */

--- a/sdk/src/main/java/software/amazon/lambda/durable/model/DurableExecutionInput.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/model/DurableExecutionInput.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.model;
 
+import java.util.List;
 import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 
 /**
@@ -10,6 +11,21 @@ import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionSt
  * @param durableExecutionArn ARN identifying this durable execution
  * @param checkpointToken token used to authenticate checkpoint API calls
  * @param initialExecutionState snapshot of operations already completed in previous invocations
+ * @param updatedOperationIds IDs of operations that changed since the previous successful invocation; empty list if
+ *     nothing changed
  */
 public record DurableExecutionInput(
-        String durableExecutionArn, String checkpointToken, CheckpointUpdatedExecutionState initialExecutionState) {}
+        String durableExecutionArn,
+        String checkpointToken,
+        CheckpointUpdatedExecutionState initialExecutionState,
+        List<String> updatedOperationIds) {
+
+    /**
+     * Constructor that defaults updatedOperationIds to empty list. Used by tests that don't need to supply updated
+     * operation IDs.
+     */
+    public DurableExecutionInput(
+            String durableExecutionArn, String checkpointToken, CheckpointUpdatedExecutionState initialExecutionState) {
+        this(durableExecutionArn, checkpointToken, initialExecutionState, List.of());
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -10,10 +10,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.lambda.model.ErrorObject;
 import software.amazon.awssdk.services.lambda.model.Operation;
+import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.awssdk.services.lambda.model.OperationType;
 import software.amazon.awssdk.services.lambda.model.OperationUpdate;
 import software.amazon.lambda.durable.context.DurableContextImpl;
+import software.amazon.lambda.durable.exception.DurableOperationException;
 import software.amazon.lambda.durable.exception.IllegalDurableOperationException;
 import software.amazon.lambda.durable.exception.NonDeterministicExecutionException;
 import software.amazon.lambda.durable.exception.UnrecoverableDurableExecutionException;
@@ -141,7 +144,7 @@ public abstract class BaseDurableOperation {
                 // This enables the OTel plugin to emit spans for operations that transitioned while Lambda was frozen.
                 if (replayCompletedOperation.get()
                         && executionManager.isOperationUpdatedSinceLastInvocation(getOperationId())) {
-                    fireOnOperationEnd(existing, null);
+                    fireOnOperationEnd(existing, extractErrorFromOperation(existing));
                 }
 
                 replay(existing);
@@ -354,7 +357,7 @@ public abstract class BaseDurableOperation {
 
             // Fire onOperationEnd plugin hook — operation reached terminal status for the first time (not replay)
             if (!replayCompletedOperation.get()) {
-                fireOnOperationEnd(operation, null);
+                fireOnOperationEnd(operation, extractErrorFromOperation(operation));
             }
 
             markCompletionFutureCompleted();
@@ -521,5 +524,44 @@ public abstract class BaseDurableOperation {
         var info = PluginInfoConverter.toOperationEndInfo(
                 operation, operationIdentifier, durableContext.getParentId(), error);
         getPluginRunner().onOperationEnd(info);
+    }
+
+    /**
+     * Extracts the error from a terminal operation as a Throwable. Returns null if the operation succeeded or has no
+     * error details.
+     */
+    private Throwable extractErrorFromOperation(Operation operation) {
+        if (operation.status() != OperationStatus.FAILED
+                && operation.status() != OperationStatus.TIMED_OUT
+                && operation.status() != OperationStatus.STOPPED) {
+            return null;
+        }
+        var errorObject = getErrorObject(operation);
+        if (errorObject == null) {
+            return null;
+        }
+        return new DurableOperationException(operation, errorObject);
+    }
+
+    /** Extracts the ErrorObject from an operation based on its type. */
+    private static ErrorObject getErrorObject(Operation operation) {
+        if (operation.type() == null) {
+            return null;
+        }
+        return switch (operation.type()) {
+            case STEP ->
+                operation.stepDetails() != null ? operation.stepDetails().error() : null;
+            case CHAINED_INVOKE ->
+                operation.chainedInvokeDetails() != null
+                        ? operation.chainedInvokeDetails().error()
+                        : null;
+            case CALLBACK ->
+                operation.callbackDetails() != null
+                        ? operation.callbackDetails().error()
+                        : null;
+            case CONTEXT ->
+                operation.contextDetails() != null ? operation.contextDetails().error() : null;
+            default -> null;
+        };
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -136,6 +136,14 @@ public abstract class BaseDurableOperation {
                 }
                 // Fire onOperationStart plugin hook (including replay)
                 fireOnOperationStart(existing);
+
+                // Fire onOperationEnd for operations that completed during suspension (between invocations).
+                // This enables the OTel plugin to emit spans for operations that transitioned while Lambda was frozen.
+                if (replayCompletedOperation.get()
+                        && executionManager.isOperationUpdatedSinceLastInvocation(getOperationId())) {
+                    fireOnOperationEnd(existing, null);
+                }
+
                 replay(existing);
             } else {
                 if (durableContext.isReplaying()) {

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationEndInfo.java
@@ -6,7 +6,7 @@ package software.amazon.lambda.durable.plugin;
  * Information provided at the end of a Lambda invocation.
  *
  * @param requestId the Lambda request ID for this invocation
- * @param executionArn the durable execution ARN
+ * @param durableExecutionArn the durable execution ARN
  * @param isFirstInvocation true if this is the first invocation of the execution
  * @param invocationStatus the invocation outcome (SUCCEEDED, FAILED, or PENDING)
  * @param executionError non-null if the execution failed
@@ -15,7 +15,7 @@ package software.amazon.lambda.durable.plugin;
 @Deprecated
 public record InvocationEndInfo(
         String requestId,
-        String executionArn,
+        String durableExecutionArn,
         boolean isFirstInvocation,
         InvocationStatus invocationStatus,
         Throwable executionError) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
@@ -6,9 +6,9 @@ package software.amazon.lambda.durable.plugin;
  * Invocation-level information available to plugin hooks.
  *
  * @param requestId the Lambda request ID for this invocation
- * @param executionArn the durable execution ARN
+ * @param durableExecutionArn the durable execution ARN
  * @param isFirstInvocation true if this is the first invocation of the execution (not a replay invocation)
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
 @Deprecated
-public record InvocationInfo(String requestId, String executionArn, boolean isFirstInvocation) {}
+public record InvocationInfo(String requestId, String durableExecutionArn, boolean isFirstInvocation) {}

--- a/sdk/src/test/java/software/amazon/lambda/durable/execution/ExecutionManagerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/execution/ExecutionManagerTest.java
@@ -139,4 +139,59 @@ class ExecutionManagerTest {
         assertNotNull(executionManager.getExecutionOperation());
         assertEquals(EXECUTION_OP_ID, executionManager.getExecutionOperation().id());
     }
+
+    // ─── UpdatedOperationIds tests ───────────────────────────────────────
+
+    @Test
+    void isOperationUpdatedSinceLastInvocation_returnsFalse_whenEmptyList() {
+        // Default 3-arg constructor uses empty list
+        var manager = createManager(List.of(executionOp(), stepOp("1", OperationStatus.SUCCEEDED)));
+
+        assertFalse(manager.isOperationUpdatedSinceLastInvocation("1"));
+    }
+
+    @Test
+    void isOperationUpdatedSinceLastInvocation_returnsTrue_whenOperationIsInList() {
+        client = TestUtils.createMockClient();
+        var initialState = CheckpointUpdatedExecutionState.builder()
+                .operations(List.of(executionOp(), stepOp("1", OperationStatus.SUCCEEDED)))
+                .build();
+        var input = new DurableExecutionInput(EXECUTION_ARN, "test-token", initialState, List.of("1"));
+        var manager = new ExecutionManager(
+                input,
+                DurableConfig.builder().withDurableExecutionClient(client).build());
+
+        assertTrue(manager.isOperationUpdatedSinceLastInvocation("1"));
+    }
+
+    @Test
+    void isOperationUpdatedSinceLastInvocation_returnsFalse_whenOperationNotInList() {
+        client = TestUtils.createMockClient();
+        var initialState = CheckpointUpdatedExecutionState.builder()
+                .operations(List.of(executionOp(), stepOp("1", OperationStatus.SUCCEEDED)))
+                .build();
+        var input = new DurableExecutionInput(EXECUTION_ARN, "test-token", initialState, List.of("2"));
+        var manager = new ExecutionManager(
+                input,
+                DurableConfig.builder().withDurableExecutionClient(client).build());
+
+        assertFalse(manager.isOperationUpdatedSinceLastInvocation("1"));
+    }
+
+    @Test
+    void isOperationUpdatedSinceLastInvocation_handlesMultipleIds() {
+        client = TestUtils.createMockClient();
+        var initialState = CheckpointUpdatedExecutionState.builder()
+                .operations(List.of(executionOp(), stepOp("1", OperationStatus.SUCCEEDED)))
+                .build();
+        var input = new DurableExecutionInput(EXECUTION_ARN, "test-token", initialState, List.of("1", "2", "3"));
+        var manager = new ExecutionManager(
+                input,
+                DurableConfig.builder().withDurableExecutionClient(client).build());
+
+        assertTrue(manager.isOperationUpdatedSinceLastInvocation("1"));
+        assertTrue(manager.isOperationUpdatedSinceLastInvocation("2"));
+        assertTrue(manager.isOperationUpdatedSinceLastInvocation("3"));
+        assertFalse(manager.isOperationUpdatedSinceLastInvocation("4"));
+    }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
https://github.com/aws/aws-durable-execution-sdk-java/issues/435

### Description
- Consume the new UpdatedOperationIds field from the backend invocation payload to determine which operations transitioned during suspension.
- Fire onOperationEnd plugin hook for replayed-completed operations that are in the updated set, enabling the OTel plugin to emit spans for operations that completed while Lambda was frozen.

### Demo/Screenshots
N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Yes

#### Integration Tests

Have integration tests been written for these changes? Yes

#### Examples

Has a new example been added for the change? (if applicable) I'll add tests validating actual spans/Otel behavior in separate PR.
