### PR TITLE
chore: bump version to 1.2.1-SNAPSHOT

### DIFF
--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.lambda.durable</groupId>
         <artifactId>aws-durable-execution-sdk-java-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aws-durable-execution-sdk-java-coverage-report</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.lambda.durable</groupId>
         <artifactId>aws-durable-execution-sdk-java-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aws-durable-execution-sdk-java-examples</artifactId>

--- a/otel-plugin/pom.xml
+++ b/otel-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.lambda.durable</groupId>
         <artifactId>aws-durable-execution-sdk-java-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aws-durable-execution-sdk-java-otel</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>software.amazon.lambda.durable</groupId>
     <artifactId>aws-durable-execution-sdk-java-parent</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>AWS Lambda Durable Execution SDK</name>

--- a/sdk-integration-tests/pom.xml
+++ b/sdk-integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.lambda.durable</groupId>
         <artifactId>aws-durable-execution-sdk-java-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aws-durable-execution-sdk-java-integration-tests</artifactId>

--- a/sdk-testing/pom.xml
+++ b/sdk-testing/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.lambda.durable</groupId>
         <artifactId>aws-durable-execution-sdk-java-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aws-durable-execution-sdk-java-testing</artifactId>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.lambda.durable</groupId>
         <artifactId>aws-durable-execution-sdk-java-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aws-durable-execution-sdk-java</artifactId>


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

N/A

### Description

Release workflow for version 1.2.0 got interrupted. Manually updating the versions to `1.2.1-SNAPSHOT`.

### Demo/Screenshots

### Checklist

N/A

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
