### PR TITLE
fix: operations always return deserialized result

### DIFF
--- a/docs/migration-1.x-to-2.x.md
+++ b/docs/migration-1.x-to-2.x.md
@@ -185,6 +185,7 @@ assertThrows(IllegalStateException.class, future::get);
 What changes in practice:
 
 - Serialization problems now fail on first execution instead of surfacing later on replay.
+- Operation results can be returned after a SerDes round-trip so first execution matches replay.
 - Custom `SerDes` implementations must be able to deserialize SDK-managed values they serialize.
 - Child-context results are validated consistently, including virtual child-context paths.
 
@@ -192,20 +193,21 @@ This is usually a correctness improvement, but it can surface previously hidden 
 
 ### New opt-out configuration
 
-If your workload is very performance-sensitive and you need to skip the extra validation deserialize pass, you can opt out:
+If your workload is very performance-sensitive and you need to skip the extra deserialize pass, you can opt out:
 
 ```java
 @Override
 protected DurableConfig createConfiguration() {
     return DurableConfig.builder()
-            .withSerializationRoundTripValidation(false)
+            .withDeserializeAfterSerialization(false)
             .build();
 }
 ```
 
 Use that carefully:
 
-- Disabling validation can hide serialization bugs until replay.
+- Disabling this can hide serialization bugs until replay.
+- First execution may return the raw result shape instead of the replay result shape.
 - Custom `SerDes` implementations are still expected to be round-trip safe.
 
 ## Recommended Validation After Upgrading
@@ -226,6 +228,6 @@ Most upgrades are straightforward:
 - Logger metadata moves to `executionArn`, `operationId`, and `operationName`
 - Replay-sensitive logging becomes per-context, `isReplaying()` moves to `DurableContext`, and step logs are no longer replay-suppressed
 - Validation failures now throw `IllegalStateException`
-- Serialization round-trip problems surface earlier by default, with an opt-out via `withSerializationRoundTripValidation(false)`
+- Serialization round-trip problems surface earlier by default, with an opt-out via `withDeserializeAfterSerialization(false)`
 
 If you update those areas first, the `1.x` to `2.x` migration should be low risk.

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/general/CustomConfigExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/general/CustomConfigExample.java
@@ -31,7 +31,7 @@ import software.amazon.lambda.durable.serde.SerDes;
  *   <li>Automatic region detection with fallback to us-east-1 for testing environments
  *   <li>Environment variable credentials provider
  *   <li>Custom SerDes with snake_case property naming
