### PR TITLE
docs: clarify invoke supports standard Lambda functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Your durable function extends `DurableHandler<I, O>` and implements `handleReque
 - `ctx.wait()` – Suspend execution without compute charges
 - `ctx.createCallback()` – Wait for external events (approvals, webhooks)
 - `ctx.waitForCallback()` – Simplify callback handling by combining callback creation and submission in one operation
-- `ctx.invoke()` – Invoke another Lambda function and wait for the result
+- `ctx.invoke()` – Invoke another Lambda function, durable or standard, and wait for the result
 - `ctx.runInChildContext()` – Run an isolated child context with its own checkpoint log
 - `ctx.map()` – Apply a function to each item in a collection concurrently
 - `ctx.parallel()` - Run multiple operations concurrently with optional concurrency control
@@ -96,7 +96,7 @@ See [Deploy Lambda durable functions with Infrastructure as Code](https://docs.a
 - [<u>Steps</u>](docs/core/steps.md) – Execute code with automatic checkpointing and retry support
 - [<u>Wait</u>](docs/core/wait.md) - Pause execution without blocking Lambda resources
 - [<u>Callbacks</u>](docs/core/callbacks.md) - Wait for external systems to respond
-- [<u>Invoke</u>](docs/core/invoke.md) - Call other durable functions
+- [<u>Invoke</u>](docs/core/invoke.md) - Call durable functions or standard Lambda functions
 - [<u>Child Contexts</u>](docs/core/child-contexts.md) - Organize complex workflows into isolated units
 - [<u>Map</u>](docs/core/map.md) - Apply a function across a collection concurrently
 - [<u>Parallel</u>](docs/core/parallel.md) - Run multiple operations concurrently with optional concurrency control

--- a/docs/core/invoke.md
+++ b/docs/core/invoke.md
@@ -1,4 +1,10 @@
-## invoke() - Invoke another Lambda function
+## invoke() - Invoke Other Lambda Functions Durably
+
+The invoke operation calls another Lambda function and waits for its result. It supports both durable functions and standard on-demand Lambda functions.
+
+When you call `ctx.invoke()` or `ctx.invokeAsync()`, the SDK checkpoints the start of the operation and the durable functions backend invokes the target Lambda function. On replay, the SDK returns the checkpointed result without invoking the target again.
+
+`functionName` can be a Lambda function name or ARN. Durable function targets require an alias or version qualifier; standard on-demand Lambda functions do not require a qualifier.
 
 
 ```java

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/invoke/SimpleInvokeExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/invoke/SimpleInvokeExample.java
@@ -10,13 +10,13 @@ import software.amazon.lambda.durable.examples.types.GreetingRequest;
 /**
  * Simple example demonstrating basic invoke execution with the Durable Execution SDK.
  *
- * <p>This handler invokes another durable lambda function simple-step-example
+ * <p>This handler invokes another Lambda function, such as simple-step-example.
  */
 public class SimpleInvokeExample extends DurableHandler<GreetingRequest, String> {
 
     @Override
     public String handleRequest(GreetingRequest input, DurableContext context) {
-        // invoke `simple-step-example` function
+        // Invoke the `simple-step-example` function.
         var future = context.invokeAsync(
                 "call-greeting1",
                 "simple-step-example" + input.getName() + ":$LATEST",


### PR DESCRIPTION
## Summary
- Clarify ctx.invoke supports durable and standard Lambda functions
- Document qualifier requirement difference for durable vs on-demand targets
- Update invoke example comment

## Testing
- mvn spotless:apply
- git diff --check