### PR TITLE
feat: user friendly message for StepInterruptedException

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/exception/StepInterruptedException.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/exception/StepInterruptedException.java
@@ -7,20 +7,23 @@ import software.amazon.awssdk.services.lambda.model.Operation;
 
 /** Exception thrown when a step with AT_MOST_ONCE_PER_RETRY semantics was started but interrupted before completion. */
 public class StepInterruptedException extends StepException {
+    private static final String ERROR_TYPE = StepInterruptedException.class.getName();
+
     public StepInterruptedException(Operation operation) {
-        super(operation, toErrorObject(), formatMessage(operation));
+        super(operation, toErrorObject(operation), formatMessage(operation));
     }
 
     public static boolean isStepInterruptedException(ErrorObject errorObject) {
         if (errorObject == null) {
             return false;
         }
-        return StepInterruptedException.toErrorObject().errorType().equals(errorObject.errorType());
+        return ERROR_TYPE.equals(errorObject.errorType());
     }
 
-    private static ErrorObject toErrorObject() {
+    private static ErrorObject toErrorObject(Operation operation) {
         return ErrorObject.builder()
-                .errorType(StepInterruptedException.class.getName())
+                .errorType(ERROR_TYPE)
+                .errorMessage(formatMessage(operation))
                 .build();
     }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

add a user friendly error message for `StepInterruptedException`

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

```
--- Validating test description 1-17 (StepAtMostOnceNoRetry) ---
  Invoking StepAtMostOnceNoRetry with event from 1-17.yaml ...
  Saved execution history to tmp/java-step/1-17.json
  ✅ PASSED
     Placeholders: {'INPUT_1': 'ntj9vqdr', 'ID1': '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b'}

--- Validating test description 1-18 (StepAtMostOnceWithRetry) ---
  Invoking StepAtMostOnceWithRetry with event from 1-18.yaml ...
  Saved execution history to tmp/java-step/1-18.json
  ✅ PASSED
     Placeholders: {'INPUT_1': 'u9bp40br', 'ID1': '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b'}
```

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
