### PR TITLE
refactor(otel): Add X-Ray context extraction with trace ID priority

### DIFF
--- a/otel-plugin/pom.xml
+++ b/otel-plugin/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>aws-durable-execution-sdk-java-otel</artifactId>
-    <name>AWS Lambda Durable Execution SDK - OpenTelemetry Plugin</name>
+    <name>AWS Lambda Durable Execution SDK OpenTelemetry Plugin</name>
     <description>OpenTelemetry instrumentation plugin for AWS Lambda Durable Execution SDK</description>
 
     <properties>
@@ -46,13 +46,6 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-context</artifactId>
             <version>${opentelemetry.version}</version>
-        </dependency>
-
-        <!-- AWS X-Ray Propagator (official OTel contrib) -->
-        <dependency>
-            <groupId>io.opentelemetry.contrib</groupId>
-            <artifactId>opentelemetry-aws-xray-propagator</artifactId>
-            <version>1.57.0-alpha</version>
         </dependency>
 
         <!-- SLF4J for logging -->

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ContextExtractor.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ContextExtractor.java
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.otel;
 
-import io.opentelemetry.context.Context;
-
 /**
- * Extracts OTel trace context from the Lambda runtime environment.
+ * Extracts trace context from the Lambda runtime environment.
  *
  * <p>Implementations read trace context from various sources (X-Ray trace header, W3C traceparent, etc.) and return an
- * OTel {@link Context} that can be used as the parent for invocation spans.
+ * {@link ExtractedContext} containing the trace ID and optional parent span ID.
  *
  * <p>Called once per invocation in {@code onInvocationStart} to establish the parent trace context.
  *
@@ -21,7 +19,7 @@ public interface ContextExtractor {
     /**
      * Extracts trace context from the runtime environment.
      *
-     * @return the extracted OTel context, or {@link Context#root()} if no context is available
+     * @return the extracted context, or {@code null} if no context is available
      */
-    Context extract();
+    ExtractedContext extract();
 }

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
@@ -11,11 +11,18 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Generates deterministic trace and span IDs for durable execution observability.
  *
- * <p>All invocations of the same execution share a single trace ID (derived from the execution ARN). Operations get
- * stable span IDs derived from the execution ARN + operation ID, ensuring the same operation produces the same span
- * across invocations.
+ * <p>Trace ID resolution order:
  *
