### PR TITLE
Add custom shouldComplete completion decisions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -89,6 +89,7 @@ mvn test -Dtest=CloudBasedIntegrationTest \
 | [WaitAtLeastInProcessExample](src/main/java/software/amazon/lambda/durable/examples/wait/WaitAtLeastInProcessExample.java) | Wait completes before async step (no suspension) |
 | [ManyAsyncStepsExample](src/main/java/software/amazon/lambda/durable/examples/step/ManyAsyncStepsExample.java) | Performance test with 500 concurrent async steps |
 | [SimpleMapExample](src/main/java/software/amazon/lambda/durable/examples/map/SimpleMapExample.java) | Concurrent map over a collection with durable steps |
+| [CustomShouldCompleteMapExample](src/main/java/software/amazon/lambda/durable/examples/map/CustomShouldCompleteMapExample.java) | Custom map completion with `shouldComplete` decisions |
 | [WaitForConditionExample](src/main/java/software/amazon/lambda/durable/examples/wait/WaitForConditionExample.java) | Poll a condition until met with `waitForCondition()` |
 | [OtelExample](src/main/java/software/amazon/lambda/durable/examples/general/OtelExample.java) | OpenTelemetry instrumentation with logging span export |
 | [OtelXRayStepExample](src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayStepExample.java) | Export step spans to X-Ray through the ADOT Lambda Layer |

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/map/CustomShouldCompleteMapExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/map/CustomShouldCompleteMapExample.java
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples.map;
+
+import static software.amazon.lambda.durable.config.CompletionConfig.CompletionDecision.complete;
+import static software.amazon.lambda.durable.config.CompletionConfig.CompletionDecision.continueExecution;
+import static software.amazon.lambda.durable.model.ConcurrencyCompletionStatus.CUSTOM_COMPLETION_FAILED;
+import static software.amazon.lambda.durable.model.ConcurrencyCompletionStatus.CUSTOM_COMPLETION_SUCCEEDED;
+import static software.amazon.lambda.durable.model.MapResult.MapResultItem.Status.SKIPPED;
+
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.CompletionConfig;
+import software.amazon.lambda.durable.config.MapConfig;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+
+/**
+ * Example demonstrating a custom {@code shouldComplete} condition for a map operation.
+ *
+ * <p>The operation completes successfully once enough providers respond, or completes unsuccessfully once too many
+ * providers fail. The custom decision chooses both when the map completes and which completion status the caller sees.
+ */
+public class CustomShouldCompleteMapExample
+        extends DurableHandler<CustomShouldCompleteMapExample.Input, CustomShouldCompleteMapExample.Output> {
+
+    public record Input(List<String> providers, int requiredSuccesses, int failureLimit) {
+        public Input {
+            providers = providers == null
+                    ? List.of("primary", "secondary", "bad-cache", "tertiary")
+                    : List.copyOf(providers);
+            requiredSuccesses = requiredSuccesses > 0 ? requiredSuccesses : 2;
+            failureLimit = failureLimit > 0 ? failureLimit : 2;
+        }
+    }
+
+    public record Output(
+            String completionStatus, boolean completionSucceeded, List<String> responses, int failed, int skipped) {}
+
+    @Override
+    public Output handleRequest(Input input, DurableContext context) {
+        var config = MapConfig.builder()
+                .maxConcurrency(1)
+                .completionConfig(CompletionConfig.shouldComplete(status -> {
+                    if (status.successCount() >= input.requiredSuccesses()) {
+                        return complete(CUSTOM_COMPLETION_SUCCEEDED);
+                    }
+                    if (status.failureCount() >= input.failureLimit()) {
+                        return complete(CUSTOM_COMPLETION_FAILED);
+                    }
+                    return continueExecution();
+                }))
+                .build();
+
+        var result = context.map(
+                "query-providers",
+                input.providers(),
+                String.class,
+                (provider, index, ctx) -> ctx.step(
+                        "query-" + index,
+                        String.class,
+                        stepCtx -> {
+                            if (provider.startsWith("bad-")) {
+                                throw new RuntimeException("Provider unavailable: " + provider);
+                            }
+                            return "response:" + provider;
+                        },
+                        StepConfig.builder()
+                                .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                                .build()),
+                config);
+
+        var skipped = (int)
+                result.items().stream().filter(item -> item.status() == SKIPPED).count();
+        return new Output(
+                result.completionReason().name(),
+                result.completionReason().isSucceeded(),
+                result.succeeded(),
+                result.failed().size(),
+                skipped);
+    }
+}

--- a/examples/src/test/java/software/amazon/lambda/durable/examples/map/CustomShouldCompleteMapExampleTest.java
+++ b/examples/src/test/java/software/amazon/lambda/durable/examples/map/CustomShouldCompleteMapExampleTest.java
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.examples.map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
+
+class CustomShouldCompleteMapExampleTest {
+
+    @Test
+    void testCustomShouldCompleteSucceedsAfterRequiredResponses() {
+        var handler = new CustomShouldCompleteMapExample();
+        var runner = LocalDurableTestRunner.create(CustomShouldCompleteMapExample.Input.class, handler);
+
+        var input = new CustomShouldCompleteMapExample.Input(List.of("primary", "secondary", "bad-cache"), 2, 2);
+        var result = runner.runUntilComplete(input);
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        var output = result.getResult(CustomShouldCompleteMapExample.Output.class);
+        assertEquals("CUSTOM_COMPLETION_SUCCEEDED", output.completionStatus());
+        assertTrue(output.completionSucceeded());
+        assertEquals(List.of("response:primary", "response:secondary"), output.responses());
+        assertEquals(0, output.failed());
+        assertEquals(1, output.skipped());
+    }
+
+    @Test
+    void testCustomShouldCompleteCanCompleteAsFailed() {
+        var handler = new CustomShouldCompleteMapExample();
+        var runner = LocalDurableTestRunner.create(CustomShouldCompleteMapExample.Input.class, handler);
+
+        var input = new CustomShouldCompleteMapExample.Input(List.of("bad-primary", "bad-secondary", "primary"), 2, 2);
+        var result = runner.runUntilComplete(input);
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        var output = result.getResult(CustomShouldCompleteMapExample.Output.class);
+        assertEquals("CUSTOM_COMPLETION_FAILED", output.completionStatus());
+        assertFalse(output.completionSucceeded());
+        assertTrue(output.responses().isEmpty());
+        assertEquals(2, output.failed());
+        assertEquals(1, output.skipped());
+    }
+
+    @Test
+    void testReplay() {
+        var handler = new CustomShouldCompleteMapExample();
+        var runner = LocalDurableTestRunner.create(CustomShouldCompleteMapExample.Input.class, handler);
+
+        var input = new CustomShouldCompleteMapExample.Input(List.of("primary", "secondary", "bad-cache"), 2, 2);
+        var result1 = runner.runUntilComplete(input);
+        var result2 = runner.runUntilComplete(input);
+
+        assertEquals(
+                result1.getResult(CustomShouldCompleteMapExample.Output.class),
+                result2.getResult(CustomShouldCompleteMapExample.Output.class));
+    }
+}

