### PR TITLE
chore: allow build and e2etests run until all versions complete

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         java:
           - 17
@@ -84,4 +85,3 @@ jobs:
           target-folder: javadoc
           java-version: 17
           project: maven
-

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,6 +38,7 @@ jobs:
       AWS_REGION: us-west-2
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         java:
           - 17


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

allow build and e2etests jobs to run until all versions complete so that it's easier to tell if it's a flaky test

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