- * <p>When no pending operation ID is set, falls back to random generation (standard OTel behavior).
+ * <ol>
+ *   <li>If an extracted trace ID is set (from {@code _X_AMZN_TRACE_ID}), use it. The durable execution backend
+ *       propagates the same Root to all invocations, so this naturally unifies the trace.
+ *   <li>If no extracted trace ID is available (local tests, non-Lambda environments), derive a deterministic trace ID
+ *       from the execution ARN using SHA-256.
+ *   <li>If neither is set, fall back to random generation.
+ * </ol>
+ *
+ * <p>Span IDs for operations are deterministic (derived from execution ARN + operation ID), ensuring the same operation
+ * produces the same span across invocations. When no pending operation ID is set, falls back to random generation.
  *
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
@@ -24,18 +31,30 @@ public class DeterministicIdGenerator implements IdGenerator {
 
     private static final IdGenerator RANDOM = IdGenerator.random();
 
-    private final AtomicReference<String> executionTraceId = new AtomicReference<>(null);
+    private final AtomicReference<String> extractedTraceId = new AtomicReference<>(null);
+    private final AtomicReference<String> arnDerivedTraceId = new AtomicReference<>(null);
     private final ThreadLocal<String> pendingSpanOperationId = new ThreadLocal<>();
     private final AtomicReference<String> durableExecutionArn = new AtomicReference<>(null);
 
     /**
-     * Sets the execution ARN used for generating deterministic IDs.
+     * Sets an externally extracted trace ID (e.g., from the X-Ray trace header). This takes highest priority for trace
+     * ID generation.
+     *
+     * @param traceId 32-char lowercase hex trace ID
+     */
+    public void setExtractedTraceId(String traceId) {
+        this.extractedTraceId.set(traceId);
+    }
+
+    /**
+     * Sets the execution ARN used for generating deterministic IDs. Computes and caches an ARN-derived trace ID as
+     * fallback when no extracted trace ID is available.
      *
      * @param arn the durable execution ARN
      */
     public void setDurableExecutionArn(String arn) {
         this.durableExecutionArn.set(arn);
-        this.executionTraceId.set(generateTraceIdFromArn(arn));
+        this.arnDerivedTraceId.set(generateTraceIdFromArn(arn));
     }
 
     /**
@@ -50,9 +69,6 @@ public class DeterministicIdGenerator implements IdGenerator {
     /**
      * Generates a deterministic span ID for a given operation ID without consuming the ThreadLocal state.
      *
-     * <p>Used for creating non-recording placeholder spans when a parent operation's span context is needed but hasn't
-     * been exported yet.
-     *
      * @param operationId the operation ID to derive the span ID from
      * @return a deterministic 16-char hex span ID
      */
@@ -62,10 +78,17 @@ public class DeterministicIdGenerator implements IdGenerator {
 
     @Override
     public String generateTraceId() {
-        var cached = executionTraceId.get();
-        if (cached != null) {
-            return cached;
+        // Priority 1: extracted from X-Ray header (backend propagates same Root across invocations)
+        var extracted = extractedTraceId.get();
+        if (extracted != null) {
+            return extracted;
         }
+        // Priority 2: deterministic from execution ARN (local tests, non-Lambda)
+        var arnDerived = arnDerivedTraceId.get();
+        if (arnDerived != null) {
+            return arnDerived;
+        }
+        // Priority 3: random fallback
         return RANDOM.generateTraceId();
     }
 
@@ -79,27 +102,19 @@ public class DeterministicIdGenerator implements IdGenerator {
         return RANDOM.generateSpanId();
     }
 
-    /**
-     * Generates a deterministic trace ID from an execution ARN.
-     *
-     * <p>Uses SHA-256 hash truncated to 32 hex chars (128 bits) for the trace ID.
-     */
+    /** Generates a deterministic trace ID from an execution ARN using SHA-256 truncated to 32 hex chars. */
     private String generateTraceIdFromArn(String arn) {
         var hash = sha256(arn);
-        // Trace ID is 32 hex chars (16 bytes)
         return hash.substring(0, 32);
     }
 
     /**
-     * Generates a deterministic span ID from the execution ARN + operation ID.
-     *
-     * <p>Uses SHA-256 hash truncated to 16 hex chars (64 bits) for the span ID.
+     * Generates a deterministic span ID from the execution ARN + operation ID using SHA-256 truncated to 16 hex chars.
      */
     private String generateSpanIdFromOperation(String operationId) {
         var arn = durableExecutionArn.get();
         var input = arn != null ? arn + ":" + operationId : operationId;
         var hash = sha256(input);
-        // Span ID is 16 hex chars (8 bytes)
         return hash.substring(0, 16);
     }
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExtractedContext.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExtractedContext.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.otel;
+
+/**
+ * Trace context extracted from the Lambda runtime environment.
+ *
+ * <p>Contains the trace ID (always present) and an optional parent span ID. When the durable execution backend
+ * propagates the same X-Ray Root across all invocations, the trace ID will be consistent, enabling spans from different
+ * invocations to be stitched into a single trace.
+ *
+ * @param traceId 32-character lowercase hex trace ID (OTel format, no dashes)
+ * @param parentSpanId 16-character lowercase hex parent span ID (may be null if no parent available)
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public record ExtractedContext(String traceId, String parentSpanId) {}

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OpenTelemetryDurablePlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OpenTelemetryDurablePlugin.java
@@ -39,7 +39,22 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  *   <li><b>Attempt span</b> — one per user function execution (step attempt, child context run)
  * </ul>
  *
- * <p>Uses deterministic span/trace IDs so all invocations of the same execution share a single trace.
+ * <p>Trace ID resolution:
+ *
+ * <ol>
+ *   <li>Uses the X-Ray trace ID from {@code _X_AMZN_TRACE_ID} when available. The durable execution backend propagates
+ *       the same Root to all invocations of the same execution, naturally unifying the trace.
+ *   <li>Falls back to a deterministic trace ID derived from the execution ARN (for local tests or non-Lambda
+ *       environments).
+ * </ol>
+ *
+ * <p>Requires the ADOT Lambda Layer for trace export. Configure with:
+ *
+ * <ul>
+ *   <li>Lambda Layer: {@code aws-otel-java-agent} (ADOT Java auto-instrumentation layer)
+ *   <li>Env var: {@code AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler}
+ *   <li>Tracing: Active (to populate {@code _X_AMZN_TRACE_ID})
+ * </ul>
  *
  * <p>Thread-safe: uses {@link ConcurrentHashMap} for span/scope storage since the SDK runs user code on multiple
  * threads.
@@ -75,6 +90,17 @@ public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
     /**
      * Creates an OTel plugin with default settings: X-Ray context extraction, MDC enabled.
      *
+     * <p>Uses the provided tracer provider builder. Customers configure exporters and span processors on the builder —
+     * the plugin handles ID generation.
+     *
+     * <p>For ADOT layer usage, configure with an OTLP exporter:
+     *
+     * <pre>{@code
+     * var otlpExporter = OtlpGrpcSpanExporter.getDefault(); // sends to localhost:4317
+     * var plugin = new OpenTelemetryDurablePlugin(
+     *     SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
+     * }</pre>
+     *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      */
     public OpenTelemetryDurablePlugin(SdkTracerProviderBuilder tracerProviderBuilder) {
@@ -95,10 +121,6 @@ public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
     /**
      * Creates an OTel plugin with full configuration.
      *
-     * <p>The plugin internally creates a {@link DeterministicIdGenerator} and sets it on the provided builder before
-     * building the tracer provider. Customers configure exporters, span processors, and samplers on the builder — the
-     * plugin handles ID generation.
-     *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
      * @param enableMdc if true, injects trace_id/span_id into SLF4J MDC for log correlation
@@ -117,14 +139,36 @@ public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
     @Override
     public void onInvocationStart(InvocationInfo info) {
         this.durableExecutionArn = info.durableExecutionArn();
+
+        // Set execution ARN for deterministic span ID generation
         idGenerator.setDurableExecutionArn(info.durableExecutionArn());
 
-        // Extract parent context from Lambda environment (X-Ray, W3C, etc.)
-        var extractedParentContext = contextExtractor.extract();
+        // Extract trace context from environment (X-Ray header)
+        var extractedContext = contextExtractor.extract();
 
-        // Create invocation span as child of extracted context
+        if (extractedContext != null) {
+            // Use the X-Ray trace ID — backend propagates same Root across all invocations
+            idGenerator.setExtractedTraceId(extractedContext.traceId());
+        }
+        // If no extracted context, idGenerator falls back to ARN-derived trace ID
+
+        // Determine parent context for the invocation span
+        Context parentContext;
+        if (extractedContext != null && extractedContext.parentSpanId() != null) {
+            // Create a remote parent span context from the X-Ray Parent field
+            var parentSpanContext = SpanContext.createFromRemoteParent(
+                    extractedContext.traceId(),
+                    extractedContext.parentSpanId(),
+                    TraceFlags.getSampled(),
+                    TraceState.getDefault());
+            parentContext = Context.root().with(Span.wrap(parentSpanContext));
+        } else {
+            parentContext = Context.root();
+        }
+
+        // Create invocation span as child of Lambda's X-Ray segment (via Parent field)
         var spanBuilder = tracer.spanBuilder("durable.invocation")
-                .setParent(extractedParentContext)
+                .setParent(parentContext)
                 .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())
                 .setAttribute(DURABLE_FIRST_INVOCATION, info.isFirstInvocation());
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/XRayContextExtractor.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/XRayContextExtractor.java
@@ -2,19 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.otel;
 
-import io.opentelemetry.context.Context;
-import io.opentelemetry.context.propagation.TextMapGetter;
-import io.opentelemetry.contrib.awsxray.propagator.AwsXrayPropagator;
-import java.util.Collections;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Extracts OTel trace context from the AWS X-Ray {@code _X_AMZN_TRACE_ID} environment variable using the official
- * OpenTelemetry AWS X-Ray Propagator.
+ * Extracts OTel trace context from the AWS X-Ray {@code _X_AMZN_TRACE_ID} environment variable.
  *
- * <p>Lambda runtime sets this environment variable with the X-Ray trace header for each invocation. This extractor
- * reads it and uses the official {@link AwsXrayPropagator} to parse it into an OTel-compatible {@link Context}.
+ * <p>The durable execution backend propagates the same Root trace ID to every invocation of the same execution, so all
+ * invocations share one trace. This extractor parses that header and returns the trace ID in OTel format (32 hex chars)
+ * along with the parent span ID (16 hex chars).
+ *
+ * <p>X-Ray header format: {@code Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1}
+ *
+ * <p>The Root field is converted to OTel format by stripping "1-" and removing dashes:
+ * {@code 5759e988bd862e3fe1be46a994272793}
  *
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
@@ -23,33 +25,74 @@ public class XRayContextExtractor implements ContextExtractor {
 
     private static final Logger logger = LoggerFactory.getLogger(XRayContextExtractor.class);
     private static final String XRAY_ENV_VAR = "_X_AMZN_TRACE_ID";
-    private static final String XRAY_HEADER_KEY = "X-Amzn-Trace-Id";
-    private static final AwsXrayPropagator PROPAGATOR = AwsXrayPropagator.getInstance();
-
-    /** A TextMapGetter that reads the X-Ray trace header from the Lambda environment variable. */
-    private static final TextMapGetter<String> ENV_GETTER = new TextMapGetter<>() {
-        @Override
-        public Iterable<String> keys(String carrier) {
-            return Collections.singletonList(XRAY_HEADER_KEY);
-        }
-
-        @Override
-        public String get(String carrier, String key) {
-            if (XRAY_HEADER_KEY.equalsIgnoreCase(key)) {
-                return carrier;
-            }
-            return null;
-        }
-    };
+    private static final Pattern HEX_32 = Pattern.compile("[0-9a-f]{32}");
+    private static final Pattern HEX_16 = Pattern.compile("[0-9a-f]{16}");
 
     @Override
-    public Context extract() {
+    public ExtractedContext extract() {
         var traceHeader = System.getenv(XRAY_ENV_VAR);
         if (traceHeader == null || traceHeader.isEmpty()) {
             logger.debug("No X-Ray trace header found in environment");
-            return Context.root();
+            return null;
         }
 
-        return PROPAGATOR.extract(Context.root(), traceHeader, ENV_GETTER);
+        String root = null;
+        String parent = null;
+
+        for (var part : traceHeader.split(";")) {
+            var eqIdx = part.indexOf('=');
+            if (eqIdx <= 0) continue;
+            var key = part.substring(0, eqIdx).trim();
+            var value = part.substring(eqIdx + 1).trim();
+
+            switch (key) {
+                case "Root" -> root = value;
+                case "Parent" -> parent = value;
+            }
+        }
+
+        if (root == null) {
+            logger.debug("X-Ray header missing Root field: {}", traceHeader);
+            return null;
+        }
+
+        // Root format: 1-5759e988-bd862e3fe1be46a994272793
+        // Strip "1-" prefix, remove dashes → 32-char hex OTel trace ID
+        var traceId = xrayRootToOtelTraceId(root);
+        if (traceId == null) {
+            logger.debug("Invalid X-Ray Root field: {}", root);
+            return null;
+        }
+
+        // Parent is a 16-char hex span ID
+        String parentSpanId = null;
+        if (parent != null) {
+            var normalized = parent.toLowerCase();
+            if (HEX_16.matcher(normalized).matches()) {
+                parentSpanId = normalized;
+            }
+        }
+
+        return new ExtractedContext(traceId, parentSpanId);
+    }
+
+    /**
+     * Converts an X-Ray Root value to a 32-char OTel trace ID.
+     *
+     * @param root e.g. "1-5759e988-bd862e3fe1be46a994272793"
+     * @return 32-char lowercase hex string, or null if invalid
+     */
+    static String xrayRootToOtelTraceId(String root) {
+        // Strip "1-" version prefix
+        if (!root.startsWith("1-")) {
+            return null;
+        }
+        var withoutVersion = root.substring(2);
+        var hex = withoutVersion.replace("-", "").toLowerCase();
+
+        if (hex.length() != 32 || !HEX_32.matcher(hex).matches()) {
+            return null;
+        }
+        return hex;
     }
 }

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/DeterministicIdGeneratorTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/DeterministicIdGeneratorTest.java
@@ -136,4 +136,122 @@ class DeterministicIdGeneratorTest {
 
         assertTrue(spanId.matches("[0-9a-f]{16}"), "Span ID should be 16 hex chars: " + spanId);
     }
+
+    // ─── X-Ray extracted trace ID priority tests ─────────────────────────
+
+    @Test
+    void generateTraceId_extractedTakesPriorityOverArn() {
+        var xrayTraceId = "5759e988bd862e3fe1be46a994272793";
+        generator.setDurableExecutionArn("arn:aws:lambda:us-east-1:123:function:test");
+        generator.setExtractedTraceId(xrayTraceId);
+
+        var result = generator.generateTraceId();
+
+        assertEquals(xrayTraceId, result, "Extracted X-Ray trace ID should take priority over ARN-derived");
+    }
+
+    @Test
+    void generateTraceId_extractedIdReturnedConsistently() {
+        var xrayTraceId = "aabbccddee112233445566778899aabb";
+        generator.setExtractedTraceId(xrayTraceId);
+
+        // Should return the same value on every call
+        assertEquals(xrayTraceId, generator.generateTraceId());
+        assertEquals(xrayTraceId, generator.generateTraceId());
+        assertEquals(xrayTraceId, generator.generateTraceId());
+    }
+
+    @Test
+    void generateTraceId_extractedIdOverridesArnDerived() {
+        generator.setDurableExecutionArn("arn:exec1");
+        var arnDerived = generator.generateTraceId();
+
+        // Now set an extracted ID — it should override
+        var xrayTraceId = "1234567890abcdef1234567890abcdef";
+        generator.setExtractedTraceId(xrayTraceId);
+
+        var afterExtracted = generator.generateTraceId();
+        assertEquals(xrayTraceId, afterExtracted);
+        assertNotEquals(arnDerived, afterExtracted, "Extracted should differ from ARN-derived");
+    }
+
+    @Test
+    void generateTraceId_priorityOrder_extractedFirst() {
+        // Priority 1: extracted > Priority 2: ARN-derived > Priority 3: random
+        var extracted = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+        generator.setDurableExecutionArn("arn:some-arn");
+        generator.setExtractedTraceId(extracted);
+
+        assertEquals(extracted, generator.generateTraceId());
+    }
+
+    @Test
+    void generateTraceId_priorityOrder_arnDerivedWhenNoExtracted() {
+        // Priority 2: ARN-derived when no extracted set
+        generator.setDurableExecutionArn("arn:some-arn");
+
+        var result = generator.generateTraceId();
+        assertNotNull(result);
+        assertEquals(32, result.length());
+
+        // Should be deterministic
+        assertEquals(result, generator.generateTraceId());
+    }
+
+    @Test
+    void generateTraceId_priorityOrder_randomWhenNeitherSet() {
+        // Priority 3: random when neither extracted nor ARN set
+        var id1 = generator.generateTraceId();
+        var id2 = generator.generateTraceId();
+
+        assertNotNull(id1);
+        assertEquals(32, id1.length());
+        assertNotEquals(id1, id2, "Random IDs should differ");
+    }
+
+    @Test
+    void setExtractedTraceId_withNull_clearsExtracted() {
+        var xrayTraceId = "5759e988bd862e3fe1be46a994272793";
+        generator.setDurableExecutionArn("arn:exec1");
+        generator.setExtractedTraceId(xrayTraceId);
+
+        assertEquals(xrayTraceId, generator.generateTraceId());
+
+        // Clear extracted — should fall back to ARN-derived
+        generator.setExtractedTraceId(null);
+        var afterClear = generator.generateTraceId();
+        assertNotEquals(xrayTraceId, afterClear, "Should fall back to ARN-derived after clearing extracted");
+        assertEquals(32, afterClear.length());
+    }
+
+    @Test
+    void setExtractedTraceId_simulatesMultipleInvocations_sameExecution() {
+        // Simulates backend propagating same X-Ray Root across invocations
+        var xrayTraceId = "5759e988bd862e3fe1be46a994272793";
+
+        // First invocation
+        generator.setExtractedTraceId(xrayTraceId);
+        generator.setDurableExecutionArn("arn:exec1");
+        var firstInvocation = generator.generateTraceId();
+
+        // Second invocation (same execution, same X-Ray Root from backend)
+        var generator2 = new DeterministicIdGenerator();
+        generator2.setExtractedTraceId(xrayTraceId);
+        generator2.setDurableExecutionArn("arn:exec1");
+        var secondInvocation = generator2.generateTraceId();
+
+        assertEquals(firstInvocation, secondInvocation, "Same X-Ray Root should produce same trace across invocations");
+        assertEquals(xrayTraceId, firstInvocation);
+    }
+
+    @Test
+    void setExtractedTraceId_validXrayFormat_32HexChars() {
+        // Real-world format: X-Ray Root stripped and dashless
+        var xrayTraceId = "5759e988bd862e3fe1be46a994272793";
+        generator.setExtractedTraceId(xrayTraceId);
+
+        var result = generator.generateTraceId();
+        assertEquals(xrayTraceId, result);
+        assertTrue(result.matches("[0-9a-f]{32}"));
+    }
 }

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
@@ -57,7 +57,7 @@ class MdcSpanEnricherTest {
 
         var plugin = new OpenTelemetryDurablePlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> io.opentelemetry.context.Context.root(),
+                () -> null,
                 true);
 
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec-mdc-test", true));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OpenTelemetryDurablePluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OpenTelemetryDurablePluginTest.java
@@ -24,7 +24,7 @@ class OpenTelemetryDurablePluginTest {
 
         plugin = new OpenTelemetryDurablePlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> io.opentelemetry.context.Context.root(),
+                () -> null,
                 false);
     }
 
@@ -216,7 +216,7 @@ class OpenTelemetryDurablePluginTest {
                 SdkTracerProvider.builder()
                         .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOff())
                         .addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> io.opentelemetry.context.Context.root(),
+                () -> null,
                 false);
 
         sampledPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
@@ -230,5 +230,191 @@ class OpenTelemetryDurablePluginTest {
                 new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         assertTrue(spanExporter.getFinishedSpanItems().isEmpty(), "No spans should be exported with 0% sampling");
+    }
+
+    // ─── X-Ray trace ID extraction integration tests ─────────────────────
+
+    @Test
+    void xrayExtraction_usesExtractedTraceId_overArnDerived() {
+        var xrayTraceId = "5759e988bd862e3fe1be46a994272793";
+        var extractedContext = new ExtractedContext(xrayTraceId, null);
+
+        spanExporter = InMemorySpanExporter.create();
+        var xrayPlugin = new OpenTelemetryDurablePlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
+                () -> extractedContext,
+                false);
+
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        assertEquals(1, spans.size());
+        assertEquals(xrayTraceId, spans.get(0).getTraceId(), "Span should use the extracted X-Ray trace ID");
+    }
+
+    @Test
+    void xrayExtraction_allSpansShareExtractedTraceId() {
+        var xrayTraceId = "aabbccddee112233445566778899aabb";
+        var extractedContext = new ExtractedContext(xrayTraceId, null);
+
+        spanExporter = InMemorySpanExporter.create();
+        var xrayPlugin = new OpenTelemetryDurablePlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
+                () -> extractedContext,
+                false);
+
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        xrayPlugin.onOperationStart(new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null));
+        xrayPlugin.onUserFunctionStart(
+                new UserFunctionStartInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), false, 1));
+        xrayPlugin.onUserFunctionEnd(new UserFunctionEndInfo(
+                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+        xrayPlugin.onOperationEnd(
+                new OperationEndInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), null));
+        xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        assertTrue(spans.size() >= 2, "Should have invocation + operation + attempt spans");
+        assertTrue(
+                spans.stream().allMatch(s -> s.getTraceId().equals(xrayTraceId)),
+                "All spans must share the extracted X-Ray trace ID");
+    }
+
+    @Test
+    void xrayExtraction_withParentSpanId_invocationSpanHasCorrectParent() {
+        var xrayTraceId = "5759e988bd862e3fe1be46a994272793";
+        var parentSpanId = "53995c3f42cd8ad8";
+        var extractedContext = new ExtractedContext(xrayTraceId, parentSpanId);
+
+        spanExporter = InMemorySpanExporter.create();
+        var xrayPlugin = new OpenTelemetryDurablePlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
+                () -> extractedContext,
+                false);
+
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        assertEquals(1, spans.size());
+
+        var invocationSpan = spans.get(0);
+        assertEquals(xrayTraceId, invocationSpan.getTraceId());
+        assertEquals(
+                parentSpanId,
+                invocationSpan.getParentSpanId(),
+                "Invocation span should be parented to X-Ray Parent span");
+    }
+
+    @Test
+    void xrayExtraction_withoutParentSpanId_invocationSpanIsRoot() {
+        var xrayTraceId = "5759e988bd862e3fe1be46a994272793";
+        var extractedContext = new ExtractedContext(xrayTraceId, null);
+
+        spanExporter = InMemorySpanExporter.create();
+        var xrayPlugin = new OpenTelemetryDurablePlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
+                () -> extractedContext,
+                false);
+
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        assertEquals(1, spans.size());
+
+        var invocationSpan = spans.get(0);
+        assertEquals(xrayTraceId, invocationSpan.getTraceId());
+        // Parent span ID should be empty/invalid when no parent provided
+        assertFalse(
+                io.opentelemetry.api.trace.SpanContext.create(
+                                xrayTraceId,
+                                invocationSpan.getParentSpanId(),
+                                io.opentelemetry.api.trace.TraceFlags.getSampled(),
+                                io.opentelemetry.api.trace.TraceState.getDefault())
+                        .isRemote(),
+                "Without X-Ray parent, invocation span should not have a remote parent");
+    }
+
+    @Test
+    void xrayExtraction_multipleInvocations_sameTraceId_unifiedTrace() {
+        var xrayTraceId = "5759e988bd862e3fe1be46a994272793";
+        var extractedContext = new ExtractedContext(xrayTraceId, "53995c3f42cd8ad8");
+
+        spanExporter = InMemorySpanExporter.create();
+        var xrayPlugin = new OpenTelemetryDurablePlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
+                () -> extractedContext,
+                false);
+
+        // First invocation
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        xrayPlugin.onOperationStart(new OperationInfo("op-1", "step-1", "STEP", "Step", null, Instant.now(), null));
+        xrayPlugin.onOperationEnd(
+                new OperationEndInfo("op-1", "step-1", "STEP", "Step", null, Instant.now(), Instant.now(), null));
+        xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.PENDING, null));
+
+        // Second invocation (same execution, same X-Ray Root from backend)
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-2", "arn:exec1", false));
+        xrayPlugin.onOperationStart(new OperationInfo("op-2", "step-2", "STEP", "Step", null, Instant.now(), null));
+        xrayPlugin.onOperationEnd(
+                new OperationEndInfo("op-2", "step-2", "STEP", "Step", null, Instant.now(), Instant.now(), null));
+        xrayPlugin.onInvocationEnd(
+                new InvocationEndInfo("req-2", "arn:exec1", false, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        assertTrue(spans.size() >= 4, "Should have spans from both invocations");
+
+        // All spans share the same X-Ray trace ID — unified trace
+        assertTrue(
+                spans.stream().allMatch(s -> s.getTraceId().equals(xrayTraceId)),
+                "Both invocations should produce spans with the same X-Ray trace ID");
+    }
+
+    @Test
+    void xrayExtraction_nullExtractor_fallsBackToArnDerived() {
+        spanExporter = InMemorySpanExporter.create();
+        var noXrayPlugin = new OpenTelemetryDurablePlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
+                () -> null,
+                false);
+
+        var arn = "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1";
+        noXrayPlugin.onInvocationStart(new InvocationInfo("req-1", arn, true));
+        noXrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        assertEquals(1, spans.size());
+
+        var traceId = spans.get(0).getTraceId();
+        assertNotNull(traceId);
+        assertEquals(32, traceId.length());
+        assertTrue(traceId.matches("[0-9a-f]{32}"), "ARN-derived trace ID should be valid hex");
+    }
+
+    @Test
+    void xrayExtraction_extractedTraceIdMatchesXrayConversion() {
+        // Verify the end-to-end flow: X-Ray header → parse → trace ID in span
+        var xrayRoot = "1-5759e988-bd862e3fe1be46a994272793";
+        var expectedOtelTraceId = "5759e988bd862e3fe1be46a994272793";
+
+        // Simulate what XRayContextExtractor does
+        var convertedId = XRayContextExtractor.xrayRootToOtelTraceId(xrayRoot);
+        assertEquals(expectedOtelTraceId, convertedId);
+
+        // Now feed it through the plugin
+        var extractedContext = new ExtractedContext(convertedId, null);
+        spanExporter = InMemorySpanExporter.create();
+        var xrayPlugin = new OpenTelemetryDurablePlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
+                () -> extractedContext,
+                false);
+
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        assertEquals(expectedOtelTraceId, spans.get(0).getTraceId());
     }
 }

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/XRayContextExtractorTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/XRayContextExtractorTest.java
@@ -4,25 +4,143 @@ package software.amazon.lambda.durable.otel;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.opentelemetry.context.Context;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class XRayContextExtractorTest {
 
     @Test
-    void extract_withoutEnvVar_returnsRoot() {
+    void extract_withoutEnvVar_returnsNull() {
         // _X_AMZN_TRACE_ID is not set in test environment
         var extractor = new XRayContextExtractor();
         var context = extractor.extract();
 
-        // Should return root context when env var is missing
-        assertEquals(Context.root(), context);
+        // Should return null when env var is missing
+        assertNull(context);
     }
 
     @Test
     void extract_implementsContextExtractor() {
         // Verify XRayContextExtractor implements the ContextExtractor interface
         ContextExtractor extractor = new XRayContextExtractor();
-        assertNotNull(extractor.extract());
+        // In test env without _X_AMZN_TRACE_ID, returns null
+        assertNull(extractor.extract());
+    }
+
+    // ─── xrayRootToOtelTraceId: valid inputs ────────────────────────────
+
+    @Test
+    void xrayRootToOtelTraceId_validRoot() {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("1-5759e988-bd862e3fe1be46a994272793");
+        assertEquals("5759e988bd862e3fe1be46a994272793", result);
+    }
+
+    @Test
+    void xrayRootToOtelTraceId_validRoot_allZeros() {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("1-00000000-000000000000000000000000");
+        assertEquals("00000000000000000000000000000000", result);
+    }
+
+    @Test
+    void xrayRootToOtelTraceId_validRoot_allFs() {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("1-ffffffff-ffffffffffffffffffffffff");
+        assertEquals("ffffffffffffffffffffffffffffffff", result);
+    }
+
+    @Test
+    void xrayRootToOtelTraceId_validRoot_mixedCase_normalizesToLowercase() {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("1-5759E988-BD862E3FE1BE46A994272793");
+        assertEquals("5759e988bd862e3fe1be46a994272793", result);
+    }
+
+    @Test
+    void xrayRootToOtelTraceId_producesExpected32CharHex() {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("1-67890abc-def01234567890abcdef0123");
+        assertNotNull(result);
+        assertEquals(32, result.length());
+        assertTrue(result.matches("[0-9a-f]{32}"), "Should be 32 lowercase hex chars");
+    }
+
+    // ─── xrayRootToOtelTraceId: invalid inputs ──────────────────────────
+
+    @Test
+    void xrayRootToOtelTraceId_invalidPrefix() {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("2-5759e988-bd862e3fe1be46a994272793");
+        assertNull(result);
+    }
+
+    @Test
+    void xrayRootToOtelTraceId_noPrefix() {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("5759e988-bd862e3fe1be46a994272793");
+        assertNull(result);
+    }
+
+    @Test
+    void xrayRootToOtelTraceId_wrongLength() {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("1-5759e988-bd862e3fe1be46a9");
+        assertNull(result);
+    }
+
+    @Test
+    void xrayRootToOtelTraceId_tooLong() {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("1-5759e988-bd862e3fe1be46a994272793aabbccdd");
+        assertNull(result);
+    }
+
+    @Test
+    void xrayRootToOtelTraceId_nonHex() {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("1-5759e988-ZZZZZZZZZZZZZZZZZZZZZZZZ");
+        assertNull(result);
+    }
+
+    @Test
+    void xrayRootToOtelTraceId_emptyString() {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("");
+        assertNull(result);
+    }
+
+    @Test
+    void xrayRootToOtelTraceId_onlyPrefix() {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("1-");
+        assertNull(result);
+    }
+
+    @Test
+    void xrayRootToOtelTraceId_noDashes() {
+        // Missing second dash — produces wrong number of hex chars after stripping
+        var result = XRayContextExtractor.xrayRootToOtelTraceId("1-5759e988bd862e3fe1be46a994272793");
+        // After stripping "1-" and removing dashes, we get 32 chars — but format is unusual
+        // This should still work because the conversion just strips "1-" and removes "-"
+        assertEquals("5759e988bd862e3fe1be46a994272793", result);
+    }
+
+    // ─── Parsing full X-Ray header format (testing via the static method) ──
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "1-5759e988-bd862e3fe1be46a994272793",
+                "1-aabbccdd-11223344556677889900aabb",
+                "1-12345678-abcdefabcdefabcdefabcdef"
+            })
+    void xrayRootToOtelTraceId_variousValidRoots(String root) {
+        var result = XRayContextExtractor.xrayRootToOtelTraceId(root);
+        assertNotNull(result);
+        assertEquals(32, result.length());
+        assertTrue(result.matches("[0-9a-f]{32}"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"invalid", "1-short", "Root=1-abc-def"})
+    void xrayRootToOtelTraceId_variousInvalidInputs(String root) {
+        if (root == null) {
+            assertThrows(NullPointerException.class, () -> XRayContextExtractor.xrayRootToOtelTraceId(root));
+        } else {
+            var result = XRayContextExtractor.xrayRootToOtelTraceId(root);
+            assertNull(result);
+        }
     }
 }

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/OtelPluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/OtelPluginIntegrationTest.java
@@ -34,7 +34,7 @@ class OtelPluginIntegrationTest {
 
         var plugin = new OpenTelemetryDurablePlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> io.opentelemetry.context.Context.root(),
+                () -> null,
                 false);
 
         otelConfig = DurableConfig.builder().withPlugins(plugin).build();
@@ -309,7 +309,7 @@ class OtelPluginIntegrationTest {
                 SdkTracerProvider.builder()
                         .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOff())
                         .addSpanProcessor(SimpleSpanProcessor.create(sampledExporter)),
-                () -> io.opentelemetry.context.Context.root(),
+                () -> null,
                 false);
 
         var noSampleConfig = DurableConfig.builder().withPlugins(noSamplePlugin).build();


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
https://github.com/aws/aws-durable-execution-sdk-java/issues/435

### Description
Refactors the OTel plugin's trace ID generation to use the X-Ray trace header propagated by the durable execution backend, replacing the external `opentelemetry-aws-xray-propagator` dependency with a lightweight hand-rolled parser.

The durable execution backend propagates the same `_X_AMZN_TRACE_ID` Root to all invocations of a given execution. By extracting and using this trace ID directly, all spans from all invocations naturally land in a single unified trace without needing ARN-derived hashing. This also enables parent span linkage so invocation spans appear as children of Lambda's X-Ray segment.

### Demo/Screenshots
N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Yes

#### Integration Tests

Have integration tests been written for these changes? Yes, updated

#### Examples

Has a new example been added for the change? (if applicable) Will add Xray tests in following PR
 