### PR TITLE
refactor(otel): Rename OpenTelemetryDurablePlugin to OtelPlugin

### DIFF
--- a/examples/src/main/java/software/amazon/lambda/durable/examples/general/OtelExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/general/OtelExample.java
@@ -9,7 +9,7 @@ import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.examples.types.GreetingRequest;
-import software.amazon.lambda.durable.otel.OpenTelemetryDurablePlugin;
+import software.amazon.lambda.durable.otel.OtelPlugin;
 
 /**
  * Example demonstrating OpenTelemetry instrumentation with the Durable Execution SDK.
@@ -39,7 +39,7 @@ public class OtelExample extends DurableHandler<GreetingRequest, String> {
 
     @Override
     protected DurableConfig createConfiguration() {
-        var otelPlugin = new OpenTelemetryDurablePlugin(
+        var otelPlugin = new OtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create())));
 
         return DurableConfig.builder().withPlugins(otelPlugin).build();

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayMapExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayMapExample.java
@@ -10,7 +10,7 @@ import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.examples.types.GreetingRequest;
-import software.amazon.lambda.durable.otel.OpenTelemetryDurablePlugin;
+import software.amazon.lambda.durable.otel.OtelPlugin;
 
 /**
  * OTel + X-Ray example: map operation that processes items concurrently.
@@ -22,8 +22,8 @@ public class OtelXRayMapExample extends DurableHandler<GreetingRequest, String> 
     @Override
     protected DurableConfig createConfiguration() {
         var otlpExporter = OtlpGrpcSpanExporter.getDefault();
-        var otelPlugin = new OpenTelemetryDurablePlugin(
-                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
+        var otelPlugin =
+                new OtelPlugin(SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
         return DurableConfig.builder().withPlugins(otelPlugin).build();
     }
 

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayNestedContextExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayNestedContextExample.java
@@ -9,7 +9,7 @@ import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.examples.types.GreetingRequest;
-import software.amazon.lambda.durable.otel.OpenTelemetryDurablePlugin;
+import software.amazon.lambda.durable.otel.OtelPlugin;
 
 /**
  * OTel + X-Ray example: nested child contexts with inner steps.
@@ -21,8 +21,8 @@ public class OtelXRayNestedContextExample extends DurableHandler<GreetingRequest
     @Override
     protected DurableConfig createConfiguration() {
         var otlpExporter = OtlpGrpcSpanExporter.getDefault();
-        var otelPlugin = new OpenTelemetryDurablePlugin(
-                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
+        var otelPlugin =
+                new OtelPlugin(SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
         return DurableConfig.builder().withPlugins(otelPlugin).build();
     }
 

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayParallelExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayParallelExample.java
@@ -9,7 +9,7 @@ import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.examples.types.GreetingRequest;
-import software.amazon.lambda.durable.otel.OpenTelemetryDurablePlugin;
+import software.amazon.lambda.durable.otel.OtelPlugin;
 
 /**
  * OTel + X-Ray example: parallel operation with multiple branches.
@@ -21,8 +21,8 @@ public class OtelXRayParallelExample extends DurableHandler<GreetingRequest, Str
     @Override
     protected DurableConfig createConfiguration() {
         var otlpExporter = OtlpGrpcSpanExporter.getDefault();
-        var otelPlugin = new OpenTelemetryDurablePlugin(
-                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
+        var otelPlugin =
+                new OtelPlugin(SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
         return DurableConfig.builder().withPlugins(otelPlugin).build();
     }
 

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayStepExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayStepExample.java
@@ -9,7 +9,7 @@ import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.examples.types.GreetingRequest;
-import software.amazon.lambda.durable.otel.OpenTelemetryDurablePlugin;
+import software.amazon.lambda.durable.otel.OtelPlugin;
 
 /**
  * OTel + X-Ray example: simple steps in a single invocation.
@@ -39,8 +39,8 @@ public class OtelXRayStepExample extends DurableHandler<GreetingRequest, String>
         // OTLP exporter sends spans to the ADOT collector (localhost:4317 by default)
         var otlpExporter = OtlpGrpcSpanExporter.getDefault();
 
-        var otelPlugin = new OpenTelemetryDurablePlugin(
-                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
+        var otelPlugin =
+                new OtelPlugin(SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
 
         return DurableConfig.builder().withPlugins(otelPlugin).build();
     }

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayWaitExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayWaitExample.java
@@ -10,7 +10,7 @@ import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.examples.types.GreetingRequest;
-import software.amazon.lambda.durable.otel.OpenTelemetryDurablePlugin;
+import software.amazon.lambda.durable.otel.OtelPlugin;
 
 /**
  * OTel + X-Ray example: step → wait → step pattern that forces multiple Lambda invocations.
@@ -51,8 +51,8 @@ public class OtelXRayWaitExample extends DurableHandler<GreetingRequest, String>
         // OTLP exporter sends spans to the ADOT collector (localhost:4317 by default)
         var otlpExporter = OtlpGrpcSpanExporter.getDefault();
 
-        var otelPlugin = new OpenTelemetryDurablePlugin(
-                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
+        var otelPlugin =
+                new OtelPlugin(SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
 
         return DurableConfig.builder().withPlugins(otelPlugin).build();
     }

--- a/otel-plugin/README.md
+++ b/otel-plugin/README.md
@@ -41,7 +41,7 @@ You also need the OpenTelemetry SDK and an exporter:
 
 1. Add the ADOT Lambda Layer to your function and set `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler`
 2. Enable X-Ray Active Tracing on the function
-3. Register `OpenTelemetryDurablePlugin` in your handler's `DurableConfig`
+3. Register `OtelPlugin` in your handler's `DurableConfig`
 4. Grant X-Ray write permissions
 
 ### 1. ADOT Lambda Layer
@@ -144,7 +144,7 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
-import software.amazon.lambda.durable.otel.OpenTelemetryDurablePlugin;
+import software.amazon.lambda.durable.otel.OtelPlugin;
 
 public class MyHandler extends DurableHandler<MyInput, MyOutput> {
 
@@ -153,7 +153,7 @@ public class MyHandler extends DurableHandler<MyInput, MyOutput> {
         // OTLP exporter sends spans to the ADOT collector (localhost:4317 by default)
         var otlpExporter = OtlpGrpcSpanExporter.getDefault();
 
-        var otelPlugin = new OpenTelemetryDurablePlugin(
+        var otelPlugin = new OtelPlugin(
                 SdkTracerProvider.builder()
                         .addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
 
@@ -207,13 +207,13 @@ durable.invocation
 
 ```java
 // Default: X-Ray context extraction, MDC enabled
-new OpenTelemetryDurablePlugin(tracerProviderBuilder);
+new OtelPlugin(tracerProviderBuilder);
 
 // Custom context extractor, MDC enabled
-new OpenTelemetryDurablePlugin(tracerProviderBuilder, contextExtractor);
+new OtelPlugin(tracerProviderBuilder, contextExtractor);
 
 // Full configuration
-new OpenTelemetryDurablePlugin(tracerProviderBuilder, contextExtractor, enableMdc);
+new OtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc);
 ```
 
 | Parameter | Description | Default |
@@ -262,21 +262,21 @@ For local testing, use a logging exporter to print spans to stdout:
 ```java
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 
-var otelPlugin = new OpenTelemetryDurablePlugin(
+var otelPlugin = new OtelPlugin(
         SdkTracerProvider.builder()
                 .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create())));
 ```
 
 ## API Reference
 
-### `OpenTelemetryDurablePlugin`
+### `OtelPlugin`
 
 The main plugin class. Implements `DurableExecutionPlugin` from the core SDK.
 
 ```java
-new OpenTelemetryDurablePlugin(SdkTracerProviderBuilder tracerProviderBuilder)
-new OpenTelemetryDurablePlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor)
-new OpenTelemetryDurablePlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor, boolean enableMdc)
+new OtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder)
+new OtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor)
+new OtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor, boolean enableMdc)
 ```
 
 ### `XRayContextExtractor`

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
@@ -20,8 +20,8 @@ import org.slf4j.MDC;
  * </ul>
  *
  * <p>Usage: Call {@link #inject()} in {@code onUserFunctionStart} (after span is active) and {@link #clear()} in
- * {@code onUserFunctionEnd}. Or use the convenience plugin {@link OpenTelemetryDurablePlugin} which handles this
- * automatically when MDC enrichment is enabled.
+ * {@code onUserFunctionEnd}. Or use the convenience plugin {@link OtelPlugin} which handles this automatically when MDC
+ * enrichment is enabled.
  *
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPlugin.java
@@ -63,9 +63,9 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
 @Deprecated
-public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
+public class OtelPlugin implements DurableExecutionPlugin {
 
-    private static final Logger logger = LoggerFactory.getLogger(OpenTelemetryDurablePlugin.class);
+    private static final Logger logger = LoggerFactory.getLogger(OtelPlugin.class);
     private static final String INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
 
     private final SdkTracerProvider tracerProvider;
@@ -98,13 +98,13 @@ public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
      *
      * <pre>{@code
      * var otlpExporter = OtlpGrpcSpanExporter.getDefault(); // sends to localhost:4317
-     * var plugin = new OpenTelemetryDurablePlugin(
+     * var plugin = new OtelPlugin(
      *     SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
      * }</pre>
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      */
-    public OpenTelemetryDurablePlugin(SdkTracerProviderBuilder tracerProviderBuilder) {
+    public OtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder) {
         this(tracerProviderBuilder, new XRayContextExtractor(), true);
     }
 