- *   <li>Optional round-trip validation toggle for performance-sensitive workloads
+ *   <li>Optional post-serialization deserialization toggle for performance-sensitive workloads
  * </ul>
  */
 public class CustomConfigExample extends DurableHandler<String, String> {
@@ -69,8 +69,8 @@ public class CustomConfigExample extends DurableHandler<String, String> {
         return DurableConfig.builder()
                 .withDurableExecutionClient(durableClient)
                 .withSerDes(customSerDes)
-                // Disable the extra deserialize pass if your workload is sensitive to the added validation cost.
-                .withSerializationRoundTripValidation(false)
+                // Disable the extra deserialize pass if your workload is sensitive to the added cost.
+                .withDeserializeAfterSerialization(false)
                 .build();
     }
 

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/general/CustomConfigExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/general/CustomConfigExample.java
@@ -31,6 +31,7 @@ import software.amazon.lambda.durable.serde.SerDes;
  *   <li>Automatic region detection with fallback to us-east-1 for testing environments
  *   <li>Environment variable credentials provider
  *   <li>Custom SerDes with snake_case property naming
+ *   <li>Optional round-trip validation toggle for performance-sensitive workloads
  * </ul>
  */
 public class CustomConfigExample extends DurableHandler<String, String> {
@@ -68,6 +69,8 @@ public class CustomConfigExample extends DurableHandler<String, String> {
         return DurableConfig.builder()
                 .withDurableExecutionClient(durableClient)
                 .withSerDes(customSerDes)
+                // Disable the extra deserialize pass if your workload is sensitive to the added validation cost.
+                .withSerializationRoundTripValidation(false)
                 .build();
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
@@ -98,7 +98,7 @@ public final class DurableConfig {
     private final LoggerConfig loggerConfig;
     private final PollingStrategy pollingStrategy;
     private final Duration checkpointDelay;
-    private final boolean validateSerializationRoundTrip;
+    private final boolean deserializeAfterSerialization;
     private final PluginRunner pluginRunner;
 
     private DurableConfig(Builder builder) {
@@ -110,7 +110,7 @@ public final class DurableConfig {
         this.loggerConfig = Objects.requireNonNullElseGet(builder.loggerConfig, LoggerConfig::defaults);
         this.pollingStrategy = Objects.requireNonNullElse(builder.pollingStrategy, PollingStrategies.Presets.DEFAULT);
         this.checkpointDelay = Objects.requireNonNullElseGet(builder.checkpointDelay, () -> Duration.ofSeconds(0));
-        this.validateSerializationRoundTrip = builder.validateSerializationRoundTrip;
+        this.deserializeAfterSerialization = builder.deserializeAfterSerialization;
         this.pluginRunner = builder.plugins.isEmpty() ? PluginRunner.noOp() : new PluginRunner(builder.plugins);
 
         validateConfiguration();
@@ -189,16 +189,16 @@ public final class DurableConfig {
     }
 
     /**
-     * Gets whether serialized operation data should be immediately deserialized to verify round-trip compatibility.
+     * Gets whether serialized operation data should be deserialized immediately after serialization.
      *
-     * <p>When enabled, the SDK validates serialized operation results and exceptions before checkpointing them. This
-     * catches incompatible SerDes behavior early at the cost of an extra deserialize pass. Defaults to true, and custom
-     * SerDes implementations are still expected to be round-trip safe even if this validation is disabled.
+     * <p>When enabled, the SDK returns deserialized operation results so first execution matches replay, and validates
+     * serialized exceptions before checkpointing them. Defaults to true, and custom SerDes implementations are still
+     * expected to be round-trip safe even if this behavior is disabled.
      *
-     * @return true when round-trip serialization validation is enabled
+     * @return true when serialized data should be deserialized immediately
      */
-    public boolean shouldValidateSerializationRoundTrip() {
-        return validateSerializationRoundTrip;
+    public boolean shouldDeserializeAfterSerialization() {
+        return deserializeAfterSerialization;
     }
 
     /**
@@ -308,7 +308,7 @@ public final class DurableConfig {
         private LoggerConfig loggerConfig;
         private PollingStrategy pollingStrategy;
         private Duration checkpointDelay;
-        private boolean validateSerializationRoundTrip = true;
+        private boolean deserializeAfterSerialization = true;
         private List<DurableExecutionPlugin> plugins = new ArrayList<>();
 
         public Builder() {}
@@ -420,18 +420,16 @@ public final class DurableConfig {
         }
 
         /**
-         * Controls whether the SDK immediately deserializes serialized results and exceptions to verify they can be
-         * read back before checkpointing.
+         * Controls whether the SDK immediately deserializes serialized operation data after serialization.
          *
-         * <p>This validation is enabled by default. Disable it only to avoid the extra deserialize pass when the
-         * additional safety check is too expensive for your workload. Custom SerDes implementations are still expected
-         * to round-trip SDK-managed values correctly.
+         * <p>This is enabled by default. When enabled, operation results are returned after a SerDes round-trip so
+         * first execution returns the same value shape as replay, and exceptions are checked before checkpointing.
          *
-         * @param validateSerializationRoundTrip true to validate serialized data with an immediate deserialize pass
+         * @param deserializeAfterSerialization true to deserialize serialized data immediately
          * @return This builder
          */
-        public Builder withSerializationRoundTripValidation(boolean validateSerializationRoundTrip) {
-            this.validateSerializationRoundTrip = validateSerializationRoundTrip;
+        public Builder withDeserializeAfterSerialization(boolean deserializeAfterSerialization) {
+            this.deserializeAfterSerialization = deserializeAfterSerialization;
             return this;
         }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
@@ -98,6 +98,7 @@ public final class DurableConfig {
     private final LoggerConfig loggerConfig;
     private final PollingStrategy pollingStrategy;
     private final Duration checkpointDelay;
+    private final boolean validateSerializationRoundTrip;
     private final PluginRunner pluginRunner;
 
     private DurableConfig(Builder builder) {
@@ -109,6 +110,7 @@ public final class DurableConfig {
         this.loggerConfig = Objects.requireNonNullElseGet(builder.loggerConfig, LoggerConfig::defaults);
         this.pollingStrategy = Objects.requireNonNullElse(builder.pollingStrategy, PollingStrategies.Presets.DEFAULT);
         this.checkpointDelay = Objects.requireNonNullElseGet(builder.checkpointDelay, () -> Duration.ofSeconds(0));
+        this.validateSerializationRoundTrip = builder.validateSerializationRoundTrip;
         this.pluginRunner = builder.plugins.isEmpty() ? PluginRunner.noOp() : new PluginRunner(builder.plugins);
 
         validateConfiguration();
@@ -184,6 +186,19 @@ public final class DurableConfig {
      */
     public Duration getCheckpointDelay() {
         return checkpointDelay;
+    }
+
+    /**
+     * Gets whether serialized operation data should be immediately deserialized to verify round-trip compatibility.
+     *
+     * <p>When enabled, the SDK validates serialized operation results and exceptions before checkpointing them. This
+     * catches incompatible SerDes behavior early at the cost of an extra deserialize pass. Defaults to true, and custom
+     * SerDes implementations are still expected to be round-trip safe even if this validation is disabled.
+     *
+     * @return true when round-trip serialization validation is enabled
+     */
+    public boolean shouldValidateSerializationRoundTrip() {
+        return validateSerializationRoundTrip;
     }
 
     /**
@@ -293,6 +308,7 @@ public final class DurableConfig {
         private LoggerConfig loggerConfig;
         private PollingStrategy pollingStrategy;
         private Duration checkpointDelay;
+        private boolean validateSerializationRoundTrip = true;
         private List<DurableExecutionPlugin> plugins = new ArrayList<>();
 
         public Builder() {}
@@ -400,6 +416,22 @@ public final class DurableConfig {
          */
         public Builder withCheckpointDelay(Duration duration) {
             this.checkpointDelay = duration;
+            return this;
+        }
+
+        /**
+         * Controls whether the SDK immediately deserializes serialized results and exceptions to verify they can be
+         * read back before checkpointing.
+         *
+         * <p>This validation is enabled by default. Disable it only to avoid the extra deserialize pass when the
+         * additional safety check is too expensive for your workload. Custom SerDes implementations are still expected
+         * to round-trip SDK-managed values correctly.
+         *
+         * @param validateSerializationRoundTrip true to validate serialized data with an immediate deserialize pass
+         * @return This builder
+         */
+        public Builder withSerializationRoundTripValidation(boolean validateSerializationRoundTrip) {
+            this.validateSerializationRoundTrip = validateSerializationRoundTrip;
             return this;
         }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableHandler.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableHandler.java
@@ -117,6 +117,7 @@ public abstract class DurableHandler<I, O> implements RequestStreamHandler {
      *         .withDurableExecutionClient(durableClient)
      *         .withSerDes(customSerDes)  // Optional: custom SerDes for user data
      *         .withExecutorService(customExecutor)  // Optional: custom thread pool
+     *         .withSerializationRoundTripValidation(false)  // Optional: skip extra validation deserialize pass
      *         .build();
      * }
      * }</pre>

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableHandler.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableHandler.java
@@ -117,7 +117,7 @@ public abstract class DurableHandler<I, O> implements RequestStreamHandler {
      *         .withDurableExecutionClient(durableClient)
      *         .withSerDes(customSerDes)  // Optional: custom SerDes for user data
      *         .withExecutorService(customExecutor)  // Optional: custom thread pool
-     *         .withSerializationRoundTripValidation(false)  // Optional: skip extra validation deserialize pass
+     *         .withDeserializeAfterSerialization(false)  // Optional: skip immediate deserialize pass
      *         .build();
      * }
      * }</pre>

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
@@ -149,6 +149,8 @@ public class ChildContextOperation<T> extends SerializableDurableOperation<T> {
     }
 
     private void handleChildContextSuccess(T result) {
+        var serialized = serializeResult(result);
+
         if (replayChildren.get() || isVirtual || parentOperation != null && parentOperation.isOperationCompleted()) {
             // Skip checkpointing if
             // - parent ConcurrencyOperation has already completed, preventing race conditions where a child finishes
@@ -162,13 +164,11 @@ public class ChildContextOperation<T> extends SerializableDurableOperation<T> {
             }
             markAlreadyCompleted();
         } else {
-            checkpointSuccess(result);
+            checkpointSuccess(result, serialized);
         }
     }
 
-    private void checkpointSuccess(T result) {
-        var serialized = serializeResult(result);
-
+    private void checkpointSuccess(T result, String serialized) {
         if (serialized == null || serialized.getBytes(StandardCharsets.UTF_8).length < LARGE_RESULT_THRESHOLD) {
             sendOperationUpdate(
                     OperationUpdate.builder().action(OperationAction.SUCCEED).payload(serialized));

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
@@ -149,7 +149,7 @@ public class ChildContextOperation<T> extends SerializableDurableOperation<T> {
     }
 
     private void handleChildContextSuccess(T result) {
-        var serialized = serializeResult(result);
+        var serializedResult = serializeAndDeserializeResult(result);
 
         if (replayChildren.get() || isVirtual || parentOperation != null && parentOperation.isOperationCompleted()) {
             // Skip checkpointing if
@@ -158,13 +158,13 @@ public class ChildContextOperation<T> extends SerializableDurableOperation<T> {
             // - replaying a SUCCEEDED child with replayChildren=true — skip checkpointing.
             // - nestingType is FLAT
             // Mark the completableFuture completed so get() doesn't block waiting for a checkpoint response.
-            cachedOperationResult.set(DeserializedOperationResult.succeeded(result));
+            cachedOperationResult.set(DeserializedOperationResult.succeeded(serializedResult.deserialized()));
             if (isVirtual) {
                 fireOnOperationEnd(null, null);
             }
             markAlreadyCompleted();
         } else {
-            checkpointSuccess(result, serialized);
+            checkpointSuccess(serializedResult.deserialized(), serializedResult.serialized());
         }
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
@@ -178,21 +178,22 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
     @Override
     protected void handleCompletion(ConcurrencyCompletionStatus concurrencyCompletionStatus) {
         this.cachedResult = constructMapResult(concurrencyCompletionStatus);
-        var serialized = serializeResult(cachedResult);
-        var serializedBytes = serialized.getBytes(StandardCharsets.UTF_8);
+        var serializedResult = serializeAndDeserializeResult(cachedResult);
+        this.cachedResult = serializedResult.deserialized();
+        var serializedBytes = serializedResult.serialized().getBytes(StandardCharsets.UTF_8);
 
         if (serializedBytes.length < LARGE_RESULT_THRESHOLD) {
             sendOperationUpdate(OperationUpdate.builder()
                     .action(OperationAction.SUCCEED)
                     .subType(getSubType().getValue())
-                    .payload(serialized));
+                    .payload(serializedResult.serialized()));
         } else {
             // Large result: checkpoint with stripped payload + replayChildren flag
-            var strippedResult = serializeResult(stripMapResult(cachedResult));
+            var strippedResult = serializeAndDeserializeResult(stripMapResult(cachedResult));
             sendOperationUpdate(OperationUpdate.builder()
                     .action(OperationAction.SUCCEED)
                     .subType(getSubType().getValue())
-                    .payload(strippedResult)
+                    .payload(strippedResult.serialized())
                     .contextOptions(
                             ContextOptions.builder().replayChildren(true).build()));
         }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
@@ -78,13 +78,15 @@ public class ParallelOperation extends ConcurrencyOperation<ParallelResult> impl
         int skippedCount = items.size() - succeededCount - failedCount;
         cachedResult = new ParallelResult(
                 items.size(), succeededCount, failedCount, skippedCount, concurrencyCompletionStatus, statuses);
+        var serializedResult = serializeAndDeserializeResult(cachedResult);
+        cachedResult = serializedResult.deserialized();
 
         // Branches added after checkpoint will not exist in the checkpointed result, but they'll be in the returned
         // value from get() method.
         sendOperationUpdate(OperationUpdate.builder()
                 .action(OperationAction.SUCCEED)
                 .subType(getSubType().getValue())
-                .payload(serializeResult(cachedResult))
+                .payload(serializedResult.serialized())
                 .contextOptions(ContextOptions.builder().replayChildren(true).build()));
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/SerializableDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/SerializableDurableOperation.java
@@ -34,6 +34,8 @@ import software.amazon.lambda.durable.util.ExceptionHelper;
 public abstract class SerializableDurableOperation<T> extends BaseDurableOperation implements DurableFuture<T> {
     private static final Logger logger = LoggerFactory.getLogger(SerializableDurableOperation.class);
 
+    protected record SerializedResult<T>(String serialized, T deserialized) {}
+
     private final TypeToken<T> resultTypeToken;
     private final SerDes resultSerDes;
 
@@ -95,17 +97,18 @@ public abstract class SerializableDurableOperation<T> extends BaseDurableOperati
     }
 
     /**
-     * Serializes the result to a string.
+     * Serializes the result and returns the value that should be exposed to callers.
+     *
+     * <p>Use this for operations that cache a first-execution result instead of reading it back from checkpoint data.
+     * This keeps first execution consistent with replay when a SerDes normalizes or otherwise changes the value.
      *
      * @param result the result to serialize
-     * @return the serialized string
+     * @return the serialized string and the deserialized result
      */
-    protected String serializeResult(T result) {
+    protected SerializedResult<T> serializeAndDeserializeResult(T result) {
         var serialized = resultSerDes.serialize(result);
-        if (shouldValidateSerializationRoundTrip()) {
-            deserializeResult(serialized);
-        }
-        return serialized;
+        var deserialized = shouldDeserializeAfterSerialization() ? deserializeResult(serialized) : result;
+        return new SerializedResult<>(serialized, deserialized);
     }
 
     /**
@@ -117,15 +120,15 @@ public abstract class SerializableDurableOperation<T> extends BaseDurableOperati
     @SuppressWarnings("ThrowableNotThrown")
     protected ErrorObject serializeException(Throwable throwable) {
         var error = ExceptionHelper.buildErrorObject(throwable, resultSerDes);
-        if (shouldValidateSerializationRoundTrip()) {
+        if (shouldDeserializeAfterSerialization()) {
             deserializeException(error);
         }
         return error;
     }
 
-    private boolean shouldValidateSerializationRoundTrip() {
+    private boolean shouldDeserializeAfterSerialization() {
         var config = getContext().getDurableConfig();
-        return config == null || config.shouldValidateSerializationRoundTrip();
+        return config == null || config.shouldDeserializeAfterSerialization();
     }
 
     /**

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/SerializableDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/SerializableDurableOperation.java
@@ -101,7 +101,11 @@ public abstract class SerializableDurableOperation<T> extends BaseDurableOperati
      * @return the serialized string
      */
     protected String serializeResult(T result) {
-        return resultSerDes.serialize(result);
+        var serialized = resultSerDes.serialize(result);
+        if (shouldValidateSerializationRoundTrip()) {
+            deserializeResult(serialized);
+        }
+        return serialized;
     }
 
     /**
@@ -110,8 +114,18 @@ public abstract class SerializableDurableOperation<T> extends BaseDurableOperati
      * @param throwable the exception to serialize
      * @return the serialized error object
      */
+    @SuppressWarnings("ThrowableNotThrown")
     protected ErrorObject serializeException(Throwable throwable) {
-        return ExceptionHelper.buildErrorObject(throwable, resultSerDes);
+        var error = ExceptionHelper.buildErrorObject(throwable, resultSerDes);
+        if (shouldValidateSerializationRoundTrip()) {
+            deserializeException(error);
+        }
+        return error;
+    }
+
+    private boolean shouldValidateSerializationRoundTrip() {
+        var config = getContext().getDurableConfig();
+        return config == null || config.shouldValidateSerializationRoundTrip();
     }
 
     /**

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
@@ -144,9 +144,11 @@ public class StepOperation<T> extends SerializableDurableOperation<T> {
     }
 
     private void handleStepSucceeded(T result) {
+        var serializedResult = serializeAndDeserializeResult(result);
+
         // Send SUCCEED
         var successUpdate =
-                OperationUpdate.builder().action(OperationAction.SUCCEED).payload(serializeResult(result));
+                OperationUpdate.builder().action(OperationAction.SUCCEED).payload(serializedResult.serialized());
 
         // sendOperationUpdate must be synchronous here. When waiting for the return of this call,
         // the context threads waiting for the result of this step operation will be wakened up and registered.

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitForConditionOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitForConditionOperation.java
@@ -128,15 +128,15 @@ public class WaitForConditionOperation<T> extends SerializableDurableOperation<T
                     // Execute check function in user executor
                     WaitForConditionResult<T> result = checkFunc.apply(currentState, stepContext);
 
-                    // Serialize/deserialize round-trip on the value to ensure state is checkpoint-safe
-                    var serializedState = serializeResult(result.value());
-                    T deserializedValue = deserializeResult(serializedState);
+                    // Normalize the value through SerDes so first execution matches replay.
+                    var serializedState = serializeAndDeserializeResult(result.value());
+                    T deserializedValue = serializedState.deserialized();
 
                     if (result.isDone()) {
                         // Condition met — checkpoint SUCCEED
                         var successUpdate = OperationUpdate.builder()
                                 .action(OperationAction.SUCCEED)
-                                .payload(serializedState);
+                                .payload(serializedState.serialized());
                         sendOperationUpdate(successUpdate);
                     } else {
                         // Compute delay from strategy
@@ -145,7 +145,7 @@ public class WaitForConditionOperation<T> extends SerializableDurableOperation<T
                         // Checkpoint RETRY with delay
                         var retryUpdate = OperationUpdate.builder()
                                 .action(OperationAction.RETRY)
-                                .payload(serializedState)
+                                .payload(serializedState.serialized())
                                 .stepOptions(StepOptions.builder()
                                         .nextAttemptDelaySeconds(Math.toIntExact(delay.toSeconds()))
                                         .build());

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
@@ -88,6 +88,24 @@ class DurableConfigTest {
     }
 
     @Test
+    void testBuilder_SerializationRoundTripValidationDefaultsToTrue() {
+        var config =
+                DurableConfig.builder().withDurableExecutionClient(mockClient).build();
+
+        assertTrue(config.shouldValidateSerializationRoundTrip());
+    }
+
+    @Test
+    void testBuilder_WithSerializationRoundTripValidationDisabled() {
+        var config = DurableConfig.builder()
+                .withDurableExecutionClient(mockClient)
+                .withSerializationRoundTripValidation(false)
+                .build();
+
+        assertFalse(config.shouldValidateSerializationRoundTrip());
+    }
+
+    @Test
     void testBuilder_WithAllCustomComponents() {
         var config = DurableConfig.builder()
                 .withDurableExecutionClient(mockClient)
@@ -131,6 +149,7 @@ class DurableConfigTest {
         assertSame(builder, builder.withDurableExecutionClient(mockClient));
         assertSame(builder, builder.withSerDes(mockSerDes));
         assertSame(builder, builder.withExecutorService(mockExecutor));
+        assertSame(builder, builder.withSerializationRoundTripValidation(false));
     }
 
     @Test

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
@@ -88,21 +88,21 @@ class DurableConfigTest {
     }
 
     @Test
-    void testBuilder_SerializationRoundTripValidationDefaultsToTrue() {
+    void testBuilder_DeserializeAfterSerializationDefaultsToTrue() {
         var config =
                 DurableConfig.builder().withDurableExecutionClient(mockClient).build();
 
-        assertTrue(config.shouldValidateSerializationRoundTrip());
+        assertTrue(config.shouldDeserializeAfterSerialization());
     }
 
     @Test
-    void testBuilder_WithSerializationRoundTripValidationDisabled() {
+    void testBuilder_WithDeserializeAfterSerializationDisabled() {
         var config = DurableConfig.builder()
                 .withDurableExecutionClient(mockClient)
-                .withSerializationRoundTripValidation(false)
+                .withDeserializeAfterSerialization(false)
                 .build();
 
-        assertFalse(config.shouldValidateSerializationRoundTrip());
+        assertFalse(config.shouldDeserializeAfterSerialization());
     }
 
     @Test
@@ -149,7 +149,7 @@ class DurableConfigTest {
         assertSame(builder, builder.withDurableExecutionClient(mockClient));
         assertSame(builder, builder.withSerDes(mockSerDes));
         assertSame(builder, builder.withExecutorService(mockExecutor));
-        assertSame(builder, builder.withSerializationRoundTripValidation(false));
+        assertSame(builder, builder.withDeserializeAfterSerialization(false));
     }
 
     @Test

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/ChildContextOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/ChildContextOperationTest.java
@@ -24,15 +24,29 @@ import software.amazon.lambda.durable.config.RunInChildContextConfig;
 import software.amazon.lambda.durable.context.DurableContextImpl;
 import software.amazon.lambda.durable.exception.ChildContextFailedException;
 import software.amazon.lambda.durable.exception.NonDeterministicExecutionException;
+import software.amazon.lambda.durable.exception.SerDesException;
 import software.amazon.lambda.durable.execution.ExecutionManager;
 import software.amazon.lambda.durable.execution.ThreadContext;
 import software.amazon.lambda.durable.execution.ThreadType;
 import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
+import software.amazon.lambda.durable.serde.SerDes;
 
 /** Unit tests for ChildContextOperation. */
 class ChildContextOperationTest {
+
+    private static final class SerializationOnlySerDes implements SerDes {
+        @Override
+        public String serialize(Object value) {
+            return "\"serialized\"";
+        }
+
+        @Override
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            throw new SerDesException("cannot deserialize");
+        }
+    }
 
     private static final JacksonSerDes SERDES = new JacksonSerDes();
 
@@ -49,8 +63,13 @@ class ChildContextOperationTest {
     }
 
     private DurableConfig createConfig() {
+        return createConfig(true);
+    }
+
+    private DurableConfig createConfig(boolean validateSerializationRoundTrip) {
         return DurableConfig.builder()
                 .withExecutorService(Executors.newCachedThreadPool())
+                .withSerializationRoundTripValidation(validateSerializationRoundTrip)
                 .build();
     }
 
@@ -58,20 +77,28 @@ class ChildContextOperationTest {
             OperationIdentifier.of("1", "test-context", OperationSubType.RUN_IN_CHILD_CONTEXT);
 
     private ChildContextOperation<String> createOperation(Function<DurableContext, String> func) {
+        return createOperation(func, SERDES);
+    }
+
+    private ChildContextOperation<String> createOperation(Function<DurableContext, String> func, SerDes serDes) {
         return new ChildContextOperation<>(
                 OPERATION_IDENTIFIER,
                 func,
                 TypeToken.get(String.class),
-                RunInChildContextConfig.builder().serDes(SERDES).build(),
+                RunInChildContextConfig.builder().serDes(serDes).build(),
                 durableContext);
     }
 
     private ChildContextOperation<String> createVirtualOperation(Function<DurableContext, String> func) {
+        return createVirtualOperation(func, SERDES);
+    }
+
+    private ChildContextOperation<String> createVirtualOperation(Function<DurableContext, String> func, SerDes serDes) {
         return new ChildContextOperation<>(
                 OPERATION_IDENTIFIER,
                 func,
                 TypeToken.get(String.class),
-                RunInChildContextConfig.builder().serDes(SERDES).isVirtual(true).build(),
+                RunInChildContextConfig.builder().serDes(serDes).isVirtual(true).build(),
                 durableContext);
     }
 
@@ -309,6 +336,40 @@ class ChildContextOperationTest {
         // sendOperationUpdate should only be called once for START, not for SUCCEED
         verify(executionManager, never())
                 .sendOperationUpdate(argThat(update -> update.action() == OperationAction.SUCCEED));
+    }
+
+    /** Virtual child still validates result round-trip before skipping a success checkpoint. */
+    @Test
+    void virtualChildFailsWhenResultCannotBeDeserialized() throws Exception {
+        when(executionManager.getOperationAndUpdateReplayState("1")).thenReturn(null);
+
+        var operation = createVirtualOperation(ctx -> "result", new SerializationOnlySerDes());
+        operation.execute();
+        Thread.sleep(200);
+
+        var thrown = assertThrows(ChildContextFailedException.class, operation::get);
+        assertTrue(thrown.getMessage().contains(SerDesException.class.getName()));
+        verify(executionManager, never())
+                .sendOperationUpdate(argThat(update -> update.action() == OperationAction.SUCCEED));
+        verify(executionManager, never())
+                .sendOperationUpdate(argThat(update -> update.action() == OperationAction.FAIL));
+    }
+
+    /** Virtual child can skip round-trip validation when disabled in DurableConfig. */
+    @Test
+    void virtualChildSucceedsWhenResultValidationDisabled() throws Exception {
+        when(executionManager.getOperationAndUpdateReplayState("1")).thenReturn(null);
+        when(durableContext.getDurableConfig()).thenReturn(createConfig(false));
+
+        var operation = createVirtualOperation(ctx -> "result", new SerializationOnlySerDes());
+        operation.execute();
+        Thread.sleep(200);
+
+        assertEquals("result", operation.get());
+        verify(executionManager, never())
+                .sendOperationUpdate(argThat(update -> update.action() == OperationAction.SUCCEED));
+        verify(executionManager, never())
+                .sendOperationUpdate(argThat(update -> update.action() == OperationAction.FAIL));
     }
 
     /** Child skips failure checkpoint when parent operation has already completed. */

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/ChildContextOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/ChildContextOperationTest.java
@@ -48,6 +48,19 @@ class ChildContextOperationTest {
         }
     }
 
+    private static final class NormalizingSerDes implements SerDes {
+        @Override
+        public String serialize(Object value) {
+            return "\"serialized\"";
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            return (T) "deserialized";
+        }
+    }
+
     private static final JacksonSerDes SERDES = new JacksonSerDes();
 
     private DurableContextImpl durableContext;
@@ -66,10 +79,10 @@ class ChildContextOperationTest {
         return createConfig(true);
     }
 
-    private DurableConfig createConfig(boolean validateSerializationRoundTrip) {
+    private DurableConfig createConfig(boolean deserializeAfterSerialization) {
         return DurableConfig.builder()
                 .withExecutorService(Executors.newCachedThreadPool())
-                .withSerializationRoundTripValidation(validateSerializationRoundTrip)
+                .withDeserializeAfterSerialization(deserializeAfterSerialization)
                 .build();
     }
 
@@ -157,6 +170,15 @@ class ChildContextOperationTest {
 
         assertEquals("should-execute", result);
         assertTrue(functionCalled.get(), "Function should be called during SUCCEEDED replay");
+    }
+
+    @Test
+    void virtualChildReturnsDeserializedResult() {
+        var operation = createVirtualOperation(ctx -> "raw", new NormalizingSerDes());
+
+        operation.execute();
+
+        assertEquals("deserialized", operation.get());
     }
 
     // ===== FAILED replay =====
@@ -355,7 +377,7 @@ class ChildContextOperationTest {
                 .sendOperationUpdate(argThat(update -> update.action() == OperationAction.FAIL));
     }
 
-    /** Virtual child can skip round-trip validation when disabled in DurableConfig. */
+    /** Virtual child can skip result deserialization when disabled in DurableConfig. */
     @Test
     void virtualChildSucceedsWhenResultValidationDisabled() throws Exception {
         when(executionManager.getOperationAndUpdateReplayState("1")).thenReturn(null);

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/SerializableDurableOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/SerializableDurableOperationTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
@@ -27,7 +28,9 @@ import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.awssdk.services.lambda.model.OperationType;
 import software.amazon.awssdk.services.lambda.model.OperationUpdate;
+import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.client.DurableExecutionClient;
 import software.amazon.lambda.durable.context.DurableContextImpl;
 import software.amazon.lambda.durable.exception.IllegalDurableOperationException;
 import software.amazon.lambda.durable.exception.NonDeterministicExecutionException;
@@ -41,6 +44,32 @@ import software.amazon.lambda.durable.serde.JacksonSerDes;
 import software.amazon.lambda.durable.serde.SerDes;
 
 class SerializableDurableOperationTest {
+
+    private static final class TrackingSerDes extends JacksonSerDes {
+        private final AtomicInteger deserializeCount = new AtomicInteger(0);
+
+        @Override
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            deserializeCount.incrementAndGet();
+            return super.deserialize(data, typeToken);
+        }
+
+        int getDeserializeCount() {
+            return deserializeCount.get();
+        }
+    }
+
+    private static final class SerializationOnlySerDes implements SerDes {
+        @Override
+        public String serialize(Object value) {
+            return "\"serialized\"";
+        }
+
+        @Override
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            throw new SerDesException("cannot deserialize");
+        }
+    }
 
     private static final String OPERATION_ID = "1";
     private static final String CONTEXT_ID = "1-step";
@@ -341,6 +370,73 @@ class SerializableDurableOperationTest {
     }
 
     @Test
+    void serializeResultValidatesRoundTrip() {
+        var serDes = new TrackingSerDes();
+        SerializableDurableOperation<String> op =
+                new SerializableDurableOperation<>(OPERATION_IDENTIFIER, RESULT_TYPE, serDes, durableContext) {
+                    @Override
+                    protected void start() {}
+
+                    @Override
+                    protected void replay(Operation existing) {}
+
+                    @Override
+                    public String get() {
+                        assertEquals("\"abc\"", serializeResult("abc"));
+                        assertEquals(1, serDes.getDeserializeCount());
+                        return RESULT;
+                    }
+                };
+
+        op.get();
+    }
+
+    @Test
+    void serializeResultThrowsWhenRoundTripFails() {
+        var serDes = new SerializationOnlySerDes();
+        SerializableDurableOperation<String> op =
+                new SerializableDurableOperation<>(OPERATION_IDENTIFIER, RESULT_TYPE, serDes, durableContext) {
+                    @Override
+                    protected void start() {}
+
+                    @Override
+                    protected void replay(Operation existing) {}
+
+                    @Override
+                    public String get() {
+                        var thrown = assertThrows(SerDesException.class, () -> serializeResult("abc"));
+                        assertEquals("cannot deserialize", thrown.getMessage());
+                        return RESULT;
+                    }
+                };
+
+        op.get();
+    }
+
+    @Test
+    void serializeResultSkipsRoundTripValidationWhenDisabled() {
+        when(durableContext.getDurableConfig()).thenReturn(configWithSerializationValidation(false));
+
+        var serDes = new SerializationOnlySerDes();
+        SerializableDurableOperation<String> op =
+                new SerializableDurableOperation<>(OPERATION_IDENTIFIER, RESULT_TYPE, serDes, durableContext) {
+                    @Override
+                    protected void start() {}
+
+                    @Override
+                    protected void replay(Operation existing) {}
+
+                    @Override
+                    public String get() {
+                        assertEquals("\"serialized\"", serializeResult("abc"));
+                        return RESULT;
+                    }
+                };
+
+        op.get();
+    }
+
+    @Test
     void deserializeException() {
         SerializableDurableOperation<String> op =
                 new SerializableDurableOperation<>(OPERATION_IDENTIFIER, RESULT_TYPE, SER_DES, durableContext) {
@@ -359,6 +455,53 @@ class SerializableDurableOperationTest {
                         Throwable ex = deserializeException(serializeException(new RuntimeException("test exception")));
                         assertInstanceOf(RuntimeException.class, ex);
                         assertEquals("test exception", ex.getMessage());
+                        return RESULT;
+                    }
+                };
+
+        op.get();
+    }
+
+    @Test
+    void serializeExceptionValidatesRoundTrip() {
+        var serDes = new TrackingSerDes();
+        SerializableDurableOperation<String> op =
+                new SerializableDurableOperation<>(OPERATION_IDENTIFIER, RESULT_TYPE, serDes, durableContext) {
+                    @Override
+                    protected void start() {}
+
+                    @Override
+                    protected void replay(Operation existing) {}
+
+                    @Override
+                    public String get() {
+                        var error = serializeException(new RuntimeException("test exception"));
+                        assertEquals(RuntimeException.class.getName(), error.errorType());
+                        assertEquals(1, serDes.getDeserializeCount());
+                        return RESULT;
+                    }
+                };
+
+        op.get();
+    }
+
+    @Test
+    void serializeExceptionSkipsRoundTripValidationWhenDisabled() {
+        when(durableContext.getDurableConfig()).thenReturn(configWithSerializationValidation(false));
+
+        var serDes = new SerializationOnlySerDes();
+        SerializableDurableOperation<String> op =
+                new SerializableDurableOperation<>(OPERATION_IDENTIFIER, RESULT_TYPE, serDes, durableContext) {
+                    @Override
+                    protected void start() {}
+
+                    @Override
+                    protected void replay(Operation existing) {}
+
+                    @Override
+                    public String get() {
+                        var error = serializeException(new RuntimeException("test exception"));
+                        assertEquals(RuntimeException.class.getName(), error.errorType());
                         return RESULT;
                     }
                 };
@@ -410,5 +553,12 @@ class SerializableDurableOperationTest {
 
         op.execute();
         verify(executionManager, times(1)).sendOperationUpdate(update.build());
+    }
+
+    private DurableConfig configWithSerializationValidation(boolean validateSerializationRoundTrip) {
+        return DurableConfig.builder()
+                .withDurableExecutionClient(mock(DurableExecutionClient.class))
+                .withSerializationRoundTripValidation(validateSerializationRoundTrip)
+                .build();
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/SerializableDurableOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/SerializableDurableOperationTest.java
@@ -71,6 +71,19 @@ class SerializableDurableOperationTest {
         }
     }
 
+    private static final class NormalizingSerDes implements SerDes {
+        @Override
+        public String serialize(Object value) {
+            return "\"serialized\"";
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            return (T) "deserialized";
+        }
+    }
+
     private static final String OPERATION_ID = "1";
     private static final String CONTEXT_ID = "1-step";
     private static final String OPERATION_NAME = "name";
@@ -360,7 +373,7 @@ class SerializableDurableOperationTest {
 
                     @Override
                     public String get() {
-                        assertEquals("abc", deserializeResult(serializeResult("abc")));
+                        assertEquals("abc", deserializeResult(SER_DES.serialize("abc")));
                         assertEquals("", deserializeResult("\"\""));
                         assertThrows(SerDesException.class, () -> deserializeResult("x"));
                         return RESULT;
@@ -370,7 +383,7 @@ class SerializableDurableOperationTest {
     }
 
     @Test
-    void serializeResultValidatesRoundTrip() {
+    void serializeAndDeserializeResultDeserializesResult() {
         var serDes = new TrackingSerDes();
         SerializableDurableOperation<String> op =
                 new SerializableDurableOperation<>(OPERATION_IDENTIFIER, RESULT_TYPE, serDes, durableContext) {
@@ -382,7 +395,9 @@ class SerializableDurableOperationTest {
 
                     @Override
                     public String get() {
-                        assertEquals("\"abc\"", serializeResult("abc"));
+                        var result = serializeAndDeserializeResult("abc");
+                        assertEquals("\"abc\"", result.serialized());
+                        assertEquals("abc", result.deserialized());
                         assertEquals(1, serDes.getDeserializeCount());
                         return RESULT;
                     }
@@ -392,7 +407,7 @@ class SerializableDurableOperationTest {
     }
 
     @Test
-    void serializeResultThrowsWhenRoundTripFails() {
+    void serializeAndDeserializeResultThrowsWhenDeserializeFails() {
         var serDes = new SerializationOnlySerDes();
         SerializableDurableOperation<String> op =
                 new SerializableDurableOperation<>(OPERATION_IDENTIFIER, RESULT_TYPE, serDes, durableContext) {
@@ -404,7 +419,7 @@ class SerializableDurableOperationTest {
 
                     @Override
                     public String get() {
-                        var thrown = assertThrows(SerDesException.class, () -> serializeResult("abc"));
+                        var thrown = assertThrows(SerDesException.class, () -> serializeAndDeserializeResult("abc"));
                         assertEquals("cannot deserialize", thrown.getMessage());
                         return RESULT;
                     }
@@ -414,10 +429,10 @@ class SerializableDurableOperationTest {
     }
 
     @Test
-    void serializeResultSkipsRoundTripValidationWhenDisabled() {
-        when(durableContext.getDurableConfig()).thenReturn(configWithSerializationValidation(false));
+    void serializeAndDeserializeResultReturnsRawResultWhenDeserializationDisabled() {
+        when(durableContext.getDurableConfig()).thenReturn(configWithDeserializeAfterSerialization(false));
 
-        var serDes = new SerializationOnlySerDes();
+        var serDes = new NormalizingSerDes();
         SerializableDurableOperation<String> op =
                 new SerializableDurableOperation<>(OPERATION_IDENTIFIER, RESULT_TYPE, serDes, durableContext) {
                     @Override
@@ -428,7 +443,32 @@ class SerializableDurableOperationTest {
 
                     @Override
                     public String get() {
-                        assertEquals("\"serialized\"", serializeResult("abc"));
+                        var result = serializeAndDeserializeResult("abc");
+                        assertEquals("\"serialized\"", result.serialized());
+                        assertEquals("abc", result.deserialized());
+                        return RESULT;
+                    }
+                };
+
+        op.get();
+    }
+
+    @Test
+    void serializeAndDeserializeResultReturnsDeserializedValue() {
+        SerializableDurableOperation<String> op =
+                new SerializableDurableOperation<>(
+                        OPERATION_IDENTIFIER, RESULT_TYPE, new NormalizingSerDes(), durableContext) {
+                    @Override
+                    protected void start() {}
+
+                    @Override
+                    protected void replay(Operation existing) {}
+
+                    @Override
+                    public String get() {
+                        var result = serializeAndDeserializeResult("raw");
+                        assertEquals("\"serialized\"", result.serialized());
+                        assertEquals("deserialized", result.deserialized());
                         return RESULT;
                     }
                 };
@@ -487,7 +527,7 @@ class SerializableDurableOperationTest {
 
     @Test
     void serializeExceptionSkipsRoundTripValidationWhenDisabled() {
-        when(durableContext.getDurableConfig()).thenReturn(configWithSerializationValidation(false));
+        when(durableContext.getDurableConfig()).thenReturn(configWithDeserializeAfterSerialization(false));
 
         var serDes = new SerializationOnlySerDes();
         SerializableDurableOperation<String> op =
@@ -555,10 +595,10 @@ class SerializableDurableOperationTest {
         verify(executionManager, times(1)).sendOperationUpdate(update.build());
     }
 
-    private DurableConfig configWithSerializationValidation(boolean validateSerializationRoundTrip) {
+    private DurableConfig configWithDeserializeAfterSerialization(boolean deserializeAfterSerialization) {
         return DurableConfig.builder()
                 .withDurableExecutionClient(mock(DurableExecutionClient.class))
-                .withSerializationRoundTripValidation(validateSerializationRoundTrip)
+                .withDeserializeAfterSerialization(deserializeAfterSerialization)
                 .build();
     }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fix #456 

### Description

Call deserialize immediately after serialize to make sure the serialized result is always deserialize-able

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
