### PR TITLE
fix: fix the new javadoc jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ on:
       - 'pom.xml'
 
 permissions:
-  contents: write
+  contents: read
   pages: write
   id-token: write
 
@@ -66,38 +66,30 @@ jobs:
         run: mvn -B install --file pom.xml
 
       - name: Generate JaCoCo Badge
-        if: ${{ github.ref == 'refs/heads/main' && matrix.java == 17 }}
+        if: ${{ matrix.java == 17 }}
         uses: cicirello/jacoco-badge-generator@72266185b7ee48a6fd74eaf0238395cc8b14fef8 # v2
         with:
           jacoco-csv-file: coverage-report/target/site/jacoco-aggregate/jacoco.csv
           badges-directory: coverage-report/target/site/jacoco-aggregate
 
-      - name: Publish coverage report to GitHub Pages
-        if: ${{ github.ref == 'refs/heads/main' && matrix.java == 17 }}
-        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
-        with:
-          branch: docs
-          folder: coverage-report/target/site/jacoco-aggregate
-          target-folder: coverage
-
       - name: Generate javadoc site
-        if: ${{ github.ref == 'refs/heads/main' && matrix.java == 17 }}
+        if: ${{ matrix.java == 17 }}
         run: mvn -B -pl sdk -am javadoc:javadoc
 
       - name: Configure GitHub Pages
-        if: ${{ github.ref == 'refs/heads/main' && matrix.java == 17 }}
+        if: ${{ matrix.java == 17 }}
         uses: actions/configure-pages@v5
 
       - name: Prepare GitHub Pages artifact
-        if: ${{ github.ref == 'refs/heads/main' && matrix.java == 17 }}
+        if: ${{ matrix.java == 17 }}
         run: |
           mkdir -p github-pages/coverage github-pages/javadoc
           cp -R coverage-report/target/site/jacoco-aggregate/. github-pages/coverage
-          cp -R sdk/target/site/apidocs/. github-pages/javadoc
+          cp -R sdk/target/reports/apidocs/. github-pages/javadoc
           touch github-pages/.nojekyll
 
       - name: Upload GitHub Pages artifact
-        if: ${{ github.ref == 'refs/heads/main' && matrix.java == 17 }}
+        if: ${{ matrix.java == 17 }}
         uses: actions/upload-pages-artifact@v4
         with:
           path: github-pages


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fix the regression from #473 

### Description

The build failed in main branch for the error

```
cp: cannot stat 'sdk/target/site/apidocs/.': No such file or directory
```

The jobs were not run in the PR branch. Updated to make them run in PR and build the artifacts correctly:

https://github.com/aws/aws-durable-execution-sdk-java/actions/runs/27846018281/artifacts/7757576781

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
