### PR TITLE
fix(otel): Use operation startTimestamp for continuation spans

### DIFF
--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPlugin.java
@@ -309,6 +309,10 @@ public class OtelPlugin implements DurableExecutionPlugin {
                     .setAttribute(DURABLE_OPERATION_ID, info.id())
                     .setAttribute(DURABLE_OPERATION_TYPE, info.type());
 
+            if (info.startTimestamp() != null) {
+                spanBuilder.setStartTimestamp(info.startTimestamp());
+            }
+
             if (info.name() != null) {
                 spanBuilder.setAttribute(DURABLE_OPERATION_NAME, info.name());
             }

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OtelPluginTest.java
@@ -507,6 +507,30 @@ class OtelPluginTest {
     }
 
     @Test
+    void operationEnd_withoutMatchingStart_usesOperationStartTimestamp() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+
+        var operationStart = Instant.parse("2026-01-15T08:30:00Z");
+        var operationEnd = Instant.parse("2026-01-15T09:00:00Z");
+
+        // onOperationEnd without a prior onOperationStart — continuation span
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-wait-1", "my-wait", "WAIT", "Wait", null, operationStart, operationEnd, "SUCCEEDED", false, null));
+
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var continuationSpan = spanExporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().contains("wait"))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(
+                operationStart.toEpochMilli(),
+                continuationSpan.getStartEpochNanos() / 1_000_000,
+                "Continuation span should use the operation's startTimestamp");
+    }
+
+    @Test
     void operationEnd_withoutMatchingStart_withError_setsErrorStatus() {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

Set the span start time to the operation's original startTimestamp when creating continuation spans in onOperationEnd. Previously the span defaulted to the current wall-clock time, which misrepresented the actual duration of cross-invocation operations.

Add a test to verify the continuation span uses the operation's startTimestamp.

### Demo/Screenshots
n/a

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? yes

#### Integration Tests

Have integration tests been written for these changes? no

#### Examples

Has a new example been added for the change? (if applicable)

no
