### PR TITLE
fix(otel): Align span attributes and log enrichment with cross-SDK spec

### DIFF
--- a/examples/src/main/java/software/amazon/lambda/durable/examples/general/OtelExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/general/OtelExample.java
@@ -18,7 +18,7 @@ import software.amazon.lambda.durable.otel.OtelPlugin;
  *
  * <ul>
  *   <li>Deterministic trace/span IDs (all invocations of the same execution share one trace)
- *   <li>MDC log enrichment (trace_id and span_id in every log line)
+ *   <li>MDC log enrichment (traceId, spanId, traceSampled in every log line)
  *   <li>Logging exporter (spans printed to stdout → CloudWatch Logs)
  * </ul>
  *
@@ -47,7 +47,7 @@ public class OtelExample extends DurableHandler<GreetingRequest, String> {
 
     @Override
     public String handleRequest(GreetingRequest input, DurableContext context) {
-        // Log with MDC — trace_id and span_id will be in the JSON output
+        // Log with MDC — traceId and spanId will be in the JSON output
         context.getLogger().info("Starting OTel example for {}", input.getName());
 
         var greeting = context.step("create-greeting", String.class, stepCtx -> {

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayStepExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayStepExample.java
@@ -18,18 +18,17 @@ import software.amazon.lambda.durable.otel.OtelPlugin;
  *
  * <ul>
  *   <li>{@code Tracing: Active} on the Lambda function
- *   <li>ADOT Lambda Layer added to the function
- *   <li>{@code AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler} environment variable
+ *   <li>ADOT Lambda Layer added to the function (for the OTLP collector)
  * </ul>
  *
  * <p>Expected trace structure in X-Ray:
  *
  * <pre>
- * durable.invocation
- * ├── durable.step:create-greeting
- * │   └── durable.step:create-greeting [attempt 1]
- * └── durable.step:transform
- *     └── durable.step:transform [attempt 1]
+ * invocation
+ * ├── create-greeting
+ * │   └── create-greeting attempt 1
+ * └── transform
+ *     └── transform attempt 1
  * </pre>
  */
 public class OtelXRayStepExample extends DurableHandler<GreetingRequest, String> {

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayWaitExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayWaitExample.java
@@ -26,8 +26,7 @@ import software.amazon.lambda.durable.otel.OtelPlugin;
  *
  * <ul>
  *   <li>{@code Tracing: Active} on the Lambda function
- *   <li>ADOT Lambda Layer added to the function
- *   <li>{@code AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler} environment variable
+ *   <li>ADOT Lambda Layer added to the function (for the OTLP collector)
  * </ul>
  *
  * <p>Expected trace structure in X-Ray (all under one trace ID — backend propagates same Root):

--- a/otel-plugin/README.md
+++ b/otel-plugin/README.md
@@ -9,7 +9,7 @@ OpenTelemetry instrumentation plugin for the AWS Lambda Durable Execution SDK fo
 - **Deterministic Trace IDs**: All invocations of the same durable execution share a single trace, derived from the X-Ray trace header or execution ARN
 - **Span-per-Operation**: Each durable operation (step, wait, map, etc.) gets its own span with accurate timing
 - **Attempt Spans**: Each user function execution (step attempt, child context run) gets a span, including retries
-- **Log Correlation**: Injects `trace_id` and `span_id` into SLF4J MDC for end-to-end observability
+- **Log Correlation**: Injects `traceId`, `spanId`, and `traceSampled` into SLF4J MDC for end-to-end observability
 - **Self-Contained Setup**: No manual TracerProvider configuration required beyond the exporter
 
 ## Installation
@@ -18,7 +18,7 @@ OpenTelemetry instrumentation plugin for the AWS Lambda Durable Execution SDK fo
 <dependency>
     <groupId>software.amazon.lambda.durable</groupId>
     <artifactId>aws-durable-execution-sdk-java-plugin-otel</artifactId>
-    <version>0.1.0</version>
+    <version>${durable.sdk.version}</version>
 </dependency>
 ```
 
@@ -39,37 +39,21 @@ You also need the OpenTelemetry SDK and an exporter:
 
 ## Quick Start using X-Ray/CloudWatch Tracing
 
-1. Add the ADOT Lambda Layer to your function and set `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler`
+1. Add the ADOT Lambda Layer to your function
 2. Enable X-Ray Active Tracing on the function
 3. Register `OtelPlugin` in your handler's `DurableConfig`
 4. Grant X-Ray write permissions
 
 ### 1. ADOT Lambda Layer
 
-This plugin requires the [AWS Distro for OpenTelemetry (ADOT) Lambda layer](https://aws-otel.github.io/docs/getting-started/lambda) to export traces from your Lambda function.
+This plugin uses the [AWS Distro for OpenTelemetry (ADOT) Lambda layer](https://aws-otel.github.io/docs/getting-started/lambda) for trace export. The layer provides an OTLP collector that receives spans from the plugin and exports them to X-Ray.
+
+> **Note:** Do NOT set `AWS_LAMBDA_EXEC_WRAPPER`. The ADOT layer's collector extension runs independently as a Lambda External Extension. The wrapper would attach the auto-instrumentation agent which creates a competing TracerProvider, causing disconnected service nodes in the X-Ray trace map.
 
 The layer ARN follows the format:
 
 ```
-arn:aws:lambda:<region>:<account-id>:layer:AWSOpenTelemetryDistroJava:<version>
-```
-
-The account ID varies by region. Refer to the [ADOT Lambda Layer ARNs](https://aws-otel.github.io/docs/getting-started/lambda#aws-lambda-layer-for-opentelemetry-arns) page for region-specific ARNs, account IDs, and the latest version number.
-
-**AWS CLI:**
-
-```bash
-aws lambda update-function-configuration \
-  --function-name your-function-name \
-  --layers "arn:aws:lambda:<region>:<account-id>:layer:AWSOpenTelemetryDistroJava:<version>"
-```
-
-You must also set the `AWS_LAMBDA_EXEC_WRAPPER` environment variable:
-
-```bash
-aws lambda update-function-configuration \
-  --function-name your-function-name \
-  --environment "Variables={AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler}"
+arn:aws:lambda:<region>:901920570463:layer:aws-otel-java-agent-<arch>-ver-1-32-0:6
 ```
 
 **CloudFormation / SAM:**
@@ -78,29 +62,19 @@ aws lambda update-function-configuration \
 MyFunction:
   Type: AWS::Serverless::Function
   Properties:
+    Tracing: Active
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:<account-id>:layer:AWSOpenTelemetryDistroJava:<version>
-    Environment:
-      Variables:
-        AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
+      - !Sub
+        - arn:aws:lambda:${AWS::Region}:901920570463:layer:aws-otel-java-agent-${Arch}-ver-1-32-0:6
+        - Arch: amd64
 ```
 
-**CDK (Java):**
+**AWS CLI:**
 
-```java
-import software.amazon.awscdk.services.lambda.*;
-
-var adotLayer = LayerVersion.fromLayerVersionArn(this, "AdotLayer",
-        String.format("arn:aws:lambda:%s:<account-id>:layer:AWSOpenTelemetryDistroJava:<version>",
-                this.getRegion()));
-
-Function.Builder.create(this, "MyFunction")
-        .runtime(Runtime.JAVA_17)
-        .handler("com.example.MyHandler::handleRequest")
-        .code(Code.fromAsset("target/my-function.jar"))
-        .layers(List.of(adotLayer))
-        .environment(Map.of("AWS_LAMBDA_EXEC_WRAPPER", "/opt/otel-handler"))
-        .build();
+```bash
+aws lambda update-function-configuration \
+  --function-name your-function-name \
+  --layers "arn:aws:lambda:<region>:901920570463:layer:aws-otel-java-agent-amd64-ver-1-32-0:6"
 ```
 
 ### 2. AWS X-Ray Active Tracing
@@ -127,14 +101,6 @@ MyFunction:
       Mode: Active
 ```
 
-**CDK (Java):**
-
-```java
-Function.Builder.create(this, "MyFunction")
-        .tracing(Tracing.ACTIVE)
-        .build();
-```
-
 ### 3. In Your Lambda Handler
 
 ```java
@@ -150,7 +116,6 @@ public class MyHandler extends DurableHandler<MyInput, MyOutput> {
 
     @Override
     protected DurableConfig createConfiguration() {
-        // OTLP exporter sends spans to the ADOT collector (localhost:4317 by default)
         var otlpExporter = OtlpGrpcSpanExporter.getDefault();
 
         var otelPlugin = new OtelPlugin(
@@ -178,8 +143,6 @@ public class MyHandler extends DurableHandler<MyInput, MyOutput> {
 }
 ```
 
-That's it. The plugin handles TracerProvider setup, deterministic ID generation, and span lifecycle internally.
-
 ### 4. Grant Permissions
 
 The function's execution role needs the `AWSXRayDaemonWriteAccess` managed policy (or equivalent permissions) to write traces to X-Ray.
@@ -189,17 +152,62 @@ The function's execution role needs the `AWSXRayDaemonWriteAccess` managed polic
 The plugin creates spans at three levels:
 
 ```
-durable.invocation
-├── durable.step:fetch-data
-│   └── durable.step:fetch-data [attempt 1]
-├── durable.wait:cool-down
-└── durable.step:process
-    └── durable.step:process [attempt 1]
+invocation
+├── fetch-data
+│   └── fetch-data attempt 1
+├── cool-down
+└── process
+    └── process attempt 1
 ```
 
-- **Invocation span** — one per Lambda invocation, covers the entire invocation lifecycle
+- **Invocation span** (`SpanKind.SERVER`) — one per Lambda invocation, creates a distinct X-Ray service node
 - **Operation span** — one per durable operation, named after your step/wait names
 - **Attempt span** — one per user function execution (retries produce additional attempt spans)
+
+## Span Attributes
+
+### Invocation Span
+
+| Attribute | Description |
+|-----------|-------------|
+| `durable.execution.arn` | The durable execution ARN |
+| `durable.invocation.status` | SUCCEEDED, FAILED, PENDING, or RETRYING |
+| `durable.invocation.first` | Whether this is the first invocation of the execution |
+| `faas.invocation_id` | Lambda request ID |
+
+### Operation Span
+
+| Attribute | Description |
+|-----------|-------------|
+| `durable.execution.arn` | The durable execution ARN |
+| `durable.operation.id` | Unique operation ID |
+| `durable.operation.type` | STEP, WAIT, CONTEXT, CHAINED_INVOKE, CALLBACK |
+| `durable.operation.name` | Human-readable name (if provided) |
+| `durable.operation.subtype` | Map, Parallel, WaitForCondition, etc. |
+| `durable.operation.status` | Backend status: SUCCEEDED, FAILED, PENDING, TIMED_OUT, etc. |
+
+### Attempt Span (not emitted for CONTEXT operations)
+
+| Attribute | Description |
+|-----------|-------------|
+| `durable.execution.arn` | The durable execution ARN |
+| `durable.operation.id` | Parent operation ID |
+| `durable.operation.type` | Parent operation type |
+| `durable.operation.name` | Parent operation name |
+| `durable.attempt.number` | 1-based attempt number |
+| `durable.attempt.outcome` | SUCCEEDED or FAILED |
+
+## Log Correlation (MDC)
+
+When `enableMdc` is true (default), the plugin injects these fields into SLF4J MDC during user function execution:
+
+| MDC Key | Description |
+|---------|-------------|
+| `traceId` | W3C trace ID (32 hex chars) |
+| `spanId` | Current span ID (16 hex chars) |
+| `traceSampled` | Whether the trace is sampled (true/false) |
+
+These appear automatically in structured log output (Log4j2 JSON, Logback JSON) for log-trace correlation.
 
 ## Configuration
 
@@ -220,16 +228,7 @@ new OtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc);
 |-----------|-------------|---------|
 | `tracerProviderBuilder` | `SdkTracerProviderBuilder` with your exporter/processor configured | Required |
 | `contextExtractor` | Extracts parent trace context from the Lambda environment | `XRayContextExtractor` |
-| `enableMdc` | If true, injects `trace_id`/`span_id` into SLF4J MDC | `true` |
-
-### Environment Variables for ADOT Layer
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint for the OTLP exporter | Set by ADOT layer |
-| `AWS_LAMBDA_EXEC_WRAPPER` | Set to `/opt/otel-handler` for ADOT layer instrumentation | — |
-| `OTEL_TRACES_SAMPLER` | Sampler to use (e.g., `traceidratio` for ratio-based sampling) | `always_on` |
-| `OTEL_TRACES_SAMPLER_ARG` | Argument for the sampler (e.g., `0.3` to sample 30%) | — |
+| `enableMdc` | If true, injects `traceId`/`spanId`/`traceSampled` into SLF4J MDC | `true` |
 
 ## Verification
 
@@ -242,18 +241,19 @@ After deploying your function with the plugin configured:
    - Child spans for each durable operation (named after your step names)
    - All invocations of the same execution grouped under one trace ID
 
-3. **Check log correlation** — Verify that your logs include `trace_id` and `span_id` fields matching the spans in the trace view.
-
-4. **Confirm sampling** — If you set `OTEL_TRACES_SAMPLER=traceidratio` with an arg less than 1.0, verify that only the expected proportion of traces appear.
+3. **Check log correlation** — Verify that your logs include `traceId` and `spanId` fields matching the spans in the trace view.
 
 ### Troubleshooting
 
 | Symptom | Likely Cause |
 |---------|-------------|
-| No traces appear | ADOT layer not configured, or `AWS_LAMBDA_EXEC_WRAPPER` not set |
+| No traces appear | ADOT layer not added to the function |
 | Traces appear but are fragmented | X-Ray active tracing not enabled on the Lambda function |
-| Missing spans for some operations | `OTEL_TRACES_SAMPLER_ARG` set below 1.0 |
+| Missing spans for some operations | Sampling is configured below 1.0 |
 | `_X_AMZN_TRACE_ID` not populated | X-Ray active tracing not enabled |
+| Two service nodes in trace map | `AWS_LAMBDA_EXEC_WRAPPER` is set — remove it (see note above) |
+
+> **Note on ADOT wrapper:** Do not set `AWS_LAMBDA_EXEC_WRAPPER`. The wrapper attaches the auto-instrumentation agent which creates a separate TracerProvider. Since the plugin needs its own TracerProvider (for deterministic ID generation), having two providers causes X-Ray to render disconnected service nodes.
 
 ## Local Development
 
@@ -267,31 +267,11 @@ var otelPlugin = new OtelPlugin(
                 .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create())));
 ```
 
-## API Reference
-
-### `OtelPlugin`
-
-The main plugin class. Implements `DurableExecutionPlugin` from the core SDK.
-
-```java
-new OtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder)
-new OtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor)
-new OtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor, boolean enableMdc)
-```
-
-### `XRayContextExtractor`
-
-Default context extractor. Reads the `_X_AMZN_TRACE_ID` environment variable to derive trace context.
-
-### `ContextExtractor`
-
-Interface for custom context extractor implementations.
-
 ## Requirements
 
 - Java 17+
-- AWS Durable Execution SDK for Java 1.2.1+
-- OpenTelemetry SDK 1.20.0+
+- AWS Durable Execution SDK for Java 2.0.0+
+- OpenTelemetry SDK 1.30.0+
 
 ## License
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
@@ -14,9 +14,9 @@ import org.slf4j.MDC;
  * <p>MDC keys injected:
  *
  * <ul>
- *   <li>{@code trace_id} — the W3C trace ID (32 hex chars)
- *   <li>{@code span_id} — the current span ID (16 hex chars)
- *   <li>{@code durable.execution.arn} — the execution ARN
+ *   <li>{@code traceId} — the W3C trace ID (32 hex chars)
+ *   <li>{@code spanId} — the current span ID (16 hex chars)
+ *   <li>{@code traceSampled} — whether the trace is sampled (true/false)
  * </ul>
  *
  * <p>Usage: Call {@link #inject()} in {@code onUserFunctionStart} (after span is active) and {@link #clear()} in
@@ -28,25 +28,19 @@ import org.slf4j.MDC;
 @Deprecated
 public final class MdcSpanEnricher {
 
-    public static final String MDC_TRACE_ID = "trace_id";
-    public static final String MDC_SPAN_ID = "span_id";
-    public static final String MDC_EXECUTION_ARN = "durable.execution.arn";
+    public static final String MDC_TRACE_ID = "traceId";
+    public static final String MDC_SPAN_ID = "spanId";
+    public static final String MDC_TRACE_SAMPLED = "traceSampled";
 
     private MdcSpanEnricher() {}
 
-    /**
-     * Injects the current span's trace ID and span ID into MDC.
-     *
-     * @param durableExecutionArn the durable execution ARN (may be null)
-     */
-    public static void inject(String durableExecutionArn) {
+    /** Injects the current span's trace ID, span ID, and sampling flag into MDC. */
+    public static void inject() {
         var span = Span.current();
         if (span.getSpanContext().isValid()) {
             MDC.put(MDC_TRACE_ID, span.getSpanContext().getTraceId());
             MDC.put(MDC_SPAN_ID, span.getSpanContext().getSpanId());
-        }
-        if (durableExecutionArn != null) {
-            MDC.put(MDC_EXECUTION_ARN, durableExecutionArn);
+            MDC.put(MDC_TRACE_SAMPLED, String.valueOf(span.getSpanContext().isSampled()));
         }
     }
 
@@ -54,6 +48,6 @@ public final class MdcSpanEnricher {
     public static void clear() {
         MDC.remove(MDC_TRACE_ID);
         MDC.remove(MDC_SPAN_ID);
-        MDC.remove(MDC_EXECUTION_ARN);
+        MDC.remove(MDC_TRACE_SAMPLED);
     }
 }

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPlugin.java
@@ -23,7 +23,6 @@ import java.time.Instant;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.lambda.durable.execution.SuspendExecutionException;
 import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
 import software.amazon.lambda.durable.plugin.InvocationEndInfo;
 import software.amazon.lambda.durable.plugin.InvocationInfo;
@@ -56,10 +55,12 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * <p>Requires the ADOT Lambda Layer for trace export. Configure with:
  *
  * <ul>
- *   <li>Lambda Layer: {@code aws-otel-java-agent} (ADOT Java auto-instrumentation layer)
- *   <li>Env var: {@code AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler}
+ *   <li>Lambda Layer: {@code aws-otel-java-agent} (provides the OTLP collector extension)
  *   <li>Tracing: Active (to populate {@code _X_AMZN_TRACE_ID})
  * </ul>
+ *
+ * <p>Note: Do NOT set {@code AWS_LAMBDA_EXEC_WRAPPER}. The collector extension runs independently. The wrapper would
+ * attach the auto-instrumentation agent which creates a competing TracerProvider.
  *
  * <p>Thread-safe: uses {@link ConcurrentHashMap} for span/scope storage since the SDK runs user code on multiple
  * threads.
@@ -127,7 +128,7 @@ public class OtelPlugin implements DurableExecutionPlugin {
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
-     * @param enableMdc if true, injects trace_id/span_id into SLF4J MDC for log correlation
+     * @param enableMdc if true, injects traceId/spanId/traceSampled into SLF4J MDC for log correlation
      */
     public OtelPlugin(
             SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor, boolean enableMdc) {
@@ -199,13 +200,13 @@ public class OtelPlugin implements DurableExecutionPlugin {
         // End any operation spans that are still open (operations that didn't complete in this invocation)
         for (var entry : operationSpans.entrySet()) {
             var span = entry.getValue();
-            span.setAttribute(AttributeKey.stringKey("durable.operation.status"), "PENDING");
+            span.setAttribute(DURABLE_OPERATION_STATUS, "PENDING");
             span.end();
         }
         operationSpans.clear();
         operationContexts.clear();
 
-        // End any attempt spans that are still open (e.g., SuspendExecutionException skipped onUserFunctionEnd)
+        // End any attempt spans that are still open (e.g., crash before onUserFunctionEnd)
         for (var entry : attemptScopes.entrySet()) {
             entry.getValue().close();
         }
@@ -267,9 +268,6 @@ public class OtelPlugin implements DurableExecutionPlugin {
         if (info.subType() != null) {
             spanBuilder.setAttribute(DURABLE_OPERATION_SUBTYPE, info.subType());
         }
-        if (info.parentId() != null) {
-            spanBuilder.setAttribute(DURABLE_OPERATION_PARENT_ID, info.parentId());
-        }
 
         var span = spanBuilder.startSpan();
 
@@ -286,6 +284,9 @@ public class OtelPlugin implements DurableExecutionPlugin {
 
         if (span != null) {
             // Operation was started in this invocation — end normally
+            if (info.status() != null) {
+                span.setAttribute(DURABLE_OPERATION_STATUS, info.status());
+            }
             if (info.error() != null) {
                 span.setStatus(StatusCode.ERROR, info.error().getMessage());
                 span.recordException(info.error());
@@ -314,6 +315,9 @@ public class OtelPlugin implements DurableExecutionPlugin {
 
             var continuationSpan = spanBuilder.startSpan();
 
+            if (info.status() != null) {
+                continuationSpan.setAttribute(DURABLE_OPERATION_STATUS, info.status());
+            }
             if (info.error() != null) {
                 continuationSpan.setStatus(StatusCode.ERROR, info.error().getMessage());
                 continuationSpan.recordException(info.error());
@@ -327,6 +331,23 @@ public class OtelPlugin implements DurableExecutionPlugin {
 
     @Override
     public void onUserFunctionStart(UserFunctionStartInfo info) {
+        // Skip attempt spans for CONTEXT operations — they are a scoping construct, not a
+        // retriable unit of work, so attempt number/outcome attributes don't apply.
+        // The operation span itself provides parent context for auto-instrumented calls.
+        if ("CONTEXT".equals(info.type())) {
+            // Still set the operation span as current so auto-instrumented calls become children
+            var operationSpan = operationSpans.get(info.id());
+            if (operationSpan != null) {
+                var scope = operationSpan.makeCurrent();
+                var key = attemptKey(info.id(), info.attempt());
+                attemptScopes.put(key, scope);
+            }
+            if (enableMdc) {
+                MdcSpanEnricher.inject();
+            }
+            return;
+        }
+
         var key = attemptKey(info.id(), info.attempt());
 
         // Use the operation span as parent for the attempt span
@@ -358,7 +379,7 @@ public class OtelPlugin implements DurableExecutionPlugin {
 
         // Inject trace context into MDC for log-trace correlation
         if (enableMdc) {
-            MdcSpanEnricher.inject(durableExecutionArn);
+            MdcSpanEnricher.inject();
         }
     }
 
@@ -372,31 +393,31 @@ public class OtelPlugin implements DurableExecutionPlugin {
             scope.close();
         }
 
+        // Clear MDC after user function completes
+        if (enableMdc) {
+            MdcSpanEnricher.clear();
+        }
+
+        // CONTEXT operations don't have attempt spans — scope cleanup is all we need
+        if ("CONTEXT".equals(info.type())) {
+            return;
+        }
+
         var span = attemptSpans.remove(key);
         if (span == null) return;
 
-        // Set outcome
-        var outcome = info.succeeded() ? "succeeded" : (info.error() != null ? "failed" : "unknown");
+        var outcome = info.succeeded() ? "SUCCEEDED" : "FAILED";
         span.setAttribute(DURABLE_ATTEMPT_OUTCOME, outcome);
 
         if (!info.succeeded() && info.error() != null) {
-            if (info.error() instanceof SuspendExecutionException) {
-                span.setAttribute(DURABLE_ATTEMPT_OUTCOME, "pending");
-            } else {
-                span.setStatus(StatusCode.ERROR, info.error().getMessage());
-                span.recordException(info.error());
-            }
+            span.setStatus(StatusCode.ERROR, info.error().getMessage());
+            span.recordException(info.error());
         }
 
         if (info.endTimestamp() != null) {
             span.end(info.endTimestamp());
         } else {
             span.end();
-        }
-
-        // Clear MDC after user function completes
-        if (enableMdc) {
-            MdcSpanEnricher.clear();
         }
     }
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/SpanAttributes.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/SpanAttributes.java
@@ -19,8 +19,7 @@ final class SpanAttributes {
     static final AttributeKey<String> DURABLE_OPERATION_TYPE = AttributeKey.stringKey("durable.operation.type");
     static final AttributeKey<String> DURABLE_OPERATION_NAME = AttributeKey.stringKey("durable.operation.name");
     static final AttributeKey<String> DURABLE_OPERATION_SUBTYPE = AttributeKey.stringKey("durable.operation.subtype");
-    static final AttributeKey<String> DURABLE_OPERATION_PARENT_ID =
-            AttributeKey.stringKey("durable.operation.parent_id");
+    static final AttributeKey<String> DURABLE_OPERATION_STATUS = AttributeKey.stringKey("durable.operation.status");
     static final AttributeKey<Long> DURABLE_ATTEMPT_NUMBER = AttributeKey.longKey("durable.attempt.number");
     static final AttributeKey<String> DURABLE_ATTEMPT_OUTCOME = AttributeKey.stringKey("durable.attempt.outcome");
     static final AttributeKey<String> DURABLE_INVOCATION_STATUS = AttributeKey.stringKey("durable.invocation.status");

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
@@ -24,35 +24,26 @@ class MdcSpanEnricherTest {
     void clear_removesAllMdcKeys() {
         MDC.put(MdcSpanEnricher.MDC_TRACE_ID, "abc123");
         MDC.put(MdcSpanEnricher.MDC_SPAN_ID, "def456");
-        MDC.put(MdcSpanEnricher.MDC_EXECUTION_ARN, "arn:test");
+        MDC.put(MdcSpanEnricher.MDC_TRACE_SAMPLED, "true");
 
         MdcSpanEnricher.clear();
 
         assertNull(MDC.get(MdcSpanEnricher.MDC_TRACE_ID));
         assertNull(MDC.get(MdcSpanEnricher.MDC_SPAN_ID));
-        assertNull(MDC.get(MdcSpanEnricher.MDC_EXECUTION_ARN));
+        assertNull(MDC.get(MdcSpanEnricher.MDC_TRACE_SAMPLED));
     }
 
     @Test
-    void inject_withNoActiveSpan_doesNotSetTraceIds() {
-        MdcSpanEnricher.inject("arn:test");
+    void inject_withNoActiveSpan_doesNotSetMdcFields() {
+        MdcSpanEnricher.inject();
 
-        // No active span → no trace/span IDs, but ARN is still set
         assertNull(MDC.get(MdcSpanEnricher.MDC_TRACE_ID));
         assertNull(MDC.get(MdcSpanEnricher.MDC_SPAN_ID));
-        assertEquals("arn:test", MDC.get(MdcSpanEnricher.MDC_EXECUTION_ARN));
+        assertNull(MDC.get(MdcSpanEnricher.MDC_TRACE_SAMPLED));
     }
 
     @Test
-    void inject_withNullArn_doesNotSetArn() {
-        MdcSpanEnricher.inject(null);
-
-        assertNull(MDC.get(MdcSpanEnricher.MDC_EXECUTION_ARN));
-    }
-
-    @Test
-    void plugin_withMdcEnabled_setsArnInMdc() {
-        // Test MDC through the full plugin lifecycle (where makeCurrent is called on same thread)
+    void plugin_withMdcEnabled_setsFieldsInMdc() {
         var spanExporter = InMemorySpanExporter.create();
 
         var plugin = new OtelPlugin(
@@ -62,19 +53,21 @@ class MdcSpanEnricherTest {
 
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec-mdc-test", true));
 
-        // Simulate onUserFunctionStart on this thread (same as production — hooks fire on user code thread)
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "step", "STEP", "Step", null, Instant.now(), false, 1));
 
-        // MDC should have execution ARN after onUserFunctionStart
-        assertEquals("arn:exec-mdc-test", MDC.get(MdcSpanEnricher.MDC_EXECUTION_ARN));
+        // MDC should have trace fields after onUserFunctionStart
+        assertNotNull(MDC.get(MdcSpanEnricher.MDC_TRACE_ID));
+        assertNotNull(MDC.get(MdcSpanEnricher.MDC_SPAN_ID));
+        assertNotNull(MDC.get(MdcSpanEnricher.MDC_TRACE_SAMPLED));
 
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
 
         // MDC should be cleared after onUserFunctionEnd
-        assertNull(MDC.get(MdcSpanEnricher.MDC_EXECUTION_ARN));
         assertNull(MDC.get(MdcSpanEnricher.MDC_TRACE_ID));
+        assertNull(MDC.get(MdcSpanEnricher.MDC_SPAN_ID));
+        assertNull(MDC.get(MdcSpanEnricher.MDC_TRACE_SAMPLED));
 
         plugin.onInvocationEnd(
                 new InvocationEndInfo("req-1", "arn:exec-mdc-test", true, InvocationStatus.SUCCEEDED, null));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OtelPluginTest.java
@@ -532,11 +532,15 @@ class OtelPluginTest {
         assertFalse(continuationSpan.getLinks().isEmpty());
     }
 
-    // ─── SuspendExecutionException handling ──────────────────────────────
+    // ─── CONTEXT operation handling ─────────────────────────────────────
 
     @Test
-    void userFunctionEnd_withSuspendException_setsOutcomePending() {
+    void contextOperation_doesNotCreateAttemptSpan() {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+
+        // Create operation span first so the CONTEXT user function has a parent
+        plugin.onOperationStart(new OperationInfo(
+                "op-1", "child-ctx", "CONTEXT", "RunInChildContext", null, Instant.now(), null, false));
 
         plugin.onUserFunctionStart(new UserFunctionStartInfo(
                 "op-1", "child-ctx", "CONTEXT", "RunInChildContext", null, Instant.now(), false, null));
@@ -556,12 +560,11 @@ class OtelPluginTest {
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.PENDING, null));
 
-        var attemptSpan = spanExporter.getFinishedSpanItems().stream()
-                .filter(s -> s.getName().contains("child-ctx"))
-                .findFirst()
-                .orElseThrow();
-        // Should NOT have ERROR status — suspension is not an error
-        assertNotEquals(StatusCode.ERROR, attemptSpan.getStatus().getStatusCode());
+        // Should only have the operation span + invocation span — no attempt span
+        var spans = spanExporter.getFinishedSpanItems();
+        var attemptSpans =
+                spans.stream().filter(s -> s.getName().contains("attempt")).toList();
+        assertTrue(attemptSpans.isEmpty(), "CONTEXT operations should not produce attempt spans");
     }
 
     // ─── Attempt span cleanup at invocation end ──────────────────────────

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/OtelPluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/OtelPluginIntegrationTest.java
@@ -261,9 +261,9 @@ class OtelPluginIntegrationTest {
 
         var spans = spanExporter.getFinishedSpanItems();
 
-        // Should have: invocation + child context operation + child context attempt (fn)
-        //            + inner step operation + inner step attempt = 5
-        assertTrue(spans.size() >= 5, "Should have at least 5 spans for child context, got " + spans.size());
+        // Should have: invocation + child context operation + inner step operation + inner step attempt = 4
+        // (no attempt span for CONTEXT operations — they are a scoping construct)
+        assertTrue(spans.size() >= 4, "Should have at least 4 spans for child context, got " + spans.size());
 
         assertSpanExists(spans, "child");
         assertSpanExists(spans, "inner");

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -297,8 +297,8 @@ public abstract class BaseDurableOperation {
                         PluginInfoConverter.toUserFunctionEndInfo(userFunctionStartInfo, true, null));
             } catch (Throwable throwable) {
                 // Fire onUserFunctionEnd for all outcomes including suspension.
-                // For SuspendExecutionException, this allows the OTel plugin to mark the attempt span as PENDING
-                // rather than leaving it with no status at invocation cleanup.
+                // This allows plugins (e.g., OTel) to properly end the attempt span and record
+                // errors, rather than leaving orphaned spans that only get cleaned up at invocation end.
                 pluginRunner.onUserFunctionEnd(
                         PluginInfoConverter.toUserFunctionEndInfo(userFunctionStartInfo, false, throwable));
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
https://github.com/aws/aws-durable-execution-sdk-java/issues/518

### Description
Aligns the Java OTel plugin's span attributes and log enrichment with the JS and Python SDKs.

### Demo/Screenshots
<img width="690" height="366" alt="Screenshot 2026-07-06 at 3 21 22 PM" src="https://github.com/user-attachments/assets/245d10ce-19a8-404b-ba71-80cd509c8c5d" />
<img width="691" height="276" alt="Screenshot 2026-07-06 at 3 21 57 PM" src="https://github.com/user-attachments/assets/84754958-9323-4a66-b44d-5f0240079467" />
<img width="701" height="315" alt="Screenshot 2026-07-06 at 3 22 09 PM" src="https://github.com/user-attachments/assets/a90fe4f6-9d39-480f-927b-c89aa7eac349" />


### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Updated

#### Integration Tests
 
Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
