### PR TITLE
fix: throw IllegalStateException when validation of thread type fail

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/NestedStepIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/NestedStepIntegrationTest.java
@@ -5,7 +5,9 @@ package software.amazon.lambda.durable;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.config.StepConfig;
 import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.retry.RetryStrategies;
 import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
 
 /** Tests that nested step calling is properly rejected. */
@@ -16,9 +18,13 @@ class NestedStepIntegrationTest {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             // outer-step's supplier calls context.step() which internally calls stepAsync().get()
             // The get() is called from the outer step's thread (named "1-step"), triggering the check
-            var future = context.stepAsync("outer-step", String.class, stepCtx -> {
-                return context.step("inner-step", String.class, stepCtx2 -> "inner-result");
-            });
+            var future = context.stepAsync(
+                    "outer-step",
+                    String.class,
+                    stepCtx -> context.step("inner-step", String.class, stepCtx2 -> "inner-result"),
+                    StepConfig.builder()
+                            .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                            .build());
             return future.get();
         });
 
@@ -38,10 +44,16 @@ class NestedStepIntegrationTest {
             var asyncFuture = context.stepAsync("async-step", String.class, stepCtx -> "async-result");
 
             // Sync step tries to await the async step's result inside its supplier
-            return context.step("sync-step", String.class, stepCtx -> {
-                // This get() is called from sync-step's thread ("2-step"), which is not allowed
-                return "combined: " + asyncFuture.get();
-            });
+            return context.step(
+                    "sync-step",
+                    String.class,
+                    stepCtx -> {
+                        // This get() is called from sync-step's thread ("2-step"), which is not allowed
+                        return "combined: " + asyncFuture.get();
+                    },
+                    StepConfig.builder()
+                            .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                            .build());
         });
 
         var result = runner.run("test");

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -191,7 +191,7 @@ public abstract class BaseDurableOperation {
     /**
      * Checks if it's called from a Step.
      *
-     * @throws IllegalDurableOperationException if it's in a step
+     * @throws IllegalStateException if it's in a step
      */
     private void validateCurrentThreadType() {
         ThreadType current = getCurrentThreadContext().threadType();
@@ -199,8 +199,7 @@ public abstract class BaseDurableOperation {
             var message = String.format(
                     "Nested %s operation is not supported on %s from within a %s execution.",
                     getType(), getName(), current);
-            // terminate execution and throw the exception
-            throw terminateExecutionWithIllegalDurableOperationException(message);
+            throw new IllegalStateException(message);
         }
     }
 

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/SerializableDurableOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/SerializableDurableOperationTest.java
@@ -114,6 +114,31 @@ class SerializableDurableOperationTest {
     }
 
     @Test
+    void waitForOperationCompletionThrowsIllegalStateExceptionWhenCalledFromStepThread() {
+        when(executionManager.getCurrentThreadContext()).thenReturn(new ThreadContext(CONTEXT_ID, ThreadType.STEP));
+
+        SerializableDurableOperation<String> op =
+                new SerializableDurableOperation<>(OPERATION_IDENTIFIER, RESULT_TYPE, SER_DES, durableContext) {
+                    @Override
+                    protected void start() {
+                        markAlreadyCompleted();
+                        assertThrows(IllegalStateException.class, this::waitForOperationCompletion);
+                    }
+
+                    @Override
+                    protected void replay(Operation existing) {}
+
+                    @Override
+                    public String get() {
+                        return RESULT;
+                    }
+                };
+
+        op.execute();
+        verify(executionManager, never()).terminateExecution(any(IllegalDurableOperationException.class));
+    }
+
+    @Test
     void waitForOperationCompletionWhenRunningAndReadyToComplete()
             throws InterruptedException, ExecutionException, TimeoutException {
         SerializableDurableOperation<String> op =


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fix #455 

### Description

When a user calls a durable method from the wrong thread, e.g.  calling `durableFuture.get()` from a step ,
currently `IllegalDurableOperationException` is thrown and the execution is immediately terminated.

`IllegalDurableOperationException` is supposed to be used in critical situation, e.g. SDK bugs or API bugs. Validation errors like above is user triggered and we shouldn't use `IllegalDurableOperationException` in this case.

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