--- a/examples/template.yaml
+++ b/examples/template.yaml
@@ -243,6 +243,16 @@ Resources:
       Handler: "software.amazon.lambda.durable.examples.map.SimpleMapExample"
       Role: !Ref RoleArn
 
+  CustomShouldCompleteMapExampleFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Join
+        - ''
+        - - !Ref FunctionNamePrefix
+          - custom-should-complete-map-example
+      Handler: "software.amazon.lambda.durable.examples.map.CustomShouldCompleteMapExample"
+      Role: !Ref RoleArn
+
   ComplexMapExampleFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -524,6 +534,10 @@ Outputs:
   SimpleMapExampleFunction:
     Description: Simple Map Example Function ARN
     Value: !GetAtt SimpleMapExampleFunction.Arn
+
+  CustomShouldCompleteMapExampleFunction:
+    Description: Custom Should Complete Map Example Function ARN
+    Value: !GetAtt CustomShouldCompleteMapExampleFunction.Arn
 
   ComplexMapExampleFunction:
     Description: Complex Map Example Function ARN

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
@@ -376,6 +376,74 @@ class MapIntegrationTest {
     }
 
     @ParameterizedTest
+    @CsvSource({"FLAT, 2", "NESTED, 6"})
+    void testMapWithShouldComplete_earlyTermination(NestingType nestingType, int events) {
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var items = List.of("a", "b", "c", "d");
+            var config = MapConfig.builder()
+                    .maxConcurrency(1)
+                    .completionConfig(CompletionConfig.shouldComplete(status -> status.successCount() >= 2
+                            ? CompletionConfig.CompletionDecision.complete(
+                                    ConcurrencyCompletionStatus.CUSTOM_COMPLETION_SUCCEEDED)
+                            : CompletionConfig.CompletionDecision.continueExecution()))
+                    .nestingType(nestingType)
+                    .build();
+            var result = context.map(
+                    "custom-complete", items, String.class, (item, index, ctx) -> item.toUpperCase(), config);
+
+            assertEquals(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_SUCCEEDED, result.completionReason());
+            assertTrue(result.completionReason().isSucceeded());
+            assertEquals(4, result.size());
+            assertEquals("A", result.getResult(0));
+            assertEquals("B", result.getResult(1));
+            assertEquals(
+                    MapResult.MapResultItem.Status.SKIPPED, result.getItem(2).status());
+            assertEquals(
+                    MapResult.MapResultItem.Status.SKIPPED, result.getItem(3).status());
+
+            return "done";
+        });
+
+        var result = runner.runUntilComplete("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(events, result.getHistoryEvents().size());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"FLAT, 2", "NESTED, 6"})
+    void testMapWithShouldCompleteDecision_canCompleteAsFailed(NestingType nestingType, int events) {
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var items = List.of("a", "b", "c", "d");
+            var config = MapConfig.builder()
+                    .maxConcurrency(1)
+                    .completionConfig(CompletionConfig.shouldComplete(status -> status.completedCount() >= 2
+                            ? CompletionConfig.CompletionDecision.complete(
+                                    ConcurrencyCompletionStatus.CUSTOM_COMPLETION_FAILED)
+                            : CompletionConfig.CompletionDecision.continueExecution()))
+                    .nestingType(nestingType)
+                    .build();
+            var result = context.map(
+                    "custom-failed-complete", items, String.class, (item, index, ctx) -> item.toUpperCase(), config);
+
+            assertEquals(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_FAILED, result.completionReason());
+            assertFalse(result.completionReason().isSucceeded());
+            assertEquals(4, result.size());
+            assertEquals("A", result.getResult(0));
+            assertEquals("B", result.getResult(1));
+            assertEquals(
+                    MapResult.MapResultItem.Status.SKIPPED, result.getItem(2).status());
+            assertEquals(
+                    MapResult.MapResultItem.Status.SKIPPED, result.getItem(3).status());
+
+            return "done";
+        });
+
+        var result = runner.runUntilComplete("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(events, result.getHistoryEvents().size());
+    }
+
+    @ParameterizedTest
     @CsvSource({"FLAT, 2", "NESTED, 8"})
     void testMapReplayAfterInterruption_cachedResultsUsed(NestingType nestingType, int events) {
         var executionCounts = new AtomicInteger(0);

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
@@ -1092,6 +1092,82 @@ class ParallelIntegrationTest {
     }
 
     @ParameterizedTest
+    @CsvSource({"FLAT, 2", "NESTED, 6"})
+    void testParallelWithShouldComplete_earlyTermination(NestingType nestingType, int events) {
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var config = ParallelConfig.builder()
+                    .maxConcurrency(1)
+                    .completionConfig(CompletionConfig.shouldComplete(status -> status.successCount() >= 2
+                            ? CompletionConfig.CompletionDecision.complete(
+                                    ConcurrencyCompletionStatus.CUSTOM_COMPLETION_SUCCEEDED)
+                            : CompletionConfig.CompletionDecision.continueExecution()))
+                    .nestingType(nestingType)
+                    .build();
+            var futures = new ArrayList<DurableFuture<String>>();
+            ParallelDurableFuture parallel = context.parallel("custom-complete", config);
+
+            try (parallel) {
+                for (var item : List.of("a", "b", "c", "d")) {
+                    futures.add(parallel.branch("branch-" + item, String.class, ctx -> item.toUpperCase()));
+                }
+            }
+
+            var result = parallel.get();
+            assertEquals(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_SUCCEEDED, result.completionStatus());
+            assertTrue(result.completionStatus().isSucceeded());
+            assertTrue(result.size() >= 2 && result.size() <= 4);
+            assertEquals(2, result.succeeded());
+            assertEquals(0, result.failed());
+            assertEquals("A", futures.get(0).get());
+            assertEquals("B", futures.get(1).get());
+
+            return "done";
+        });
+
+        var result = runner.runUntilComplete("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(events, result.getHistoryEvents().size());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"FLAT, 2", "NESTED, 6"})
+    void testParallelWithShouldCompleteDecision_canCompleteAsFailed(NestingType nestingType, int events) {
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var config = ParallelConfig.builder()
+                    .maxConcurrency(1)
+                    .completionConfig(CompletionConfig.shouldComplete(status -> status.completedCount() >= 2
+                            ? CompletionConfig.CompletionDecision.complete(
+                                    ConcurrencyCompletionStatus.CUSTOM_COMPLETION_FAILED)
+                            : CompletionConfig.CompletionDecision.continueExecution()))
+                    .nestingType(nestingType)
+                    .build();
+            var futures = new ArrayList<DurableFuture<String>>();
+            ParallelDurableFuture parallel = context.parallel("custom-failed-complete", config);
+
+            try (parallel) {
+                for (var item : List.of("a", "b", "c", "d")) {
+                    futures.add(parallel.branch("branch-" + item, String.class, ctx -> item.toUpperCase()));
+                }
+            }
+
+            var result = parallel.get();
+            assertEquals(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_FAILED, result.completionStatus());
+            assertFalse(result.completionStatus().isSucceeded());
+            assertTrue(result.size() >= 2 && result.size() <= 4);
+            assertEquals(2, result.succeeded());
+            assertEquals(0, result.failed());
+            assertEquals("A", futures.get(0).get());
+            assertEquals("B", futures.get(1).get());
+
+            return "done";
+        });
+
+        var result = runner.runUntilComplete("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(events, result.getHistoryEvents().size());
+    }
+
+    @ParameterizedTest
     @CsvSource({"FLAT, 2", "NESTED, 8"})
     void testParallelWithMinSuccessful_earlyTermination_consistentResult(NestingType nestingType, int events) {
         var executionCount = new AtomicInteger(0);

--- a/sdk/src/main/java/software/amazon/lambda/durable/config/CompletionConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/config/CompletionConfig.java
@@ -2,14 +2,94 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.config;
 
+import java.util.Objects;
+import java.util.function.Function;
+import software.amazon.lambda.durable.model.ConcurrencyCompletionStatus;
+
 /**
  * Controls when a concurrent operation (map or parallel) completes.
  *
  * <p>Provides factory methods for common completion strategies and fine-grained control via {@code minSuccessful},
- * {@code toleratedFailureCount}, and {@code toleratedFailurePercentage}.
+ * {@code toleratedFailureCount}, {@code toleratedFailurePercentage}, and {@code shouldComplete}.
  */
 public record CompletionConfig(
-        Integer minSuccessful, Integer toleratedFailureCount, Double toleratedFailurePercentage) {
+        Integer minSuccessful,
+        Integer toleratedFailureCount,
+        Double toleratedFailurePercentage,
+        Function<CompletionStatus, CompletionDecision> shouldComplete) {
+
+    public CompletionConfig(Integer minSuccessful, Integer toleratedFailureCount, Double toleratedFailurePercentage) {
+        this(minSuccessful, toleratedFailureCount, toleratedFailurePercentage, null);
+    }
+
+    public CompletionConfig {
+        if (shouldComplete != null
+                && (minSuccessful != null || toleratedFailureCount != null || toleratedFailurePercentage != null)) {
+            throw new IllegalArgumentException(
+                    "shouldComplete is mutually exclusive with minSuccessful, toleratedFailureCount, and toleratedFailurePercentage");
+        }
+    }
+
+    /**
+     * Live completion progress for a map or parallel operation.
+     *
+     * @param successCount completed items that succeeded
+     * @param failureCount completed items that failed
+     * @param completedCount completed items, equal to successCount + failureCount
+     * @param totalCount registered items
+     * @param allItemsRegistered true once the caller has registered all items
+     */
+    public record CompletionStatus(
+            int successCount, int failureCount, int completedCount, int totalCount, boolean allItemsRegistered) {
+        public CompletionStatus(int successCount, int failureCount, int completedCount, int totalCount) {
+            this(successCount, failureCount, completedCount, totalCount, completedCount == totalCount);
+        }
+
+        public CompletionStatus {
+            if (successCount < 0 || failureCount < 0 || completedCount < 0 || totalCount < 0) {
+                throw new IllegalArgumentException("completion counts must be non-negative");
+            }
+            if (completedCount != successCount + failureCount) {
+                throw new IllegalArgumentException("completedCount must equal successCount + failureCount");
+            }
+            if (completedCount > totalCount) {
+                throw new IllegalArgumentException("completedCount cannot exceed totalCount");
+            }
+        }
+
+        public boolean allCompleted() {
+            return allItemsRegistered && completedCount == totalCount;
+        }
+    }
+
+    /**
+     * The completion decision returned by {@link #completionDecisionFunction()}.
+     *
+     * @param shouldComplete true if the concurrent operation should complete now
+     * @param completionStatus status to report when completing, or null when continuing
+     */
+    public record CompletionDecision(boolean shouldComplete, ConcurrencyCompletionStatus completionStatus) {
+        public CompletionDecision {
+            if (shouldComplete && completionStatus == null) {
+                throw new IllegalArgumentException("completionStatus is required when shouldComplete is true");
+            }
+            if (!shouldComplete && completionStatus != null) {
+                throw new IllegalArgumentException("completionStatus must be null when shouldComplete is false");
+            }
+        }
+
+        public static CompletionDecision complete(ConcurrencyCompletionStatus completionStatus) {
+            return new CompletionDecision(true, completionStatus);
+        }
+
+        public static CompletionDecision continueExecution() {
+            return new CompletionDecision(false, null);
+        }
+
+        public boolean isSucceeded() {
+            return shouldComplete && completionStatus.isSucceeded();
+        }
+    }
 
     /** All items must succeed. Zero failures tolerated. */
     public static CompletionConfig allSuccessful() {
@@ -49,5 +129,65 @@ public record CompletionConfig(
                     "toleratedFailurePercentage must be between 0.0 and 1.0, got: " + percentage);
         }
         return new CompletionConfig(null, null, percentage);
+    }
+
+    /**
+     * Complete when the function returns a completing decision.
+     *
+     * <p>The decision controls whether the operation completes, the reported completion status, and whether that status
+     * represents success.
+     */
+    public static CompletionConfig shouldComplete(Function<CompletionStatus, CompletionDecision> shouldComplete) {
+        Objects.requireNonNull(shouldComplete, "shouldComplete cannot be null");
+        return new CompletionConfig(null, null, null, shouldComplete);
+    }
+
+    /**
+     * Returns the completion decision function. Legacy threshold fields are converted into this function so concurrent
+     * operations only need one completion mechanism.
+     */
+    public Function<CompletionStatus, CompletionDecision> completionDecisionFunction() {
+        return shouldComplete != null ? shouldComplete : thresholdBasedShouldComplete();
+    }
+
+    /** @return true when a custom completion function is configured. */
+    public boolean hasCustomShouldComplete() {
+        return shouldComplete != null;
+    }
+
+    private Function<CompletionStatus, CompletionDecision> thresholdBasedShouldComplete() {
+        return status -> {
+            if (minSuccessful != null) {
+                if (status.successCount() >= minSuccessful) {
+                    return CompletionDecision.complete(ConcurrencyCompletionStatus.MIN_SUCCESSFUL_REACHED);
+                }
+                if (status.allItemsRegistered() && status.totalCount() < minSuccessful) {
+                    throw new IllegalStateException("minSuccessful (" + minSuccessful
+                            + ") exceeds the number of registered items (" + status.totalCount() + ")");
+                }
+            }
+
+            var toleratedFailures = toleratedFailureLimit(status.totalCount());
+            if (toleratedFailures != null && status.failureCount() > toleratedFailures) {
+                return CompletionDecision.complete(ConcurrencyCompletionStatus.FAILURE_TOLERANCE_EXCEEDED);
+            }
+
+            if (status.allCompleted()) {
+                return CompletionDecision.complete(ConcurrencyCompletionStatus.ALL_COMPLETED);
+            }
+
+            return CompletionDecision.continueExecution();
+        };
+    }
+
+    private Integer toleratedFailureLimit(int totalCount) {
+        if (toleratedFailureCount == null && toleratedFailurePercentage == null) {
+            return null;
+        }
+        var count = toleratedFailureCount != null ? toleratedFailureCount : Integer.MAX_VALUE;
+        var percentageCount = toleratedFailurePercentage != null
+                ? (int) Math.floor(totalCount * toleratedFailurePercentage)
+                : Integer.MAX_VALUE;
+        return Math.min(count, percentageCount);
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/config/ParallelConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/config/ParallelConfig.java
@@ -81,7 +81,9 @@ public class ParallelConfig {
          * @return this builder for method chaining
          */
         public Builder completionConfig(CompletionConfig completionConfig) {
-            if (completionConfig != null && completionConfig.toleratedFailurePercentage() != null) {
+            if (completionConfig != null
+                    && !completionConfig.hasCustomShouldComplete()
+                    && completionConfig.toleratedFailurePercentage() != null) {
                 throw new IllegalArgumentException("ParallelConfig does not support toleratedFailurePercentage");
             }
             this.completionConfig = completionConfig;

--- a/sdk/src/main/java/software/amazon/lambda/durable/model/ConcurrencyCompletionStatus.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/model/ConcurrencyCompletionStatus.java
@@ -3,9 +3,17 @@
 package software.amazon.lambda.durable.model;
 
 public enum ConcurrencyCompletionStatus {
-    ALL_COMPLETED,
-    MIN_SUCCESSFUL_REACHED,
-    FAILURE_TOLERANCE_EXCEEDED;
+    ALL_COMPLETED(true),
+    MIN_SUCCESSFUL_REACHED(true),
+    FAILURE_TOLERANCE_EXCEEDED(false),
+    CUSTOM_COMPLETION_SUCCEEDED(true),
+    CUSTOM_COMPLETION_FAILED(false);
+
+    private final boolean succeeded;
+
+    ConcurrencyCompletionStatus(boolean succeeded) {
+        this.succeeded = succeeded;
+    }
 
     @Override
     public String toString() {
@@ -13,6 +21,6 @@ public enum ConcurrencyCompletionStatus {
     }
 
     public boolean isSucceeded() {
-        return this == ALL_COMPLETED || this == MIN_SUCCESSFUL_REACHED;
+        return succeeded;
     }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ConcurrencyOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ConcurrencyOperation.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -18,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.CompletionConfig;
 import software.amazon.lambda.durable.config.NestingType;
 import software.amazon.lambda.durable.config.RunInChildContextConfig;
 import software.amazon.lambda.durable.context.DurableContextImpl;
@@ -25,7 +27,6 @@ import software.amazon.lambda.durable.exception.UnrecoverableDurableExecutionExc
 import software.amazon.lambda.durable.execution.OperationIdGenerator;
 import software.amazon.lambda.durable.execution.SuspendExecutionException;
 import software.amazon.lambda.durable.execution.ThreadType;
-import software.amazon.lambda.durable.model.ConcurrencyCompletionStatus;
 import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
 import software.amazon.lambda.durable.serde.SerDes;
@@ -42,8 +43,7 @@ import software.amazon.lambda.durable.util.ExceptionHelper;
  * <ul>
  *   <li>Does NOT register its own thread — child context threads handle all suspension
  *   <li>Uses a pending queue + running counter for concurrency control
- *   <li>Completion is determined by subclass-specific logic via abstract {@code canComplete()} and
- *       {@code validateItemCount()}
+ *   <li>Completion is determined by {@link CompletionConfig#completionDecisionFunction()}
  *   <li>When a child suspends, the running count is NOT decremented
  * </ul>
  *
@@ -51,13 +51,12 @@ import software.amazon.lambda.durable.util.ExceptionHelper;
  */
 public abstract class ConcurrencyOperation<T> extends SerializableDurableOperation<T> {
 
-    protected record ExpectedCompletionStatus(int completed, ConcurrencyCompletionStatus completionStatus) {}
+    protected record ExpectedCompletionStatus(int completed, CompletionConfig.CompletionDecision completionDecision) {}
 
     private static final Logger logger = LoggerFactory.getLogger(ConcurrencyOperation.class);
 
     private final int maxConcurrency;
-    private final Integer minSuccessful;
-    private final Integer toleratedFailureCount;
+    private final Function<CompletionConfig.CompletionStatus, CompletionConfig.CompletionDecision> shouldComplete;
     private final OperationIdGenerator operationIdGenerator;
     private final DurableContextImpl rootContext;
     private final NestingType nestingType;
@@ -80,13 +79,11 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
             SerDes resultSerDes,
             DurableContextImpl durableContext,
             int maxConcurrency,
-            Integer minSuccessful,
-            Integer toleratedFailureCount,
+            Function<CompletionConfig.CompletionStatus, CompletionConfig.CompletionDecision> shouldComplete,
             NestingType nestingType) {
         super(operationIdentifier, resultTypeToken, resultSerDes, durableContext);
         this.maxConcurrency = maxConcurrency;
-        this.minSuccessful = minSuccessful;
-        this.toleratedFailureCount = toleratedFailureCount;
+        this.shouldComplete = Objects.requireNonNull(shouldComplete, "shouldComplete cannot be null");
         this.operationIdGenerator = new OperationIdGenerator(getOperationId());
         // root context of the concurrency operation is always non-virtual
         this.rootContext = durableContext.createChildContext(getOperationId(), getName(), false);
@@ -127,7 +124,7 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
     }
 
     /** Called when the concurrency operation completes. Subclasses define checkpointing behavior. */
-    protected abstract void handleCompletion(ConcurrencyCompletionStatus concurrencyCompletionStatus);
+    protected abstract void handleCompletion(CompletionConfig.CompletionDecision completionDecision);
 
     // ========== Concurrency control ==========
 
@@ -190,10 +187,9 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
                     if (isOperationCompleted()) {
                         return;
                     }
-                    var completionStatus =
-                            canComplete(succeededCount, failedCount, runningChildren, expectedCompletionStatus);
-                    if (completionStatus != null) {
-                        handleCompletion(completionStatus);
+                    var completionDecision = canComplete(succeededCount, failedCount, expectedCompletionStatus);
+                    if (completionDecision != null) {
+                        handleCompletion(completionDecision);
                         return;
                     }
 
@@ -257,8 +253,8 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
             if (isOperationCompleted()) {
                 return null;
             }
-            var completionStatus = canComplete(succeededCount, failedCount, runningChildren, expectedCompletionStatus);
-            if (completionStatus != null) {
+            var completionDecision = canComplete(succeededCount, failedCount, expectedCompletionStatus);
+            if (completionDecision != null) {
                 return null;
             }
             ArrayList<CompletableFuture<BaseDurableOperation>> futures;
@@ -317,41 +313,35 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
      *
      * @return the completion status if the operation is complete, or null if it should continue
      */
-    private ConcurrencyCompletionStatus canComplete(
+    private CompletionConfig.CompletionDecision canComplete(
             AtomicInteger succeededCount,
             AtomicInteger failedCount,
-            Set<BaseDurableOperation> runningChildren,
             ExpectedCompletionStatus expectedCompletionStatus) {
         int succeeded = succeededCount.get();
         int failed = failedCount.get();
 
         if (expectedCompletionStatus != null) {
             if (succeeded + failed >= expectedCompletionStatus.completed) {
-                return expectedCompletionStatus.completionStatus;
+                return expectedCompletionStatus.completionDecision;
             }
 
             // if expected completion status is not null, we always complete all the children previously completed
             return null;
         }
 
-        // If we've met the minimum successful count, we're done
-        if (minSuccessful != null && succeeded >= minSuccessful) {
-            return ConcurrencyCompletionStatus.MIN_SUCCESSFUL_REACHED;
-        }
+        var decision = Objects.requireNonNull(
+                shouldComplete.apply(completionStatus(succeeded, failed)),
+                "shouldComplete must return a completion decision");
+        return decision.shouldComplete() ? decision : null;
+    }
 
-        // If we've exceeded the failure tolerance, we're done
-        if (toleratedFailureCount != null && failed > toleratedFailureCount) {
-            return ConcurrencyCompletionStatus.FAILURE_TOLERANCE_EXCEEDED;
-        }
+    private CompletionConfig.CompletionStatus completionStatus(int succeeded, int failed) {
+        return new CompletionConfig.CompletionStatus(
+                succeeded, failed, succeeded + failed, branches.size(), allItemsRegistered());
+    }
 
-        // All items finished — complete
-        // This condition relies on isJoined, so the consumer will wake up and check this again when
-        // isJoined is set to true.
-        if (isJoined.get() && pendingQueue.isEmpty() && runningChildren.isEmpty()) {
-            return ConcurrencyCompletionStatus.ALL_COMPLETED;
-        }
-
-        return null;
+    private boolean allItemsRegistered() {
+        return isJoined.get();
     }
 
     /**
@@ -359,10 +349,6 @@ public abstract class ConcurrencyOperation<T> extends SerializableDurableOperati
      * zero-branch case, then delegates to {@code waitForOperationCompletion()} from BaseDurableOperation.
      */
     protected void join() {
-        if (minSuccessful != null && minSuccessful > branches.size()) {
-            throw new IllegalStateException("minSuccessful (" + minSuccessful
-                    + ") exceeds the number of registered items (" + branches.size() + ")");
-        }
         isJoined.set(true);
 
         // Notify the consumer thread this concurrency operation is joined. Consumer thread need to check the

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
@@ -17,7 +17,6 @@ import software.amazon.lambda.durable.config.MapConfig;
 import software.amazon.lambda.durable.context.DurableContextImpl;
 import software.amazon.lambda.durable.exception.UnrecoverableDurableExecutionException;
 import software.amazon.lambda.durable.execution.SuspendExecutionException;
-import software.amazon.lambda.durable.model.ConcurrencyCompletionStatus;
 import software.amazon.lambda.durable.model.MapResult;
 import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
@@ -58,10 +57,10 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                 config.serDes(),
                 durableContext,
                 config.maxConcurrency(),
-                config.completionConfig().minSuccessful(),
-                getToleratedFailureCount(config.completionConfig(), items.size()),
+                config.completionConfig().completionDecisionFunction(),
                 config.nestingType());
-        if (config.completionConfig().minSuccessful() != null
+        if (!config.completionConfig().hasCustomShouldComplete()
+                && config.completionConfig().minSuccessful() != null
                 && config.completionConfig().minSuccessful() > items.size()) {
             throw new IllegalArgumentException("minSuccessful cannot be greater than total items: "
                     + config.completionConfig().minSuccessful() + " > " + items.size());
@@ -96,25 +95,6 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                     OperationSubType.MAP_ITERATION,
                     skip);
         }
-    }
-
-    private static Integer getToleratedFailureCount(CompletionConfig completionConfig, int totalItems) {
-        if (completionConfig == null
-                || (completionConfig.toleratedFailureCount() == null
-                        && completionConfig.toleratedFailurePercentage() == null)) {
-            // neither toleratedFailureCount nor toleratedFailurePercentage is specified.
-            return null;
-        }
-        int toleratedFailureCount = completionConfig.toleratedFailureCount() != null
-                ? completionConfig.toleratedFailureCount()
-                : Integer.MAX_VALUE;
-
-        // convert percentage to count
-        int toleratedFailureCountFromPercentage = completionConfig.toleratedFailurePercentage() != null
-                ? (int) Math.floor(totalItems * completionConfig.toleratedFailurePercentage())
-                : Integer.MAX_VALUE;
-        // minimum of two if both count and percentage is specified
-        return Math.min(toleratedFailureCount, toleratedFailureCountFromPercentage);
     }
 
     @Override
@@ -155,7 +135,7 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                     var expected = new ExpectedCompletionStatus(
                             deserializedResult.succeeded().size()
                                     + deserializedResult.failed().size(),
-                            deserializedResult.completionReason());
+                            CompletionConfig.CompletionDecision.complete(deserializedResult.completionReason()));
                     executeItems(expected);
                 } else {
                     // Small result: MapResult is in the payload, skip child replay
@@ -176,8 +156,8 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
     }
 
     @Override
-    protected void handleCompletion(ConcurrencyCompletionStatus concurrencyCompletionStatus) {
-        this.cachedResult = constructMapResult(concurrencyCompletionStatus);
+    protected void handleCompletion(CompletionConfig.CompletionDecision completionDecision) {
+        this.cachedResult = constructMapResult(completionDecision);
         var serializedResult = serializeAndDeserializeResult(cachedResult);
         this.cachedResult = serializedResult.deserialized();
         var serializedBytes = serializedResult.serialized().getBytes(StandardCharsets.UTF_8);
@@ -208,7 +188,7 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
     }
 
     @SuppressWarnings("unchecked")
-    private MapResult<O> constructMapResult(ConcurrencyCompletionStatus concurrencyCompletionStatus) {
+    private MapResult<O> constructMapResult(CompletionConfig.CompletionDecision completionDecision) {
         var children = getBranches();
         var resultItems = new ArrayList<MapResult.MapResultItem<O>>(Collections.nCopies(items.size(), null));
 
@@ -234,7 +214,7 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
                 }
             }
         }
-        return new MapResult<>(resultItems, concurrencyCompletionStatus);
+        return new MapResult<>(resultItems, completionDecision.completionStatus());
     }
 
     @Override

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
@@ -12,11 +12,11 @@ import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableFuture;
 import software.amazon.lambda.durable.ParallelDurableFuture;
 import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.CompletionConfig;
 import software.amazon.lambda.durable.config.ParallelBranchConfig;
 import software.amazon.lambda.durable.config.ParallelConfig;
 import software.amazon.lambda.durable.context.DurableContextImpl;
 import software.amazon.lambda.durable.execution.ExecutionManager;
-import software.amazon.lambda.durable.model.ConcurrencyCompletionStatus;
 import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
 import software.amazon.lambda.durable.model.ParallelResult;
@@ -60,13 +60,12 @@ public class ParallelOperation extends ConcurrencyOperation<ParallelResult> impl
                 resultSerDes,
                 durableContext,
                 config.maxConcurrency(),
-                config.completionConfig().minSuccessful(),
-                config.completionConfig().toleratedFailureCount(),
+                config.completionConfig().completionDecisionFunction(),
                 config.nestingType());
     }
 
     @Override
-    protected void handleCompletion(ConcurrencyCompletionStatus concurrencyCompletionStatus) {
+    protected void handleCompletion(CompletionConfig.CompletionDecision completionDecision) {
 
         var items = List.copyOf(getBranches());
         var statuses = items.stream().map(this::getParallelItemStatus).toList();
@@ -77,7 +76,12 @@ public class ParallelOperation extends ConcurrencyOperation<ParallelResult> impl
                 statuses.stream().filter(s -> s == ParallelResult.Status.FAILED).count());
         int skippedCount = items.size() - succeededCount - failedCount;
         cachedResult = new ParallelResult(
-                items.size(), succeededCount, failedCount, skippedCount, concurrencyCompletionStatus, statuses);
+                items.size(),
+                succeededCount,
+                failedCount,
+                skippedCount,
+                completionDecision.completionStatus(),
+                statuses);
         var serializedResult = serializeAndDeserializeResult(cachedResult);
         cachedResult = serializedResult.deserialized();
 
@@ -135,7 +139,8 @@ public class ParallelOperation extends ConcurrencyOperation<ParallelResult> impl
                     : null;
             if (partialResult != null) {
                 var expected = new ExpectedCompletionStatus(
-                        partialResult.succeeded() + partialResult.failed(), partialResult.completionStatus());
+                        partialResult.succeeded() + partialResult.failed(),
+                        CompletionConfig.CompletionDecision.complete(partialResult.completionStatus()));
                 executeItems(expected);
                 return;
             }

--- a/sdk/src/test/java/software/amazon/lambda/durable/config/CompletionConfigTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/config/CompletionConfigTest.java
@@ -4,7 +4,9 @@ package software.amazon.lambda.durable.config;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.model.ConcurrencyCompletionStatus;
 
 class CompletionConfigTest {
 
@@ -15,6 +17,7 @@ class CompletionConfigTest {
         assertNull(config.minSuccessful());
         assertEquals(0, config.toleratedFailureCount());
         assertNull(config.toleratedFailurePercentage());
+        assertFalse(config.hasCustomShouldComplete());
     }
 
     @Test
@@ -24,6 +27,7 @@ class CompletionConfigTest {
         assertNull(config.minSuccessful());
         assertNull(config.toleratedFailureCount());
         assertNull(config.toleratedFailurePercentage());
+        assertFalse(config.hasCustomShouldComplete());
     }
 
     @Test
@@ -33,6 +37,7 @@ class CompletionConfigTest {
         assertEquals(1, config.minSuccessful());
         assertNull(config.toleratedFailureCount());
         assertNull(config.toleratedFailurePercentage());
+        assertFalse(config.hasCustomShouldComplete());
     }
 
     @Test
@@ -104,5 +109,209 @@ class CompletionConfigTest {
     void toleratedFailureCount_withZero_shouldPass() {
         var config = CompletionConfig.toleratedFailureCount(0);
         assertEquals(0, config.toleratedFailureCount());
+    }
+
+    @Test
+    void allCompleted_shouldCompleteReturnsAllCompletedDecision() {
+        var config = CompletionConfig.allCompleted();
+
+        var continueDecision =
+                config.completionDecisionFunction().apply(new CompletionConfig.CompletionStatus(1, 0, 1, 2, true));
+        var completeDecision =
+                config.completionDecisionFunction().apply(new CompletionConfig.CompletionStatus(1, 1, 2, 2, true));
+
+        assertFalse(continueDecision.shouldComplete());
+        assertTrue(completeDecision.shouldComplete());
+        assertTrue(completeDecision.isSucceeded());
+        assertEquals(ConcurrencyCompletionStatus.ALL_COMPLETED, completeDecision.completionStatus());
+    }
+
+    @Test
+    void minSuccessful_shouldCompleteReturnsMinSuccessfulDecision() {
+        var config = CompletionConfig.minSuccessful(2);
+
+        var decision =
+                config.completionDecisionFunction().apply(new CompletionConfig.CompletionStatus(2, 1, 3, 4, false));
+
+        assertTrue(decision.shouldComplete());
+        assertTrue(decision.isSucceeded());
+        assertEquals(ConcurrencyCompletionStatus.MIN_SUCCESSFUL_REACHED, decision.completionStatus());
+    }
+
+    @Test
+    void allSuccessful_shouldCompleteReturnsFailureToleranceExceededDecision() {
+        var config = CompletionConfig.allSuccessful();
+
+        var decision =
+                config.completionDecisionFunction().apply(new CompletionConfig.CompletionStatus(1, 1, 2, 3, false));
+
+        assertTrue(decision.shouldComplete());
+        assertFalse(decision.isSucceeded());
+        assertEquals(ConcurrencyCompletionStatus.FAILURE_TOLERANCE_EXCEEDED, decision.completionStatus());
+    }
+
+    @Test
+    void toleratedFailurePercentage_shouldCompleteUsesTotalCount() {
+        var config = CompletionConfig.toleratedFailurePercentage(0.25);
+
+        var continueDecision =
+                config.completionDecisionFunction().apply(new CompletionConfig.CompletionStatus(2, 1, 3, 4, false));
+        var completeDecision =
+                config.completionDecisionFunction().apply(new CompletionConfig.CompletionStatus(2, 2, 4, 4, false));
+
+        assertFalse(continueDecision.shouldComplete());
+        assertTrue(completeDecision.shouldComplete());
+        assertEquals(ConcurrencyCompletionStatus.FAILURE_TOLERANCE_EXCEEDED, completeDecision.completionStatus());
+    }
+
+    @Test
+    void minSuccessful_tooFewRegisteredItems_shouldThrow() {
+        var config = CompletionConfig.minSuccessful(3);
+
+        var exception = assertThrows(IllegalStateException.class, () -> config.completionDecisionFunction()
+                .apply(new CompletionConfig.CompletionStatus(2, 0, 2, 2, true)));
+
+        assertEquals("minSuccessful (3) exceeds the number of registered items (2)", exception.getMessage());
+    }
+
+    @Test
+    void shouldComplete_setsCustomCompletionDecisionFunction() {
+        var config = CompletionConfig.shouldComplete(status -> status.successCount() >= 2
+                ? CompletionConfig.CompletionDecision.complete(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_SUCCEEDED)
+                : CompletionConfig.CompletionDecision.continueExecution());
+
+        assertNull(config.minSuccessful());
+        assertNull(config.toleratedFailureCount());
+        assertNull(config.toleratedFailurePercentage());
+        assertNotNull(config.shouldComplete());
+        assertTrue(config.hasCustomShouldComplete());
+
+        var completeDecision =
+                config.completionDecisionFunction().apply(new CompletionConfig.CompletionStatus(2, 0, 2, 3, true));
+        assertTrue(completeDecision.shouldComplete());
+        assertTrue(completeDecision.isSucceeded());
+        assertEquals(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_SUCCEEDED, completeDecision.completionStatus());
+
+        var continueDecision =
+                config.completionDecisionFunction().apply(new CompletionConfig.CompletionStatus(1, 0, 1, 3, true));
+        assertFalse(continueDecision.shouldComplete());
+    }
+
+    @Test
+    void shouldComplete_completionDecisionFunctionUsesCustomDecisionWhenAllItemsCompleted() {
+        var config = CompletionConfig.shouldComplete(status -> CompletionConfig.CompletionDecision.continueExecution());
+
+        var decision =
+                config.completionDecisionFunction().apply(new CompletionConfig.CompletionStatus(1, 1, 2, 2, true));
+
+        assertFalse(decision.shouldComplete());
+    }
+
+    @Test
+    void shouldComplete_canCompleteWithBuiltInFailureStatus() {
+        var config = CompletionConfig.shouldComplete(status -> status.failureCount() > 0
+                ? CompletionConfig.CompletionDecision.complete(ConcurrencyCompletionStatus.FAILURE_TOLERANCE_EXCEEDED)
+                : CompletionConfig.CompletionDecision.continueExecution());
+
+        var decision =
+                config.completionDecisionFunction().apply(new CompletionConfig.CompletionStatus(0, 1, 1, 3, true));
+
+        assertTrue(config.hasCustomShouldComplete());
+        assertTrue(decision.shouldComplete());
+        assertFalse(decision.isSucceeded());
+        assertEquals(ConcurrencyCompletionStatus.FAILURE_TOLERANCE_EXCEEDED, decision.completionStatus());
+    }
+
+    @Test
+    void shouldComplete_canMarkCustomCompletionAsFailed() {
+        var config = CompletionConfig.shouldComplete(status -> status.completedCount() >= 2
+                ? CompletionConfig.CompletionDecision.complete(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_FAILED)
+                : CompletionConfig.CompletionDecision.continueExecution());
+
+        var decision =
+                config.completionDecisionFunction().apply(new CompletionConfig.CompletionStatus(1, 1, 2, 3, true));
+
+        assertTrue(decision.shouldComplete());
+        assertFalse(decision.isSucceeded());
+        assertEquals(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_FAILED, decision.completionStatus());
+    }
+
+    @Test
+    void shouldComplete_withNull_shouldThrow() {
+        var exception = assertThrows(
+                NullPointerException.class,
+                () -> CompletionConfig.shouldComplete(
+                        (Function<CompletionConfig.CompletionStatus, CompletionConfig.CompletionDecision>) null));
+        assertEquals("shouldComplete cannot be null", exception.getMessage());
+    }
+
+    @Test
+    void shouldComplete_withNullDecision_defersNullCheckToCaller() {
+        var config = CompletionConfig.shouldComplete(status -> null);
+
+        var decision =
+                config.completionDecisionFunction().apply(new CompletionConfig.CompletionStatus(0, 0, 0, 1, false));
+
+        assertNull(decision);
+    }
+
+    @Test
+    void completionStatus_fourArgumentConstructorMarksCompletedItemsAsAllRegistered() {
+        var status = new CompletionConfig.CompletionStatus(1, 1, 2, 2);
+
+        assertTrue(status.allItemsRegistered());
+        assertTrue(status.allCompleted());
+    }
+
+    @Test
+    void completionDecision_withStatusWhenContinuing_shouldThrow() {
+        var exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> new CompletionConfig.CompletionDecision(false, ConcurrencyCompletionStatus.ALL_COMPLETED));
+        assertEquals("completionStatus must be null when shouldComplete is false", exception.getMessage());
+    }
+
+    @Test
+    void completionDecision_withoutStatusWhenCompleting_shouldThrow() {
+        var exception =
+                assertThrows(IllegalArgumentException.class, () -> new CompletionConfig.CompletionDecision(true, null));
+        assertEquals("completionStatus is required when shouldComplete is true", exception.getMessage());
+    }
+
+    @Test
+    void completionDecision_usesCompletionStatusSuccessFlag() {
+        var decision =
+                CompletionConfig.CompletionDecision.complete(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_FAILED);
+
+        assertTrue(decision.shouldComplete());
+        assertFalse(decision.isSucceeded());
+    }
+
+    @Test
+    void hasCustomShouldComplete_usesStoredField() {
+        var config = CompletionConfig.shouldComplete(status ->
+                CompletionConfig.CompletionDecision.complete(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_SUCCEEDED));
+        var equalConfig = CompletionConfig.allCompleted();
+
+        assertNotEquals(config, equalConfig);
+        assertNotNull(config.shouldComplete());
+        assertTrue(config.hasCustomShouldComplete());
+        assertFalse(equalConfig.hasCustomShouldComplete());
+    }
+
+    @Test
+    void constructor_shouldCompleteWithThresholdFields_shouldThrow() {
+        var exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> new CompletionConfig(
+                        1,
+                        null,
+                        null,
+                        status -> CompletionConfig.CompletionDecision.complete(
+                                ConcurrencyCompletionStatus.CUSTOM_COMPLETION_SUCCEEDED)));
+
+        assertEquals(
+                "shouldComplete is mutually exclusive with minSuccessful, toleratedFailureCount, and toleratedFailurePercentage",
+                exception.getMessage());
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/config/ParallelConfigTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/config/ParallelConfigTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.model.ConcurrencyCompletionStatus;
 
 class ParallelConfigTest {
 
@@ -44,5 +45,16 @@ class ParallelConfigTest {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> ParallelConfig.builder().maxConcurrency(0).build());
+    }
+
+    @Test
+    void customShouldCompleteAllowed() {
+        var completionConfig = CompletionConfig.shouldComplete(status -> status.completedCount() >= 1
+                ? CompletionConfig.CompletionDecision.complete(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_SUCCEEDED)
+                : CompletionConfig.CompletionDecision.continueExecution());
+
+        var config = ParallelConfig.builder().completionConfig(completionConfig).build();
+
+        assertEquals(completionConfig, config.completionConfig());
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/model/ConcurrencyCompletionStatusTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/model/ConcurrencyCompletionStatusTest.java
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ConcurrencyCompletionStatusTest {
+
+    @Test
+    void isSucceeded_returnsFlagFromStatus() {
+        assertTrue(ConcurrencyCompletionStatus.ALL_COMPLETED.isSucceeded());
+        assertTrue(ConcurrencyCompletionStatus.MIN_SUCCESSFUL_REACHED.isSucceeded());
+        assertFalse(ConcurrencyCompletionStatus.FAILURE_TOLERANCE_EXCEEDED.isSucceeded());
+        assertTrue(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_SUCCEEDED.isSucceeded());
+        assertFalse(ConcurrencyCompletionStatus.CUSTOM_COMPLETION_FAILED.isSucceeded());
+    }
+}

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/ConcurrencyOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/ConcurrencyOperationTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -28,7 +29,6 @@ import software.amazon.lambda.durable.execution.ExecutionManager;
 import software.amazon.lambda.durable.execution.OperationIdGenerator;
 import software.amazon.lambda.durable.execution.ThreadContext;
 import software.amazon.lambda.durable.execution.ThreadType;
-import software.amazon.lambda.durable.model.ConcurrencyCompletionStatus;
 import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
@@ -98,6 +98,29 @@ class ConcurrencyOperationTest {
         Field field = ConcurrencyOperation.class.getDeclaredField("operationIdGenerator");
         field.setAccessible(true);
         field.set(op, mockGenerator);
+    }
+
+    private CompletionConfig.CompletionDecision canComplete(
+            ConcurrencyOperation<?> op, int succeededCount, int failedCount) throws Exception {
+        var method = ConcurrencyOperation.class.getDeclaredMethod(
+                "canComplete",
+                AtomicInteger.class,
+                AtomicInteger.class,
+                ConcurrencyOperation.ExpectedCompletionStatus.class);
+        method.setAccessible(true);
+        try {
+            return (CompletionConfig.CompletionDecision)
+                    method.invoke(op, new AtomicInteger(succeededCount), new AtomicInteger(failedCount), null);
+        } catch (InvocationTargetException e) {
+            var cause = e.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw e;
+        }
     }
 
     // ===== Callback cycle tests =====
@@ -252,6 +275,15 @@ class ConcurrencyOperationTest {
         assertFalse(functionCalled.get(), "Function should not be called during SUCCEEDED replay");
     }
 
+    @Test
+    void canComplete_whenShouldCompleteReturnsNull_shouldThrow() throws Exception {
+        var op = createOperation(CompletionConfig.shouldComplete(status -> null));
+
+        var exception = assertThrows(NullPointerException.class, () -> canComplete(op, 0, 0));
+
+        assertEquals("shouldComplete must return a completion decision", exception.getMessage());
+    }
+
     // ===== Test subclass =====
 
     static class TestConcurrencyOperation extends ConcurrencyOperation<Void> {
@@ -274,13 +306,12 @@ class ConcurrencyOperationTest {
                     resultSerDes,
                     durableContext,
                     maxConcurrency,
-                    completionConfig.minSuccessful(),
-                    completionConfig.toleratedFailureCount(),
+                    completionConfig.completionDecisionFunction(),
                     NestingType.NESTED);
         }
 
         @Override
-        protected void handleCompletion(ConcurrencyCompletionStatus completionStatus) {
+        protected void handleCompletion(CompletionConfig.CompletionDecision completionDecision) {
             successHandled = true;
             // Simulate the checkpoint ACK that a real subclass would receive after sendOperationUpdate.
             // This drives completionFuture to completion so waitForOperationCompletion() unblocks.


### PR DESCRIPTION
## Summary
- Refactor map/parallel completion so every completion path is evaluated through `CompletionConfig.shouldComplete` as a `CompletionDecision`.
- Keep existing public completion configs (`allCompleted`, `allSuccessful`, `firstSuccessful`, `minSuccessful`, tolerated failure configs) by building them on top of the same decision function.
- Add custom completion statuses with explicit success semantics: `CUSTOM_COMPLETION_SUCCEEDED` and `CUSTOM_COMPLETION_FAILED`.
- Add `CustomShouldCompleteMapExample` with local tests plus README and SAM template wiring.

## Difference from the JS proposal
This is based on the same feature request as [aws-durable-execution-sdk-js#701](https://github.com/aws/aws-durable-execution-sdk-js/issues/701), but the Java API is intentionally a bit stricter and more explicit:

- The JS issue proposes `shouldComplete: (status) => boolean`; Java uses `Function<CompletionStatus, CompletionDecision>` so the custom condition decides both whether to complete and which `ConcurrencyCompletionStatus` to report.
- The JS proposal says `shouldComplete` takes precedence and threshold fields are ignored. Java makes `shouldComplete` mutually exclusive with `minSuccessful`, `toleratedFailureCount`, and `toleratedFailurePercentage` so ambiguous configs fail fast.
- The JS proposal introduces a single informational `CUSTOM_COMPLETION` reason and derives success/failure from item outcomes. Java does not add generic `CUSTOM_COMPLETION`; custom completion must choose `CUSTOM_COMPLETION_SUCCEEDED` or `CUSTOM_COMPLETION_FAILED`, and success is carried by the enum via `completionStatus.isSucceeded()`.
- Java removes the separate `succeeded` flag from `CompletionDecision`; completed decisions must always provide a `ConcurrencyCompletionStatus`, and the status itself owns success semantics.
- Java fully relies on the custom `shouldComplete` result when custom completion is configured. It does not automatically convert all-items-completed into `ALL_COMPLETED`; callers that want an all-completed fallback can return that decision from their callback using `status.allCompleted()`.
- Java exposes `allItemsRegistered` on `CompletionStatus`, in addition to the count fields, so callbacks can distinguish “all currently registered items are done” from “the caller has finished registering items”.
- Java validates null custom decisions at the concurrency operation evaluation point (`canComplete`) instead of wrapping the user callback inside `CompletionConfig`.

## Testing
- `mvn spotless:apply`
- `mvn -pl examples -am -Dtest=CustomShouldCompleteMapExampleTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl sdk -Dtest=CompletionConfigTest,ConcurrencyCompletionStatusTest,MapResultTest,ParallelResultTest,ParallelConfigTest,ConcurrencyOperationTest,ParallelOperationTest test`
- `mvn -pl sdk,sdk-integration-tests -Dtest=MapIntegrationTest,ParallelIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`
- `git diff --cached --check`