### PR TITLE
fix(otel): Fix X-Ray trace integration and cross-invocation retry spans

### DIFF
--- a/examples/src/test/java/software/amazon/lambda/durable/examples/OtelXRayIntegrationTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/OtelXRayIntegrationTest.java
@@ -144,14 +144,13 @@ class OtelXRayIntegrationTest {
 
         // Find the trace that contains our durable spans
         var durableTrace = allTraces.stream()
-                .filter(trace ->
-                        trace.segments().stream().anyMatch(seg -> segmentContains(seg, "durable.step:create-greeting")))
+                .filter(trace -> trace.segments().stream().anyMatch(seg -> segmentContains(seg, "create-greeting")))
                 .findFirst()
                 .orElse(null);
 
         assertNotNull(
                 durableTrace,
-                "Expected to find a trace with durable.step:create-greeting segment. " + "Found " + traces.size()
+                "Expected to find a trace with create-greeting segment. " + "Found " + traces.size()
                         + " traces in the time window. Segment names: "
                         + allTraces.stream()
                                 .flatMap(t -> t.segments().stream())
@@ -165,12 +164,10 @@ class OtelXRayIntegrationTest {
 
         // Verify expected span names appear in the trace
         assertTrue(
-                allSegmentText.contains("durable.invocation"),
-                "Expected durable.invocation span in trace. Segments: " + summarizeSegments(segmentDocuments));
-        assertTrue(
-                allSegmentText.contains("durable.step:create-greeting"),
-                "Expected durable.step:create-greeting span in trace");
-        assertTrue(allSegmentText.contains("durable.step:transform"), "Expected durable.step:transform span in trace");
+                allSegmentText.contains("invocation"),
+                "Expected invocation span in trace. Segments: " + summarizeSegments(segmentDocuments));
+        assertTrue(allSegmentText.contains("create-greeting"), "Expected create-greeting span in trace");
+        assertTrue(allSegmentText.contains("transform"), "Expected transform span in trace");
 
         // Verify all segments share the same trace ID (single unified trace)
         var uniqueTraceIds =
@@ -218,14 +215,13 @@ class OtelXRayIntegrationTest {
 
         // Find the trace containing our durable spans
         var durableTrace = allTraces.stream()
-                .filter(trace ->
-                        trace.segments().stream().anyMatch(seg -> segmentContains(seg, "durable.step:before-wait")))
+                .filter(trace -> trace.segments().stream().anyMatch(seg -> segmentContains(seg, "before-wait")))
                 .findFirst()
                 .orElse(null);
 
         assertNotNull(
                 durableTrace,
-                "Expected to find a trace with durable.step:before-wait segment. " + "Found " + traces.size()
+                "Expected to find a trace with before-wait segment. " + "Found " + traces.size()
                         + " traces in the time window.");
 
         // 4. Verify multi-invocation trace structure
@@ -234,14 +230,12 @@ class OtelXRayIntegrationTest {
         var allSegmentText = String.join("\n", segmentDocuments);
 
         // Verify spans from BOTH invocations appear in the same trace
-        assertTrue(
-                allSegmentText.contains("durable.step:before-wait"), "Expected before-wait span from first invocation");
-        assertTrue(
-                allSegmentText.contains("durable.step:after-wait"), "Expected after-wait span from second invocation");
-        assertTrue(allSegmentText.contains("durable.wait:pause"), "Expected wait:pause span in trace");
+        assertTrue(allSegmentText.contains("before-wait"), "Expected before-wait span from first invocation");
+        assertTrue(allSegmentText.contains("after-wait"), "Expected after-wait span from second invocation");
+        assertTrue(allSegmentText.contains("pause"), "Expected wait:pause span in trace");
 
         // Verify multiple invocation spans (one per Lambda invocation)
-        var invocationCount = countOccurrences(allSegmentText, "durable.invocation");
+        var invocationCount = countOccurrences(allSegmentText, "invocation");
         assertTrue(
                 invocationCount >= 2,
                 "Expected at least 2 invocation spans (multi-invocation), got " + invocationCount);
@@ -264,7 +258,9 @@ class OtelXRayIntegrationTest {
             throws InterruptedException {
         // Query by durable.invocation service — our spans are in a separate trace from Lambda's
         // built-in X-Ray segment (durable backend propagates its own trace root)
-        var filterExpression = "service(\"durable.invocation\")";
+        // Filter by the Lambda function's service name — each function has a unique one.
+        // This avoids picking up traces from other durable functions that share service.name="invocation".
+        var filterExpression = "service(\"" + functionName + functionNameSuffix + "\")";
         for (int attempt = 0; attempt < XRAY_QUERY_RETRIES; attempt++) {
             var response = xrayClient.getTraceSummaries(GetTraceSummariesRequest.builder()
                     .startTime(startTime)

--- a/examples/template.yaml
+++ b/examples/template.yaml
@@ -370,9 +370,6 @@ Resources:
         - !Sub
           - arn:aws:lambda:${AWS::Region}:901920570463:layer:aws-otel-java-agent-${AdotArch}-ver-1-32-0:6
           - AdotArch: amd64
-      Environment:
-        Variables:
-          AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
 
   OtelXRayWaitExampleFunction:
     Type: AWS::Serverless::Function
@@ -389,9 +386,6 @@ Resources:
         - !Sub
           - arn:aws:lambda:${AWS::Region}:901920570463:layer:aws-otel-java-agent-${AdotArch}-ver-1-32-0:6
           - AdotArch: amd64
-      Environment:
-        Variables:
-          AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
 
   RetryInvokeExampleFunction:
     Type: AWS::Serverless::Function

--- a/otel-plugin/pom.xml
+++ b/otel-plugin/pom.xml
@@ -48,6 +48,13 @@
             <version>${opentelemetry.version}</version>
         </dependency>
 
+        <!-- OpenTelemetry Semantic Conventions (for ServiceAttributes.SERVICE_NAME) -->
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>1.32.0</version>
+        </dependency>
+
         <!-- SLF4J for logging -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPlugin.java
@@ -5,16 +5,20 @@ package software.amazon.lambda.durable.otel;
 import static software.amazon.lambda.durable.otel.SpanAttributes.*;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.semconv.ServiceAttributes;
 import java.time.Instant;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
@@ -128,6 +132,12 @@ public class OtelPlugin implements DurableExecutionPlugin {
     public OtelPlugin(
             SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor, boolean enableMdc) {
         this.idGenerator = new DeterministicIdGenerator();
+
+        // Set service.name to "invocation" — X-Ray uses this as the display name for SERVER spans,
+        // creating a separate service node in the trace map labeled "invocation".
+        var resource = Resource.create(Attributes.of(ServiceAttributes.SERVICE_NAME, "invocation"));
+        tracerProviderBuilder.addResource(resource);
+
         this.tracerProvider = tracerProviderBuilder.setIdGenerator(idGenerator).build();
         this.tracer = tracerProvider.get(INSTRUMENTATION_NAME);
         this.contextExtractor = contextExtractor;
@@ -152,10 +162,11 @@ public class OtelPlugin implements DurableExecutionPlugin {
         }
         // If no extracted context, idGenerator falls back to ARN-derived trace ID
 
-        // Determine parent context for the invocation span
+        // Determine parent context for the invocation span.
         Context parentContext;
         if (extractedContext != null && extractedContext.parentSpanId() != null) {
-            // Create a remote parent span context from the X-Ray Parent field
+            // X-Ray header has parent — create the invocation span as a child of that segment.
+            // This connects our OTLP-exported spans to the Lambda service's X-Ray segments.
             var parentSpanContext = SpanContext.createFromRemoteParent(
                     extractedContext.traceId(),
                     extractedContext.parentSpanId(),
@@ -166,8 +177,10 @@ public class OtelPlugin implements DurableExecutionPlugin {
             parentContext = Context.root();
         }
 
-        // Create invocation span as child of Lambda's X-Ray segment (via Parent field)
-        var spanBuilder = tracer.spanBuilder("durable.invocation")
+        // Create a SERVER span to establish a separate X-Ray service node.
+        // X-Ray uses service.name for the segment display name.
+        var spanBuilder = tracer.spanBuilder("invocation")
+                .setSpanKind(SpanKind.SERVER)
                 .setParent(parentContext)
                 .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())
                 .setAttribute(DURABLE_FIRST_INVOCATION, info.isFirstInvocation());
@@ -227,8 +240,6 @@ public class OtelPlugin implements DurableExecutionPlugin {
     public void onOperationStart(OperationInfo info) {
         if (info.id() == null) return;
 
-        idGenerator.setNextSpanOperationId(info.id());
-
         var parentContext = resolveParentContext(info.parentId());
 
         var spanBuilder = tracer.spanBuilder(spanName(info.type(), info.subType(), info.name()))
@@ -236,6 +247,19 @@ public class OtelPlugin implements DurableExecutionPlugin {
                 .setAttribute(DURABLE_EXECUTION_ARN, durableExecutionArn)
                 .setAttribute(DURABLE_OPERATION_ID, info.id())
                 .setAttribute(DURABLE_OPERATION_TYPE, info.type());
+
+        if (info.isReplay()) {
+            // Operation was already started in a prior invocation — use a random span ID
+            // and add a Link to the deterministic span from the original invocation for correlation.
+            var deterministicSpanId = idGenerator.generateSpanIdForOperation(info.id());
+            var traceId = idGenerator.generateTraceId();
+            var linkedSpanContext =
+                    SpanContext.create(traceId, deterministicSpanId, TraceFlags.getSampled(), TraceState.getDefault());
+            spanBuilder.addLink(linkedSpanContext);
+        } else {
+            // First execution — use deterministic span ID so continuations can link back
+            idGenerator.setNextSpanOperationId(info.id());
+        }
 
         if (info.name() != null) {
             spanBuilder.setAttribute(DURABLE_OPERATION_NAME, info.name());
@@ -400,17 +424,17 @@ public class OtelPlugin implements DurableExecutionPlugin {
 
     private static String spanName(String type, String subType, String name) {
         if (name != null) {
-            return "durable." + (subType != null ? subType.toLowerCase() : type.toLowerCase()) + ":" + name;
+            return name;
         }
-        return "durable." + (subType != null ? subType.toLowerCase() : type.toLowerCase());
+        return subType != null ? subType.toLowerCase() : type.toLowerCase();
     }
 
     private static String attemptSpanName(String type, String subType, String name, Integer attempt) {
         var base = spanName(type, subType, name);
         if (attempt != null) {
-            return base + " [attempt " + attempt + "]";
+            return base + " attempt " + attempt;
         }
-        return base + " [fn]";
+        return base;
     }
 
     private static String attemptKey(String operationId, Integer attempt) {

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/XRayContextExtractor.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/XRayContextExtractor.java
@@ -25,14 +25,21 @@ public class XRayContextExtractor implements ContextExtractor {
 
     private static final Logger logger = LoggerFactory.getLogger(XRayContextExtractor.class);
     private static final String XRAY_ENV_VAR = "_X_AMZN_TRACE_ID";
+    private static final String XRAY_SYSTEM_PROPERTY = "com.amazonaws.xray.traceHeader";
     private static final Pattern HEX_32 = Pattern.compile("[0-9a-f]{32}");
     private static final Pattern HEX_16 = Pattern.compile("[0-9a-f]{16}");
 
     @Override
     public ExtractedContext extract() {
-        var traceHeader = System.getenv(XRAY_ENV_VAR);
+        // Try system property first — Lambda runtime updates this per invocation
+        // and it avoids JVM environment variable caching issues.
+        var traceHeader = System.getProperty(XRAY_SYSTEM_PROPERTY);
         if (traceHeader == null || traceHeader.isEmpty()) {
-            logger.debug("No X-Ray trace header found in environment");
+            // Fallback to environment variable
+            traceHeader = System.getenv(XRAY_ENV_VAR);
+        }
+        if (traceHeader == null || traceHeader.isEmpty()) {
+            logger.debug("No X-Ray trace header found in environment or system properties");
             return null;
         }
 

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OtelPluginTest.java
@@ -4,6 +4,7 @@ package software.amazon.lambda.durable.otel;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -44,8 +45,67 @@ class OtelPluginTest {
         assertEquals(1, spans.size());
 
         var span = spans.get(0);
-        assertEquals("durable.invocation", span.getName());
+        assertEquals("invocation", span.getName());
         assertEquals(StatusCode.UNSET, span.getStatus().getStatusCode());
+    }
+
+    @Test
+    void invocationSpan_hasServerKind_forSeparateXRayNode() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var span = spanExporter.getFinishedSpanItems().get(0);
+        assertEquals(
+                SpanKind.SERVER,
+                span.getKind(),
+                "Invocation span must be SERVER kind so X-Ray creates a separate service node");
+    }
+
+    @Test
+    void operationSpanName_usesOperationName_withoutPrefix() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onOperationStart(
+                new OperationInfo("op-1", "create-greeting", "STEP", "Step", null, Instant.now(), null, false));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1",
+                "create-greeting",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                false,
+                null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var operationSpan = spanExporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().equals("create-greeting"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(
+                "create-greeting",
+                operationSpan.getName(),
+                "Operation span should use the operation name directly without 'durable.' prefix");
+    }
+
+    @Test
+    void attemptSpanName_usesOperationNameWithAttemptNumber() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onUserFunctionStart(
+                new UserFunctionStartInfo("op-1", "process-order", "STEP", "Step", null, Instant.now(), false, 1));
+        plugin.onUserFunctionEnd(new UserFunctionEndInfo(
+                "op-1", "process-order", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var attemptSpan = spanExporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().contains("attempt"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(
+                "process-order attempt 1",
+                attemptSpan.getName(),
+                "Attempt span should be 'name attempt N' without brackets or prefix");
     }
 
     @Test
@@ -67,10 +127,11 @@ class OtelPluginTest {
         var end = Instant.parse("2026-06-01T10:00:05Z");
 
         // Operation span created at start
-        plugin.onOperationStart(new OperationInfo("op-hash-1", "my-step", "STEP", "Step", null, start, null));
+        plugin.onOperationStart(new OperationInfo("op-hash-1", "my-step", "STEP", "Step", null, start, null, false));
 
         // Operation span ended at completion
-        plugin.onOperationEnd(new OperationEndInfo("op-hash-1", "my-step", "STEP", "Step", null, start, end, null));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-hash-1", "my-step", "STEP", "Step", null, start, end, "SUCCEEDED", false, null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -81,7 +142,7 @@ class OtelPluginTest {
                 .filter(s -> s.getName().contains("step"))
                 .findFirst()
                 .orElseThrow();
-        assertEquals("durable.step:my-step", operationSpan.getName());
+        assertEquals("my-step", operationSpan.getName());
     }
 
     @Test
@@ -142,22 +203,22 @@ class OtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", arn, true));
 
         // Step 1: operation starts, user function runs, operation completes
-        plugin.onOperationStart(new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null));
+        plugin.onOperationStart(new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
-        plugin.onOperationEnd(
-                new OperationEndInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), null));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
 
         // Step 2: operation starts, user function runs, operation completes
-        plugin.onOperationStart(new OperationInfo("op-2", "step-b", "STEP", "Step", null, Instant.now(), null));
+        plugin.onOperationStart(new OperationInfo("op-2", "step-b", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-2", "step-b", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-2", "step-b", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
-        plugin.onOperationEnd(
-                new OperationEndInfo("op-2", "step-b", "STEP", "Step", null, Instant.now(), Instant.now(), null));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-2", "step-b", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.SUCCEEDED, null));
 
@@ -194,7 +255,7 @@ class OtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
 
         // Operation starts but never completes (e.g., wait operation, invocation suspends)
-        plugin.onOperationStart(new OperationInfo("op-1", "my-wait", "WAIT", "Wait", null, Instant.now(), null));
+        plugin.onOperationStart(new OperationInfo("op-1", "my-wait", "WAIT", "Wait", null, Instant.now(), null, false));
 
         // Invocation ends without onOperationEnd being called
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.PENDING, null));
@@ -207,7 +268,7 @@ class OtelPluginTest {
                 .filter(s -> s.getName().contains("wait"))
                 .findFirst()
                 .orElseThrow();
-        assertEquals("durable.wait:my-wait", operationSpan.getName());
+        assertEquals("my-wait", operationSpan.getName());
     }
 
     @Test
@@ -225,8 +286,8 @@ class OtelPluginTest {
                 new UserFunctionStartInfo("op-1", "step", "STEP", "Step", null, Instant.now(), false, 1));
         sampledPlugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
-        sampledPlugin.onOperationEnd(
-                new OperationEndInfo("op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), null));
+        sampledPlugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
         sampledPlugin.onInvocationEnd(
                 new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -266,13 +327,14 @@ class OtelPluginTest {
                 false);
 
         xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
-        xrayPlugin.onOperationStart(new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null));
+        xrayPlugin.onOperationStart(
+                new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));
         xrayPlugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), false, 1));
         xrayPlugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
-        xrayPlugin.onOperationEnd(
-                new OperationEndInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), null));
+        xrayPlugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -351,16 +413,18 @@ class OtelPluginTest {
 
         // First invocation
         xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
-        xrayPlugin.onOperationStart(new OperationInfo("op-1", "step-1", "STEP", "Step", null, Instant.now(), null));
-        xrayPlugin.onOperationEnd(
-                new OperationEndInfo("op-1", "step-1", "STEP", "Step", null, Instant.now(), Instant.now(), null));
+        xrayPlugin.onOperationStart(
+                new OperationInfo("op-1", "step-1", "STEP", "Step", null, Instant.now(), null, false));
+        xrayPlugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "step-1", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.PENDING, null));
 
         // Second invocation (same execution, same X-Ray Root from backend)
         xrayPlugin.onInvocationStart(new InvocationInfo("req-2", "arn:exec1", false));
-        xrayPlugin.onOperationStart(new OperationInfo("op-2", "step-2", "STEP", "Step", null, Instant.now(), null));
-        xrayPlugin.onOperationEnd(
-                new OperationEndInfo("op-2", "step-2", "STEP", "Step", null, Instant.now(), Instant.now(), null));
+        xrayPlugin.onOperationStart(
+                new OperationInfo("op-2", "step-2", "STEP", "Step", null, Instant.now(), null, false));
+        xrayPlugin.onOperationEnd(new OperationEndInfo(
+                "op-2", "step-2", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
         xrayPlugin.onInvocationEnd(
                 new InvocationEndInfo("req-2", "arn:exec1", false, InvocationStatus.SUCCEEDED, null));
 
@@ -426,8 +490,8 @@ class OtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
 
         // onOperationEnd without a prior onOperationStart — operation completed between invocations
-        plugin.onOperationEnd(
-                new OperationEndInfo("op-wait-1", "my-wait", "WAIT", "Wait", null, Instant.now(), Instant.now(), null));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-wait-1", "my-wait", "WAIT", "Wait", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -438,7 +502,7 @@ class OtelPluginTest {
                 .filter(s -> s.getName().contains("wait"))
                 .findFirst()
                 .orElseThrow();
-        assertEquals("durable.wait:my-wait", continuationSpan.getName());
+        assertEquals("my-wait", continuationSpan.getName());
         assertFalse(continuationSpan.getLinks().isEmpty(), "Continuation span should have a Link");
     }
 
@@ -454,6 +518,8 @@ class OtelPluginTest {
                 null,
                 Instant.now(),
                 Instant.now(),
+                "FAILED",
+                false,
                 new RuntimeException("timed out")));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
@@ -527,16 +593,34 @@ class OtelPluginTest {
 
         // Parent context operation
         plugin.onOperationStart(new OperationInfo(
-                "op-parent", "my-context", "CONTEXT", "RunInChildContext", null, Instant.now(), null));
+                "op-parent", "my-context", "CONTEXT", "RunInChildContext", null, Instant.now(), null, false));
 
         // Child operation with parentId pointing to parent
         plugin.onOperationStart(
-                new OperationInfo("op-child", "inner-step", "STEP", "Step", "op-parent", Instant.now(), null));
+                new OperationInfo("op-child", "inner-step", "STEP", "Step", "op-parent", Instant.now(), null, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-child", "inner-step", "STEP", "Step", "op-parent", Instant.now(), Instant.now(), null));
+                "op-child",
+                "inner-step",
+                "STEP",
+                "Step",
+                "op-parent",
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                false,
+                null));
 
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-parent", "my-context", "CONTEXT", "RunInChildContext", null, Instant.now(), Instant.now(), null));
+                "op-parent",
+                "my-context",
+                "CONTEXT",
+                "RunInChildContext",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                false,
+                null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -565,14 +649,14 @@ class OtelPluginTest {
 
         // Invocation 1: step completes, wait starts
         plugin.onInvocationStart(new InvocationInfo("req-1", arn, true));
-        plugin.onOperationStart(new OperationInfo("op-1", "step-A", "STEP", "Step", null, Instant.now(), null));
+        plugin.onOperationStart(new OperationInfo("op-1", "step-A", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "step-A", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step-A", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
-        plugin.onOperationEnd(
-                new OperationEndInfo("op-1", "step-A", "STEP", "Step", null, Instant.now(), Instant.now(), null));
-        plugin.onOperationStart(new OperationInfo("op-2", "pause", "WAIT", "Wait", null, Instant.now(), null));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "step-A", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+        plugin.onOperationStart(new OperationInfo("op-2", "pause", "WAIT", "Wait", null, Instant.now(), null, false));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.PENDING, null));
 
         // Invocation 1 should have: step op + step attempt + wait (PENDING) + invocation = 4
@@ -583,15 +667,15 @@ class OtelPluginTest {
 
         // Invocation 2: wait completed between invocations, new step runs
         plugin.onInvocationStart(new InvocationInfo("req-2", arn, false));
-        plugin.onOperationEnd(
-                new OperationEndInfo("op-2", "pause", "WAIT", "Wait", null, Instant.now(), Instant.now(), null));
-        plugin.onOperationStart(new OperationInfo("op-3", "step-B", "STEP", "Step", null, Instant.now(), null));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-2", "pause", "WAIT", "Wait", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+        plugin.onOperationStart(new OperationInfo("op-3", "step-B", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-3", "step-B", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-3", "step-B", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
-        plugin.onOperationEnd(
-                new OperationEndInfo("op-3", "step-B", "STEP", "Step", null, Instant.now(), Instant.now(), null));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-3", "step-B", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", arn, false, InvocationStatus.SUCCEEDED, null));
 
         var inv2Spans = spanExporter.getFinishedSpanItems();
@@ -604,9 +688,119 @@ class OtelPluginTest {
 
         // Wait continuation should have a Link
         var waitContinuation = inv2Spans.stream()
-                .filter(s -> s.getName().contains("wait"))
+                .filter(s -> s.getName().contains("pause"))
                 .findFirst()
                 .orElseThrow();
         assertFalse(waitContinuation.getLinks().isEmpty());
+    }
+
+    // ─── Cross-invocation step retry scenario ────────────────────────────
+
+    @Test
+    void crossInvocation_stepRetry_attemptsParentedToRespectiveInvocations() {
+        var arn = "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1";
+
+        // Invocation 1: step starts, attempt 1 fails, invocation suspended during retry poll
+        plugin.onInvocationStart(new InvocationInfo("req-1", arn, true));
+        plugin.onOperationStart(
+                new OperationInfo("op-1", "process-payment", "STEP", "Step", null, Instant.now(), null, false));
+        plugin.onUserFunctionStart(
+                new UserFunctionStartInfo("op-1", "process-payment", "STEP", "Step", null, Instant.now(), false, 1));
+        plugin.onUserFunctionEnd(new UserFunctionEndInfo(
+                "op-1",
+                "process-payment",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                false,
+                new RuntimeException("payment failed")));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.PENDING, null));
+
+        var inv1Spans = spanExporter.getFinishedSpanItems();
+        // operation span (PENDING) + attempt 1 span + invocation span = 3
+        assertEquals(3, inv1Spans.size());
+
+        var inv1OperationSpan = inv1Spans.stream()
+                .filter(s ->
+                        s.getName().contains("process-payment") && !s.getName().contains("attempt"))
+                .findFirst()
+                .orElseThrow();
+        var attempt1Span = inv1Spans.stream()
+                .filter(s -> s.getName().contains("attempt 1"))
+                .findFirst()
+                .orElseThrow();
+
+        // Attempt 1 should be parented to invocation 1's operation span
+        assertEquals(
+                inv1OperationSpan.getSpanId(),
+                attempt1Span.getParentSpanId(),
+                "Attempt 1 should be parented to invocation 1's operation span");
+
+        spanExporter.reset();
+
+        // Invocation 2: step is replayed (continuation), attempt 2 executes and succeeds
+        plugin.onInvocationStart(new InvocationInfo("req-2", arn, false));
+        // isReplay=true: this operation already exists in the execution state
+        plugin.onOperationStart(
+                new OperationInfo("op-1", "process-payment", "STEP", "Step", null, Instant.now(), null, true));
+        plugin.onUserFunctionStart(
+                new UserFunctionStartInfo("op-1", "process-payment", "STEP", "Step", null, Instant.now(), false, 2));
+        plugin.onUserFunctionEnd(new UserFunctionEndInfo(
+                "op-1", "process-payment", "STEP", "Step", null, Instant.now(), Instant.now(), false, 2, true, null));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1",
+                "process-payment",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                false,
+                null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-2", arn, false, InvocationStatus.SUCCEEDED, null));
+
+        var inv2Spans = spanExporter.getFinishedSpanItems();
+        // operation span + attempt 2 span + invocation span = 3
+        assertEquals(3, inv2Spans.size());
+
+        var inv2OperationSpan = inv2Spans.stream()
+                .filter(s ->
+                        s.getName().contains("process-payment") && !s.getName().contains("attempt"))
+                .findFirst()
+                .orElseThrow();
+        var attempt2Span = inv2Spans.stream()
+                .filter(s -> s.getName().contains("attempt 2"))
+                .findFirst()
+                .orElseThrow();
+
+        // Attempt 2 should be parented to invocation 2's operation span
+        assertEquals(
+                inv2OperationSpan.getSpanId(),
+                attempt2Span.getParentSpanId(),
+                "Attempt 2 should be parented to invocation 2's operation span");
+
+        // The two operation spans must have DIFFERENT span IDs (the bug was they were the same)
+        assertNotEquals(
+                inv1OperationSpan.getSpanId(),
+                inv2OperationSpan.getSpanId(),
+                "Continuation operation span must have a different span ID from the original");
+
+        // The continuation operation span should have a Link to the original for correlation
+        assertFalse(
+                inv2OperationSpan.getLinks().isEmpty(),
+                "Continuation operation span should have a Link to the original");
+
+        // All spans share the same trace ID
+        var allSpans = new java.util.ArrayList<>(inv1Spans);
+        allSpans.addAll(inv2Spans);
+        var traceId = allSpans.get(0).getTraceId();
+        assertTrue(
+                allSpans.stream().allMatch(s -> s.getTraceId().equals(traceId)),
+                "All spans across invocations should share the same trace ID");
     }
 }

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/XRayContextExtractorTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/XRayContextExtractorTest.java
@@ -22,6 +22,23 @@ class XRayContextExtractorTest {
     }
 
     @Test
+    void extract_readsFromSystemProperty_whenEnvVarMissing() {
+        // Simulate Lambda runtime setting the system property (env var not set in tests)
+        var traceHeader = "Root=1-6a43574f-2cf3140a69b0c8fe165f9503;Parent=53995c3f42cd8ad8;Sampled=1";
+        System.setProperty("com.amazonaws.xray.traceHeader", traceHeader);
+        try {
+            var extractor = new XRayContextExtractor();
+            var context = extractor.extract();
+
+            assertNotNull(context, "Should extract context from system property when env var is missing");
+            assertEquals("6a43574f2cf3140a69b0c8fe165f9503", context.traceId());
+            assertEquals("53995c3f42cd8ad8", context.parentSpanId());
+        } finally {
+            System.clearProperty("com.amazonaws.xray.traceHeader");
+        }
+    }
+
+    @Test
     void extract_implementsContextExtractor() {
         // Verify XRayContextExtractor implements the ContextExtractor interface
         ContextExtractor extractor = new XRayContextExtractor();

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/OtelPluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/OtelPluginIntegrationTest.java
@@ -55,9 +55,9 @@ class OtelPluginIntegrationTest {
         assertTrue(spans.size() >= 3, "Expected at least 3 spans, got " + spans.size());
 
         // Verify span names
-        assertSpanExists(spans, "durable.invocation");
-        assertSpanExists(spans, "durable.step:greet");
-        assertSpanExists(spans, "durable.step:greet [attempt 1]");
+        assertSpanExists(spans, "invocation");
+        assertSpanExists(spans, "greet");
+        assertSpanExists(spans, "greet attempt 1");
 
         // All spans share the same trace ID
         var traceId = spans.get(0).getTraceId();
@@ -84,12 +84,12 @@ class OtelPluginIntegrationTest {
         // 1 invocation + 3 operations + 3 attempts = 7
         assertTrue(spans.size() >= 7, "Expected at least 7 spans, got " + spans.size());
 
-        assertSpanExists(spans, "durable.step:step-a");
-        assertSpanExists(spans, "durable.step:step-b");
-        assertSpanExists(spans, "durable.step:step-c");
-        assertSpanExists(spans, "durable.step:step-a [attempt 1]");
-        assertSpanExists(spans, "durable.step:step-b [attempt 1]");
-        assertSpanExists(spans, "durable.step:step-c [attempt 1]");
+        assertSpanExists(spans, "step-a");
+        assertSpanExists(spans, "step-b");
+        assertSpanExists(spans, "step-c");
+        assertSpanExists(spans, "step-a attempt 1");
+        assertSpanExists(spans, "step-b attempt 1");
+        assertSpanExists(spans, "step-c attempt 1");
     }
 
     @Test
@@ -153,9 +153,8 @@ class OtelPluginIntegrationTest {
         assertTrue(allSpans.size() > spansAfterFirstInvocation, "Second invocation should produce additional spans");
 
         // Verify both invocations produced invocation spans
-        var invocationSpans = allSpans.stream()
-                .filter(s -> s.getName().equals("durable.invocation"))
-                .toList();
+        var invocationSpans =
+                allSpans.stream().filter(s -> s.getName().equals("invocation")).toList();
         assertEquals(2, invocationSpans.size(), "Should have 2 invocation spans (one per run)");
     }
 
@@ -178,7 +177,7 @@ class OtelPluginIntegrationTest {
         // The wait operation span should be open (ended with PENDING status at invocation end)
         var spansAfterFirst = spanExporter.getFinishedSpanItems();
         var waitSpansAfterFirst = spansAfterFirst.stream()
-                .filter(s -> s.getName().equals("durable.wait:pause"))
+                .filter(s -> s.getName().equals("pause"))
                 .toList();
         assertEquals(1, waitSpansAfterFirst.size(), "Wait span should exist after first invocation (ended as PENDING)");
 
@@ -190,9 +189,8 @@ class OtelPluginIntegrationTest {
         // After second invocation, the wait should have a second operation span
         // (fired by onOperationEnd via updatedOperationIds) showing it completed
         var allSpans = spanExporter.getFinishedSpanItems();
-        var waitSpansTotal = allSpans.stream()
-                .filter(s -> s.getName().equals("durable.wait:pause"))
-                .toList();
+        var waitSpansTotal =
+                allSpans.stream().filter(s -> s.getName().equals("pause")).toList();
         assertEquals(
                 2,
                 waitSpansTotal.size(),
@@ -267,8 +265,8 @@ class OtelPluginIntegrationTest {
         //            + inner step operation + inner step attempt = 5
         assertTrue(spans.size() >= 5, "Should have at least 5 spans for child context, got " + spans.size());
 
-        assertSpanExists(spans, "durable.runinchildcontext:child");
-        assertSpanExists(spans, "durable.step:inner");
+        assertSpanExists(spans, "child");
+        assertSpanExists(spans, "inner");
     }
 
     @Test
@@ -293,7 +291,7 @@ class OtelPluginIntegrationTest {
 
         // Invocation span should have error status
         var invocationSpan = spans.stream()
-                .filter(s -> s.getName().equals("durable.invocation"))
+                .filter(s -> s.getName().equals("invocation"))
                 .findFirst()
                 .orElseThrow();
         assertEquals(
@@ -420,8 +418,8 @@ class OtelPluginIntegrationTest {
                 spans.stream().anyMatch(s -> s.getName().contains("fan-out")),
                 "Should have parallel operation span. Got: "
                         + spans.stream().map(SpanData::getName).toList());
-        assertSpanExists(spans, "durable.step:step-A");
-        assertSpanExists(spans, "durable.step:step-B");
+        assertSpanExists(spans, "step-A");
+        assertSpanExists(spans, "step-B");
     }
 
     @Test
@@ -440,9 +438,9 @@ class OtelPluginIntegrationTest {
 
         var spans = spanExporter.getFinishedSpanItems();
 
-        assertSpanExists(spans, "durable.runinchildcontext:outer");
-        assertSpanExists(spans, "durable.runinchildcontext:inner");
-        assertSpanExists(spans, "durable.step:deep-step");
+        assertSpanExists(spans, "outer");
+        assertSpanExists(spans, "inner");
+        assertSpanExists(spans, "deep-step");
     }
 
     @Test
@@ -475,16 +473,13 @@ class OtelPluginIntegrationTest {
         var allSpans = spanExporter.getFinishedSpanItems();
 
         // Should have 3 invocation spans
-        var invocationSpans = allSpans.stream()
-                .filter(s -> s.getName().equals("durable.invocation"))
-                .toList();
+        var invocationSpans =
+                allSpans.stream().filter(s -> s.getName().equals("invocation")).toList();
         assertEquals(3, invocationSpans.size(), "Should have 3 invocation spans");
 
         // Should have wait-A and wait-B spans
-        assertTrue(
-                allSpans.stream().anyMatch(s -> s.getName().equals("durable.wait:wait-A")), "Should have wait-A span");
-        assertTrue(
-                allSpans.stream().anyMatch(s -> s.getName().equals("durable.wait:wait-B")), "Should have wait-B span");
+        assertTrue(allSpans.stream().anyMatch(s -> s.getName().equals("wait-A")), "Should have wait-A span");
+        assertTrue(allSpans.stream().anyMatch(s -> s.getName().equals("wait-B")), "Should have wait-B span");
     }
 
     @Test

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -151,7 +151,7 @@ public abstract class BaseDurableOperation {
                 // to the deterministic span ID from the original invocation.
                 if (replayCompletedOperation.get()
                         && executionManager.isOperationUpdatedSinceLastInvocation(getOperationId())) {
-                    fireOnOperationEnd(existing, extractErrorFromOperation(existing));
+                    fireOnOperationEnd(existing, extractErrorFromOperation(existing), true);
                 }
 
                 replay(existing);
@@ -362,7 +362,7 @@ public abstract class BaseDurableOperation {
 
             // Fire onOperationEnd plugin hook — operation reached terminal status for the first time (not replay)
             if (!replayCompletedOperation.get()) {
-                fireOnOperationEnd(operation, extractErrorFromOperation(operation));
+                fireOnOperationEnd(operation, extractErrorFromOperation(operation), false);
             }
 
             markCompletionFutureCompleted();
@@ -524,10 +524,10 @@ public abstract class BaseDurableOperation {
         getPluginRunner().onOperationStart(info);
     }
 
-    /** Fires onOperationEnd plugin hook when an operation reaches terminal status for the first time. */
-    protected void fireOnOperationEnd(Operation operation, Throwable error) {
+    /** Fires onOperationEnd plugin hook when an operation reaches terminal status. */
+    protected void fireOnOperationEnd(Operation operation, Throwable error, boolean isReplay) {
         var info = PluginInfoConverter.toOperationEndInfo(
-                operation, operationIdentifier, durableContext.getParentId(), error);
+                operation, operationIdentifier, durableContext.getParentId(), isReplay, error);
         getPluginRunner().onOperationEnd(info);
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
@@ -160,7 +160,7 @@ public class ChildContextOperation<T> extends SerializableDurableOperation<T> {
             // Mark the completableFuture completed so get() doesn't block waiting for a checkpoint response.
             cachedOperationResult.set(DeserializedOperationResult.succeeded(serializedResult.deserialized()));
             if (isVirtual) {
-                fireOnOperationEnd(null, null);
+                fireOnOperationEnd(null, null, false);
             }
             markAlreadyCompleted();
         } else {
@@ -211,7 +211,7 @@ public class ChildContextOperation<T> extends SerializableDurableOperation<T> {
         // - this child is not a direct child of a parent context (i.e. nestingType == FLAT), such as a parallel branch.
         if ((parentOperation != null && parentOperation.isOperationCompleted()) || isVirtual) {
             if (isVirtual) {
-                fireOnOperationEnd(null, exception);
+                fireOnOperationEnd(null, exception, false);
             }
             markAlreadyCompleted();
             return;

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationEndInfo.java
@@ -14,6 +14,8 @@ import java.time.Instant;
  * @param parentId parent operation ID (null for root-level operations)
  * @param startTimestamp when the operation started
  * @param endTimestamp when the operation ended
+ * @param status the operation's terminal status (e.g., SUCCEEDED, FAILED, TIMED_OUT) — may be null for virtual ops
+ * @param isReplay true if this operation already existed in the execution state (completed in a prior invocation)
  * @param error non-null if the operation failed
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
@@ -26,4 +28,6 @@ public record OperationEndInfo(
         String parentId,
         Instant startTimestamp,
         Instant endTimestamp,
+        String status,
+        boolean isReplay,
         Throwable error) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationInfo.java
@@ -17,6 +17,8 @@ import java.time.Instant;
  * @param startTimestamp when the operation started — on first execution this is a local {@code Instant.now()} which may
  *     slightly differ from the timestamp recorded by the backend; on replay it comes from the backend checkpoint
  * @param endTimestamp when the operation ended (null if still running)
+ * @param isReplay true if this operation already exists in the execution state from a prior invocation. Plugins can use
+ *     this to avoid generating duplicate span IDs.
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
 @Deprecated
@@ -27,4 +29,5 @@ public record OperationInfo(
         String subType,
         String parentId,
         Instant startTimestamp,
-        Instant endTimestamp) {}
+        Instant endTimestamp,
+        boolean isReplay) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
@@ -32,7 +32,8 @@ public final class PluginInfoConverter {
                 identifier.subType() != null ? identifier.subType().getValue() : null,
                 parentId,
                 operation != null ? operation.startTimestamp() : Instant.now(),
-                operation != null ? operation.endTimestamp() : null);
+                operation != null ? operation.endTimestamp() : null,
+                operation != null);
     }
 
     /**
@@ -46,7 +47,7 @@ public final class PluginInfoConverter {
      * @return an OperationEndInfo record
      */
     public static OperationEndInfo toOperationEndInfo(
-            Operation operation, OperationIdentifier identifier, String parentId, Throwable error) {
+            Operation operation, OperationIdentifier identifier, String parentId, boolean isReplay, Throwable error) {
         return new OperationEndInfo(
                 identifier.operationId(),
                 identifier.name(),
@@ -55,6 +56,10 @@ public final class PluginInfoConverter {
                 parentId,
                 operation != null ? operation.startTimestamp() : null,
                 operation != null ? operation.endTimestamp() : null,
+                operation != null && operation.status() != null
+                        ? operation.status().toString()
+                        : null,
+                isReplay,
                 error);
     }
 

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginInfoConverterTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginInfoConverterTest.java
@@ -68,7 +68,7 @@ class PluginInfoConverterTest {
                 Operation.builder().startTimestamp(START).endTimestamp(END).build();
         var error = new RuntimeException("step failed");
 
-        var info = PluginInfoConverter.toOperationEndInfo(operation, STEP_IDENTIFIER, PARENT_ID, error);
+        var info = PluginInfoConverter.toOperationEndInfo(operation, STEP_IDENTIFIER, PARENT_ID, true, error);
 
         assertEquals(OPERATION_ID, info.id());
         assertEquals(OPERATION_NAME, info.name());
@@ -85,7 +85,7 @@ class PluginInfoConverterTest {
         var operation =
                 Operation.builder().startTimestamp(START).endTimestamp(END).build();
 
-        var info = PluginInfoConverter.toOperationEndInfo(operation, STEP_IDENTIFIER, null, null);
+        var info = PluginInfoConverter.toOperationEndInfo(operation, STEP_IDENTIFIER, null, false, null);
 
         assertNull(info.error());
     }

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
@@ -142,11 +142,12 @@ class PluginRunnerTest {
     }
 
     private static OperationInfo operationInfo() {
-        return new OperationInfo("op-1", "test-step", "STEP", null, null, Instant.now(), null);
+        return new OperationInfo("op-1", "test-step", "STEP", null, null, Instant.now(), null, false);
     }
 
     private static OperationEndInfo operationEndInfo() {
-        return new OperationEndInfo("op-1", "test-step", "STEP", null, null, Instant.now(), Instant.now(), null);
+        return new OperationEndInfo(
+                "op-1", "test-step", "STEP", null, null, Instant.now(), Instant.now(), "SUCCEEDED", false, null);
     }
 
     private static UserFunctionStartInfo attemptInfo() {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
https://github.com/aws/aws-durable-execution-sdk-java/issues/507

### Description

Fixes OTel plugin X-Ray integration: cross-invocation retry span grouping, trace context extraction, and trace map display to match the JS SDK behavior.

1. **Retry attempts grouped under wrong invocation** - When a step failed in invocation 1 and retried in invocation 2, both operation spans had the same deterministic span ID, causing trace viewers to merge them.
2. **Durable spans in separate trace** — `System.getenv("_X_AMZN_TRACE_ID")` returned stale/null values due to JVM env caching, so the plugin fell back to an ARN-derived trace ID disconnected from Lambda's X-Ray segments.
3. **Spans nested inside Lambda function instead of separate node** - Missing`service.name` resource and `SpanKind.SERVER` prevented X-Ray from creating a distinct service node for durable execution spans.

### Demo/Screenshots
<img width="1481" height="517" alt="Screenshot 2026-06-30 at 12 33 02 PM" src="https://github.com/user-attachments/assets/8df18d6d-f7b6-4d8b-94ba-1957cafe9d3e" />

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Yes

#### Integration Tests

Have integration tests been written for these changes? N/A
 
#### Examples

Has a new example been added for the change? (if applicable) Updated existing ones.
