### PR TITLE
doc: add Java SDK FAQ link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ See [Deploy Lambda durable functions with Infrastructure as Code](https://docs.a
 
 - [<u>AWS Documentation</u>](https://docs.aws.amazon.com/lambda/latest/dg/durable-functions.html) – Official AWS Lambda durable functions guide
 - [<u>Best Practices</u>](https://docs.aws.amazon.com/lambda/latest/dg/durable-best-practices.html) – Patterns and recommendations
+- [<u>FAQ</u>](https://docs.aws.amazon.com/durable-execution/sdk-reference/languages/java/) - Frequently asked questions for the Java SDK
 - [<u>Javadoc</u>](https://aws.github.io/aws-durable-execution-sdk-java/javadoc/) - API reference for the Java SDK
 - [<u>SDK Design</u>](docs/design.md) – Details of SDK internal architecture
 


### PR DESCRIPTION
## Summary
- Add the Java SDK FAQ link to the README Documentation section

Fixes: https://github.com/aws/aws-durable-execution-sdk-java/issues/472

## Testing
- Not run; documentation-only change