@@ -114,8 +114,7 @@ public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
      */
-    public OpenTelemetryDurablePlugin(
-            SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor) {
+    public OtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor) {
         this(tracerProviderBuilder, contextExtractor, true);
     }
 
@@ -126,7 +125,7 @@ public class OpenTelemetryDurablePlugin implements DurableExecutionPlugin {
      * @param contextExtractor extracts parent trace context from the Lambda environment
      * @param enableMdc if true, injects trace_id/span_id into SLF4J MDC for log correlation
      */
-    public OpenTelemetryDurablePlugin(
+    public OtelPlugin(
             SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor, boolean enableMdc) {
         this.idGenerator = new DeterministicIdGenerator();
         this.tracerProvider = tracerProviderBuilder.setIdGenerator(idGenerator).build();

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
@@ -55,7 +55,7 @@ class MdcSpanEnricherTest {
         // Test MDC through the full plugin lifecycle (where makeCurrent is called on same thread)
         var spanExporter = InMemorySpanExporter.create();
 
-        var plugin = new OpenTelemetryDurablePlugin(
+        var plugin = new OtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> null,
                 true);

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OtelPluginTest.java
@@ -14,16 +14,16 @@ import org.junit.jupiter.api.Test;
 import software.amazon.lambda.durable.execution.SuspendExecutionException;
 import software.amazon.lambda.durable.plugin.*;
 
-class OpenTelemetryDurablePluginTest {
+class OtelPluginTest {
 
     private InMemorySpanExporter spanExporter;
-    private OpenTelemetryDurablePlugin plugin;
+    private OtelPlugin plugin;
 
     @BeforeEach
     void setUp() {
         spanExporter = InMemorySpanExporter.create();
 
-        plugin = new OpenTelemetryDurablePlugin(
+        plugin = new OtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> null,
                 false);
@@ -213,7 +213,7 @@ class OpenTelemetryDurablePluginTest {
     @Test
     void sampling_disabled_producesNoSpans() {
         spanExporter = InMemorySpanExporter.create();
-        var sampledPlugin = new OpenTelemetryDurablePlugin(
+        var sampledPlugin = new OtelPlugin(
                 SdkTracerProvider.builder()
                         .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOff())
                         .addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
@@ -241,7 +241,7 @@ class OpenTelemetryDurablePluginTest {
         var extractedContext = new ExtractedContext(xrayTraceId, null);
 
         spanExporter = InMemorySpanExporter.create();
-        var xrayPlugin = new OpenTelemetryDurablePlugin(
+        var xrayPlugin = new OtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> extractedContext,
                 false);
@@ -260,7 +260,7 @@ class OpenTelemetryDurablePluginTest {
         var extractedContext = new ExtractedContext(xrayTraceId, null);
 
         spanExporter = InMemorySpanExporter.create();
-        var xrayPlugin = new OpenTelemetryDurablePlugin(
+        var xrayPlugin = new OtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> extractedContext,
                 false);
@@ -289,7 +289,7 @@ class OpenTelemetryDurablePluginTest {
         var extractedContext = new ExtractedContext(xrayTraceId, parentSpanId);
 
         spanExporter = InMemorySpanExporter.create();
-        var xrayPlugin = new OpenTelemetryDurablePlugin(
+        var xrayPlugin = new OtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> extractedContext,
                 false);
@@ -314,7 +314,7 @@ class OpenTelemetryDurablePluginTest {
         var extractedContext = new ExtractedContext(xrayTraceId, null);
 
         spanExporter = InMemorySpanExporter.create();
-        var xrayPlugin = new OpenTelemetryDurablePlugin(
+        var xrayPlugin = new OtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> extractedContext,
                 false);
@@ -344,7 +344,7 @@ class OpenTelemetryDurablePluginTest {
         var extractedContext = new ExtractedContext(xrayTraceId, "53995c3f42cd8ad8");
 
         spanExporter = InMemorySpanExporter.create();
-        var xrayPlugin = new OpenTelemetryDurablePlugin(
+        var xrayPlugin = new OtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> extractedContext,
                 false);
@@ -376,7 +376,7 @@ class OpenTelemetryDurablePluginTest {
     @Test
     void xrayExtraction_nullExtractor_fallsBackToArnDerived() {
         spanExporter = InMemorySpanExporter.create();
-        var noXrayPlugin = new OpenTelemetryDurablePlugin(
+        var noXrayPlugin = new OtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> null,
                 false);
@@ -407,7 +407,7 @@ class OpenTelemetryDurablePluginTest {
         // Now feed it through the plugin
         var extractedContext = new ExtractedContext(convertedId, null);
         spanExporter = InMemorySpanExporter.create();
-        var xrayPlugin = new OpenTelemetryDurablePlugin(
+        var xrayPlugin = new OtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> extractedContext,
                 false);

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/OtelPluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/OtelPluginIntegrationTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.lambda.durable.config.StepConfig;
 import software.amazon.lambda.durable.model.ExecutionStatus;
 import software.amazon.lambda.durable.model.WaitForConditionResult;
-import software.amazon.lambda.durable.otel.OpenTelemetryDurablePlugin;
+import software.amazon.lambda.durable.otel.OtelPlugin;
 import software.amazon.lambda.durable.retry.RetryStrategies;
 import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
 
@@ -33,7 +33,7 @@ class OtelPluginIntegrationTest {
     void setUp() {
         spanExporter = InMemorySpanExporter.create();
 
-        var plugin = new OpenTelemetryDurablePlugin(
+        var plugin = new OtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> null,
                 false);
@@ -306,7 +306,7 @@ class OtelPluginIntegrationTest {
     void sampling_off_producesNoSpans() {
         var sampledExporter = InMemorySpanExporter.create();
 
-        var noSamplePlugin = new OpenTelemetryDurablePlugin(
+        var noSamplePlugin = new OtelPlugin(
                 SdkTracerProvider.builder()
                         .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOff())
                         .addSpanProcessor(SimpleSpanProcessor.create(sampledExporter)),


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
N/A

### Description
Renames `OpenTelemetryDurablePlugin` to `OtelPlugin` to align with the shorter naming convention adopted across all durable execution SDKs (JS, Python, Java).


### Demo/Screenshots
N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
