### PR TITLE
feat(sdk): support indirect DurableHandler inheritance

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableHandler.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableHandler.java
@@ -36,6 +36,17 @@ public abstract class DurableHandler<I, O> implements RequestStreamHandler {
     }
 
     /**
+     * Constructs a handler with an explicitly provided input type. Use this when the input type cannot be inferred from
+     * the generic superclass, such as when extending {@link DurableHandler} indirectly through an intermediate class.
+     *
+     * @param inputType the token capturing the handler's input type
+     */
+    protected DurableHandler(TypeToken<I> inputType) {
+        this.inputType = inputType;
+        this.config = createConfiguration();
+    }
+
+    /**
      * Gets the configuration used by this handler. This allows test frameworks and other tools to access the handler's
      * configuration for testing purposes.
      *

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableHandlerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableHandlerTest.java
@@ -65,11 +65,38 @@ class DurableHandlerTest {
         assertTrue(exception.getMessage().contains("Unexpected payload provided to start the durable execution"));
     }
 
+    @Test
+    void testIndirectDurableHandlerInheritance() {
+        // Handler reaching DurableHandler through an intermediate class resolves
+        // its input type via the explicit constructor.
+        var handler = new ConcreteIndirectHandler();
+
+        assertNotNull(handler);
+
+        var result = handler.handleRequest("test-input", null);
+        assertEquals("indirect: test-input", result);
+    }
+
     // Test handler implementation
     private static class TestDurableHandler extends DurableHandler<String, String> {
         @Override
         public String handleRequest(String input, DurableContext context) {
             return "processed: " + input;
+        }
+    }
+
+    // Intermediate handler that forwards an explicit input type
+    private abstract static class AbstractIndirectHandler<O> extends DurableHandler<String, O> {
+        protected AbstractIndirectHandler() {
+            super(TypeToken.get(String.class));
+        }
+    }
+
+    // Inherits DurableHandler indirectly
+    private static class ConcreteIndirectHandler extends AbstractIndirectHandler<String> {
+        @Override
+        public String handleRequest(String input, DurableContext context) {
+            return "indirect: " + input;
         }
     }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

https://github.com/aws/aws-durable-execution-sdk-java/issues/415

### Description

Added a `DurableHandler` constructor which accepts an input type explicitly.

This allows users to extend `DurableHandler` indirectly through an intermediate class, where the input type can't be inferred from the superclass.

The existing no-arg constructor still infers the input type from the superclass. This was left unchanged for backwards compatability.

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? YES

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
