### PR TITLE
refactor: Rename OTel plugin artifact to plugin-otel

### DIFF
--- a/.github/workflows/release_maven.yml
+++ b/.github/workflows/release_maven.yml
@@ -294,7 +294,7 @@ jobs:
           files: |
             sdk/target/aws-durable-execution-sdk-java-${{ github.event.inputs.release_version }}.jar
             sdk-testing/target/aws-durable-execution-sdk-java-testing-${{ github.event.inputs.release_version }}.jar
-            otel-plugin/target/aws-durable-execution-sdk-java-otel-${{ github.event.inputs.release_version }}.jar
+            otel-plugin/target/aws-durable-execution-sdk-java-plugin-otel-${{ github.event.inputs.release_version }}.jar
       
       - name: Sign and publish
         run: bash .github/scripts/maven_publish.sh

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -34,7 +34,7 @@
         <!-- OTel Plugin -->
         <dependency>
             <groupId>software.amazon.lambda.durable</groupId>
-            <artifactId>aws-durable-execution-sdk-java-otel</artifactId>
+            <artifactId>aws-durable-execution-sdk-java-plugin-otel</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/otel-plugin/README.md
+++ b/otel-plugin/README.md
@@ -17,7 +17,7 @@ OpenTelemetry instrumentation plugin for the AWS Lambda Durable Execution SDK fo
 ```xml
 <dependency>
     <groupId>software.amazon.lambda.durable</groupId>
-    <artifactId>aws-durable-execution-sdk-java-otel</artifactId>
+    <artifactId>aws-durable-execution-sdk-java-plugin-otel</artifactId>
     <version>0.1.0</version>
 </dependency>
 ```

--- a/otel-plugin/pom.xml
+++ b/otel-plugin/pom.xml
@@ -10,7 +10,7 @@
         <version>1.2.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>aws-durable-execution-sdk-java-otel</artifactId>
+    <artifactId>aws-durable-execution-sdk-java-plugin-otel</artifactId>
     <name>AWS Lambda Durable Execution SDK OpenTelemetry Plugin</name>
     <description>OpenTelemetry instrumentation plugin for AWS Lambda Durable Execution SDK</description>
 

--- a/sdk-integration-tests/pom.xml
+++ b/sdk-integration-tests/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.lambda.durable</groupId>
-            <artifactId>aws-durable-execution-sdk-java-otel</artifactId>
+            <artifactId>aws-durable-execution-sdk-java-plugin-otel</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
N/A

### Description

Renames the OpenTelemetry plugin Maven artifact from `aws-durable-execution-sdk-java-otel` to `aws-durable-execution-sdk-java-plugin-otel`.


### Demo/Screenshots
N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
