### PR TITLE
chore: update Dependabot schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,8 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "UTC"
+      interval: "weekly"
+      day: "monday"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "[maven]"
@@ -16,9 +15,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "UTC"
+      interval: "weekly"
+      day: "monday"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "[github-actions]"


### PR DESCRIPTION
fixes: #353

## Summary
- Change Dependabot checks from daily to weekly
- Run Maven and GitHub Actions update checks every Monday
- Remove explicit time and timezone settings

## Tests
- Not run (configuration-only change)