### PR TITLE
feat(conformance): add Java conformance test package (step, wait suites)

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - "sdk/**"
+      - "pom.xml"
       - "conformance-tests/**"
       - ".github/workflows/conformance-tests.yml"
   workflow_dispatch:

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -1,0 +1,111 @@
+name: Conformance Tests
+
+# Full-integration conformance run: builds the SDK + Java handlers, installs the
+# pinned language-agnostic runner from PyPI, then deploys + invokes + validates
+# one SAM stack per suite. Each suite runs as its own parallel matrix job. To add
+# a suite later, add its name to `strategy.matrix.suite` (and ship its
+# template_<suite>.yaml + handlers under conformance-tests/).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "conformance-tests/**"
+      - ".github/workflows/conformance-tests.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.head_ref || github.ref_name || github.run_id }}-conformance
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write # Required for AWS OIDC credentials
+
+jobs:
+  conformance:
+    name: conformance (${{ matrix.suite }})
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: us-west-2
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [step, wait]
+    defaults:
+      run:
+        working-directory: conformance-tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: 21
+          cache: maven
+
+      - name: Setup AWS SAM CLI
+        uses: aws-actions/setup-sam@v3
+        with:
+          use-installer: true
+
+      - name: Build SDK and conformance handlers
+        working-directory: .
+        run: mvn -B -q -Dmaven.test.skip=true install --file pom.xml
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install conformance runner
+        run: pip install aws-durable-execution-conformance-tests==0.1.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          # SAM-capable deploy role (has CloudFormation/S3/IAM), same role the
+          # SAM-based e2e tests assume.
+          role-to-assume: "${{ secrets.TEST_ROLE_ARN }}"
+          role-session-name: java-sdk-conformance-test
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ secrets.TEST_ACCOUNT_ID }}
+
+      - name: Inject Lambda execution role into template
+        env:
+          ROLE_ARN: ${{ secrets.TEST_LAMBDA_EXECUTION_ROLE_ARN }}
+        run: |
+          if [ -z "$ROLE_ARN" ]; then
+            echo "TEST_LAMBDA_EXECUTION_ROLE_ARN not set; template will create its own role."
+            exit 0
+          fi
+          # Point every function at the pre-existing execution role and drop the
+          # self-created DurableFunctionRole. Mutates only the CI checkout; the
+          # checked-in template stays self-contained for local runs.
+          python3 scripts/inject_execution_role.py \
+            --template template_${{ matrix.suite }}.yaml \
+            --role-arn "$ROLE_ARN"
+
+      - name: Run conformance suite
+        run: |
+          python -m aws_durable_execution_conformance_tests.app \
+            --template template_${{ matrix.suite }}.yaml \
+            --language java \
+            --suite ${{ matrix.suite }} \
+            --name conformance-java-${{ matrix.suite }}-${{ github.run_id }} \
+            --region ${{ env.AWS_REGION }} \
+            --history-dir history-${{ matrix.suite }} \
+            --report console junit \
+            --report-file report-${{ matrix.suite }}
+
+      - name: Upload conformance report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-report-${{ matrix.suite }}
+          path: |
+            conformance-tests/report-${{ matrix.suite }}.xml
+            conformance-tests/history-${{ matrix.suite }}/
+          if-no-files-found: warn

--- a/conformance-tests/.gitignore
+++ b/conformance-tests/.gitignore
@@ -1,0 +1,5 @@
+target/
+.aws-sam/
+history-*/
+report-*.xml
+report-*.json

--- a/conformance-tests/README.md
+++ b/conformance-tests/README.md
@@ -1,0 +1,112 @@
+# Durable Execution Java SDK — Conformance Tests
+
+Cross-SDK **conformance test handlers** for the Durable Execution Java SDK.
+These handlers are deployed as AWS Lambda functions and exercised by the
+language-agnostic conformance runner
+[`aws-durable-execution-conformance-tests`](https://pypi.org/project/aws-durable-execution-conformance-tests/),
+which invokes each function, pulls its execution history, and asserts it matches
+the shared requirement specification.
+
+The runner and the requirement specifications (the `test-requirements/` YAML files)
+are **not** in this repo — they live in
+[`aws/aws-durable-execution-conformance-tests`](https://github.com/aws/aws-durable-execution-conformance-tests).
+This package owns only the **Java handlers** and the **SAM templates** that wire
+them to requirement IDs.
+
+## Layout
+
+```
+src/main/java/
+  step/                # one handler class per scenario (context.step)
+    StepBasic.java
+    StepWithRetry.java
+    ...
+  wait/                # wait / timer scenarios
+template_step.yaml     # SAM template: maps each handler -> requirement ID(s)
+template_wait.yaml
+scripts/
+  inject_execution_role.py  # CI helper: use a pre-existing execution role
+```
+
+Each SAM template is a self-contained deployment for one **suite** (operation
+category). Suites are added incrementally; today this package ships `step` and
+`wait`.
+
+## How a handler maps to a requirement
+
+The link is the `TestingMetadata.TestDescription` field on each function in the
+SAM template — a list of requirement IDs the handler satisfies:
+
+```yaml
+StepBasic:
+  Type: AWS::Serverless::Function
+  TestingMetadata:
+    TestDescription: ["1-1"]   # <- requirement ID(s) in the conformance repo
+  Properties:
+    CodeUri: .
+    Handler: step.StepBasic    # <- package.ClassName extending DurableHandler
+    Role:
+      Fn::GetAtt: [DurableFunctionRole, Arn]
+    DurableConfig:
+      RetentionPeriodInDays: 7
+      ExecutionTimeout: 300
+```
+
+The runner invokes the function once per requirement ID using that requirement's
+`Input`, then diffs the resulting execution history against the requirement's
+`ExpectedExecutionHistory`.
+
+## Authoring a new test case
+
+1. **Find (or add) the requirement.** Requirement IDs and their expected history
+   live in the conformance repo under `test-requirements/<suite>/<id>.yaml`. If
+   the behavior isn't specified yet, propose it there first.
+2. **Write the handler.** Add `src/main/java/<suite>/<DescriptiveName>.java`
+   extending `DurableHandler<I, O>`. Use the SDK's **real API** — never
+   hand-roll logic to force the expected result. A handler that fails because
+   the SDK is non-compliant is a valid, valuable outcome; that failure is the
+   signal.
+3. **Register it in the template.** Add an `AWS::Serverless::Function` entry to
+   `template_<suite>.yaml` with `Handler: <suite>.<DescriptiveName>` and the
+   matching `TestDescription: ["<id>"]`.
+4. **Rebuild and run** (below).
+
+## Running locally
+
+Prerequisites: Java 21, Maven, Python ≥ 3.14, the AWS SAM CLI, and AWS
+credentials for an account where the Durable Execution service is available.
+
+```bash
+# 1. Build the SDK + these handlers (from the repo root)
+mvn -B -Dmaven.test.skip=true install
+
+# 2. Install the conformance runner (pinned)
+pip install aws-durable-execution-conformance-tests==0.1.0
+
+# 3. Deploy + invoke + validate one suite
+cd conformance-tests
+python -m aws_durable_execution_conformance_tests.app \
+  --template template_step.yaml \
+  --language java \
+  --suite step \
+  --name conformance-java-step-local \
+  --region us-west-2 \
+  --history-dir history-step \
+  --report junit --report-file report-step
+```
+
+The runner deploys the template via SAM, invokes each function once per
+requirement ID, and reports `PASSED` / `FAILED` / `UNCOVERED` per requirement. A
+non-zero exit means at least one requirement failed.
+
+## CI
+
+`.github/workflows/conformance-tests.yml` runs the same flow on pull requests
+and on manual dispatch, one parallel job per suite (a build matrix). It assumes
+AWS credentials via OIDC using the repository's existing integration secrets.
+
+Before deploying, CI runs `scripts/inject_execution_role.py` to point every
+function at the pre-existing execution role (`TEST_LAMBDA_EXECUTION_ROLE_ARN`)
+and drop the template's self-created `DurableFunctionRole` — so CI deploys
+don't create IAM roles. This rewrites only CI's checkout; the checked-in
+template stays self-contained for local runs.

--- a/conformance-tests/pom.xml
+++ b/conformance-tests/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>software.amazon.lambda.durable</groupId>
+        <artifactId>aws-durable-execution-sdk-java-parent</artifactId>
+        <version>2.1.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>aws-durable-execution-sdk-java-conformance-tests</artifactId>
+    <packaging>jar</packaging>
+
+    <name>AWS Lambda Durable Execution SDK Conformance Tests</name>
+    <description>Cross-SDK conformance test handlers for the AWS Lambda Durable Execution SDK</description>
+    <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
+
+    <scm>
+        <connection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</connection>
+        <developerConnection>scm:git:https://github.com/aws/aws-durable-execution-sdk-java.git</developerConnection>
+        <url>https://github.com/aws/aws-durable-execution-sdk-java</url>
+    </scm>
+
+    <dependencies>
+        <!-- Local SDK dependency -->
+        <dependency>
+            <groupId>software.amazon.lambda.durable</groupId>
+            <artifactId>aws-durable-execution-sdk-java</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- AWS Lambda Java Core -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+        </dependency>
+
+        <!-- Log4j2 for logging with MDC support -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.26.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.26.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>2.26.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Shaded (uber) JAR so each Lambda deploys as a single artifact -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.2</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
+                        <version>0.2.0</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer" />
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/conformance-tests/scripts/inject_execution_role.py
+++ b/conformance-tests/scripts/inject_execution_role.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Inject a pre-existing Lambda execution role into a conformance SAM template.
+
+Rewrites the given template in place so that every AWS::Serverless::Function
+uses the provided execution role ARN, and removes the self-created
+DurableFunctionRole resource. Used by CI to avoid creating an IAM role per
+deploy; the checked-in template stays self-contained for local runs.
+
+Usage:
+    python3 scripts/inject_execution_role.py --template template_step.yaml \
+        --role-arn arn:aws:iam::123456789012:role/my-execution-role
+
+Requires PyYAML (already a dependency of the conformance runner).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import yaml
+
+SELF_CREATED_ROLE = "DurableFunctionRole"
+FUNCTION_TYPE = "AWS::Serverless::Function"
+
+
+def inject(template_path: str, role_arn: str) -> int:
+    """Rewrite template_path in place; return the number of functions updated."""
+    with open(template_path, encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+
+    resources = doc.get("Resources")
+    if not isinstance(resources, dict):
+        raise SystemExit(f"{template_path}: no Resources section found")
+
+    resources.pop(SELF_CREATED_ROLE, None)
+
+    updated = 0
+    for resource in resources.values():
+        if resource.get("Type") == FUNCTION_TYPE:
+            resource.setdefault("Properties", {})["Role"] = role_arn
+            updated += 1
+
+    if updated == 0:
+        raise SystemExit(f"{template_path}: no {FUNCTION_TYPE} resources found")
+
+    with open(template_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(doc, f, sort_keys=False)
+
+    return updated
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--template",
+        required=True,
+        help="Path to the SAM template to rewrite in place.",
+    )
+    parser.add_argument(
+        "--role-arn",
+        required=True,
+        help="Execution role ARN to set on every serverless function.",
+    )
+    args = parser.parse_args()
+    updated = inject(args.template, args.role_arn)
+    print(f"Injected execution role into {updated} functions in {args.template}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance-tests/src/main/java/step/StepAndWaitReplay.java
+++ b/conformance-tests/src/main/java/step/StepAndWaitReplay.java
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 1-8: Step and wait with replay */
+public class StepAndWaitReplay extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String result = context.step("compute", String.class, stepCtx -> "computed");
+        context.wait(null, Duration.ofSeconds(2));
+        return result;
+    }
+}

--- a/conformance-tests/src/main/java/step/StepAtMostOnceNoRetry.java
+++ b/conformance-tests/src/main/java/step/StepAtMostOnceNoRetry.java
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.config.StepSemantics;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+
+/** 1-17: AtMostOnce interrupted (no retry) */
+public class StepAtMostOnceNoRetry extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.step(
+                "at_most_once_flaky_step",
+                String.class,
+                stepCtx -> {
+                    System.out.println(input);
+                    System.out.flush();
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ignored) {
+                    }
+                    System.exit(1);
+                    return "unreachable";
+                },
+                StepConfig.builder()
+                        .semanticsPerRetry(StepSemantics.AT_MOST_ONCE_PER_RETRY)
+                        .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                        .build());
+    }
+}

--- a/conformance-tests/src/main/java/step/StepAtMostOnceWithRetry.java
+++ b/conformance-tests/src/main/java/step/StepAtMostOnceWithRetry.java
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.config.StepSemantics;
+import software.amazon.lambda.durable.retry.RetryDecision;
+
+/** 1-18: AtMostOnce interrupted (with retry, succeeds on second attempt) */
+public class StepAtMostOnceWithRetry extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.step(
+                "at-most-once-retry",
+                String.class,
+                stepCtx -> {
+                    // Print input to stdout each time step executes
+                    System.out.println(input);
+                    System.out.flush();
+
+                    // Use the SDK's built-in attempt number (1-based at runtime).
+                    // With AT_MOST_ONCE_PER_RETRY the interrupted first attempt is
+                    // checkpointed as a retry, so the re-executed step sees a higher
+                    // attempt number and succeeds.
+                    if (stepCtx.getAttempt() < 2) {
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException ignored) {
+                        }
+                        System.exit(1);
+                    }
+                    return "succeeded on second attempt";
+                },
+                StepConfig.builder()
+                        .semanticsPerRetry(StepSemantics.AT_MOST_ONCE_PER_RETRY)
+                        .retryStrategy((error, attempt) -> {
+                            if (attempt >= 3) return RetryDecision.fail();
+                            return RetryDecision.retry(Duration.ofSeconds(1));
+                        })
+                        .build());
+    }
+}

--- a/conformance-tests/src/main/java/step/StepBasic.java
+++ b/conformance-tests/src/main/java/step/StepBasic.java
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 1-1: Step basic (succeeds on first attempt) */
+public class StepBasic extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        return context.step("greet", String.class, stepCtx -> "Hello, " + input + "!");
+    }
+}

--- a/conformance-tests/src/main/java/step/StepComplexObject.java
+++ b/conformance-tests/src/main/java/step/StepComplexObject.java
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import java.util.List;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 1-4: Returning complex object */
+@SuppressWarnings("unchecked")
+public class StepComplexObject extends DurableHandler<Map<String, Object>, Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> handleRequest(Map<String, Object> input, DurableContext context) {
+        return context.step("build-response", Map.class, stepCtx -> {
+            String name = (String) input.get("name");
+            List<String> tags = (List<String>) input.get("tags");
+            return Map.of(
+                    "user", Map.of("name", name, "tags", tags),
+                    "count", tags.size());
+        });
+    }
+}

--- a/conformance-tests/src/main/java/step/StepCustomSerdes.java
+++ b/conformance-tests/src/main/java/step/StepCustomSerdes.java
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.serde.SerDes;
+
+/** 1-6: Custom serdes (per-step) - uppercases result on serialization */
+public class StepCustomSerdes extends DurableHandler<String, String> {
+
+    private static final SerDes UPPERCASE_SERDES = new SerDes() {
+        @Override
+        public String serialize(Object value) {
+            return value != null ? ((String) value).toUpperCase() : null;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            return (T) data;
+        }
+    };
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        return context.step(
+                "uppercase",
+                String.class,
+                stepCtx -> input,
+                StepConfig.builder().serDes(UPPERCASE_SERDES).build());
+    }
+}

--- a/conformance-tests/src/main/java/step/StepDefaultRetry.java
+++ b/conformance-tests/src/main/java/step/StepDefaultRetry.java
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 1-13: Default retry strategy (no explicit config) */
+public class StepDefaultRetry extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.step("default-retry", String.class, stepCtx -> {
+            // Use the SDK's built-in attempt number (1-based at runtime):
+            // fail on the first two attempts, succeed on the third.
+            if (stepCtx.getAttempt() < 3) {
+                throw new RuntimeException("Attempt " + stepCtx.getAttempt() + " failed");
+            }
+            return "recovered";
+        });
+    }
+}

--- a/conformance-tests/src/main/java/step/StepErrorCaught.java
+++ b/conformance-tests/src/main/java/step/StepErrorCaught.java
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+
+/** 1-20: Error caught and handled (try/catch) */
+public class StepErrorCaught extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        try {
+            context.step(
+                    "failing-step",
+                    String.class,
+                    stepCtx -> {
+                        throw new RuntimeException("Something went wrong");
+                    },
+                    StepConfig.builder()
+                            .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                            .build());
+        } catch (RuntimeException e) {
+            // Error caught, continue with fallback
+        }
+
+        return context.step("fallback-step", String.class, stepCtx -> "fallback_result");
+    }
+}

--- a/conformance-tests/src/main/java/step/StepLogging.java
+++ b/conformance-tests/src/main/java/step/StepLogging.java
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 1-7: Step with context logger */
+public class StepLogging extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        return context.step("greet", String.class, stepCtx -> {
+            stepCtx.getLogger().info("Greeting step started for: {}", input);
+            String greeting = "Hello, " + input + "!";
+            stepCtx.getLogger().info("Greeting step completed with: {}", greeting);
+            return greeting;
+        });
+    }
+}

--- a/conformance-tests/src/main/java/step/StepNested.java
+++ b/conformance-tests/src/main/java/step/StepNested.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 1-3: Sequential steps where second depends on first */
+public class StepNested extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String result1 = context.step("step-one", String.class, stepCtx -> "first");
+        String result2 = context.step("step-two", String.class, stepCtx -> result1 + "_second");
+        return result2;
+    }
+}

--- a/conformance-tests/src/main/java/step/StepNullResult.java
+++ b/conformance-tests/src/main/java/step/StepNullResult.java
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 1-5: Undefined/null result */
+public class StepNullResult extends DurableHandler<Object, Object> {
+
+    @Override
+    public Object handleRequest(Object input, DurableContext context) {
+        return context.step("do-nothing", Object.class, stepCtx -> null);
+    }
+}

--- a/conformance-tests/src/main/java/step/StepReplayRethrowsFailed.java
+++ b/conformance-tests/src/main/java/step/StepReplayRethrowsFailed.java
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+
+/** 1-10: Replay re-throws failed step */
+public class StepReplayRethrowsFailed extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String errorMessage = "";
+
+        try {
+            context.step(
+                    "failing-step",
+                    String.class,
+                    stepCtx -> {
+                        stepCtx.getLogger().info("step executed");
+                        throw new RuntimeException("Something went wrong");
+                    },
+                    StepConfig.builder()
+                            .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                            .build());
+        } catch (RuntimeException e) {
+            errorMessage = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+        }
+
+        context.wait(null, Duration.ofSeconds(1));
+        return "caught: " + errorMessage;
+    }
+}

--- a/conformance-tests/src/main/java/step/StepReplaySkipsSucceeded.java
+++ b/conformance-tests/src/main/java/step/StepReplaySkipsSucceeded.java
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 1-9: Replay skips succeeded step */
+public class StepReplaySkipsSucceeded extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String result = context.step("cached-step", String.class, stepCtx -> {
+            stepCtx.getLogger().info("step executed");
+            return "cached_value";
+        });
+        context.wait(null, Duration.ofSeconds(1));
+        return result;
+    }
+}

--- a/conformance-tests/src/main/java/step/StepRetryCustomConfig.java
+++ b/conformance-tests/src/main/java/step/StepRetryCustomConfig.java
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.JitterStrategy;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+
+/** 1-14: Retry with custom config (2s initial, 3x backoff, no jitter) */
+public class StepRetryCustomConfig extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.step(
+                "custom-retry",
+                String.class,
+                stepCtx -> {
+                    // Use the SDK's built-in attempt number (1-based at runtime):
+                    // fail on the first two attempts, succeed on the third.
+                    if (stepCtx.getAttempt() < 3) {
+                        throw new RuntimeException("Attempt " + stepCtx.getAttempt() + " failed");
+                    }
+                    return "finally succeeded";
+                },
+                StepConfig.builder()
+                        .retryStrategy(RetryStrategies.exponentialBackoff(
+                                5, Duration.ofSeconds(2), Duration.ofSeconds(60), 3.0, JitterStrategy.NONE))
+                        .build());
+    }
+}

--- a/conformance-tests/src/main/java/step/StepRetryExhaustion.java
+++ b/conformance-tests/src/main/java/step/StepRetryExhaustion.java
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.JitterStrategy;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+
+/** 1-12: Retry exhaustion (max attempts) */
+public class StepRetryExhaustion extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.step(
+                "always-fails",
+                String.class,
+                stepCtx -> {
+                    throw new RuntimeException("Always fails");
+                },
+                StepConfig.builder()
+                        .retryStrategy(RetryStrategies.exponentialBackoff(
+                                4, Duration.ofSeconds(1), Duration.ofSeconds(10), 1.0, JitterStrategy.NONE))
+                        .build());
+    }
+}

--- a/conformance-tests/src/main/java/step/StepRetryNonRetryable.java
+++ b/conformance-tests/src/main/java/step/StepRetryNonRetryable.java
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.RetryDecision;
+
+/** 1-16: Retry specific exception (non-retryable fails) */
+public class StepRetryNonRetryable extends DurableHandler<Object, String> {
+
+    public static class TransientError extends RuntimeException {
+        public TransientError(String message) {
+            super(message);
+        }
+    }
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.step(
+                "non-retryable",
+                String.class,
+                stepCtx -> {
+                    throw new TransientError("Temporary failure");
+                },
+                StepConfig.builder()
+                        .retryStrategy((error, attempt) -> {
+                            // Only retry ValidationError, not TransientError
+                            if (error.getClass().getSimpleName().equals("ValidationError") && attempt < 3) {
+                                return RetryDecision.retry(Duration.ofSeconds(1));
+                            }
+                            return RetryDecision.fail();
+                        })
+                        .build());
+    }
+}

--- a/conformance-tests/src/main/java/step/StepRetrySpecificException.java
+++ b/conformance-tests/src/main/java/step/StepRetrySpecificException.java
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.RetryDecision;
+
+/** 1-15: Retry specific exception (retries only TransientError) */
+public class StepRetrySpecificException extends DurableHandler<Object, String> {
+
+    public static class TransientError extends RuntimeException {
+        public TransientError(String message) {
+            super(message);
+        }
+    }
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.step(
+                "specific-retry",
+                String.class,
+                stepCtx -> {
+                    // Use the SDK's built-in attempt number (1-based at runtime):
+                    // fail on the first attempt, succeed on the second.
+                    if (stepCtx.getAttempt() < 2) {
+                        throw new TransientError("Temporary failure");
+                    }
+                    return "recovered from transient";
+                },
+                StepConfig.builder()
+                        .retryStrategy((error, attempt) -> {
+                            if (error instanceof TransientError && attempt < 3) {
+                                return RetryDecision.retry(Duration.ofSeconds(1));
+                            }
+                            return RetryDecision.fail();
+                        })
+                        .build());
+    }
+}

--- a/conformance-tests/src/main/java/step/StepWithError.java
+++ b/conformance-tests/src/main/java/step/StepWithError.java
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+
+/** 1-19: Step with error (fails permanently) */
+public class StepWithError extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.step(
+                "failing-step",
+                String.class,
+                stepCtx -> {
+                    throw new RuntimeException("Something went wrong");
+                },
+                StepConfig.builder()
+                        .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                        .build());
+    }
+}

--- a/conformance-tests/src/main/java/step/StepWithName.java
+++ b/conformance-tests/src/main/java/step/StepWithName.java
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 1-2: Step with name */
+public class StepWithName extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        return context.step("custom_step_name", String.class, stepCtx -> "Hello, " + input + "!");
+    }
+}

--- a/conformance-tests/src/main/java/step/StepWithRetry.java
+++ b/conformance-tests/src/main/java/step/StepWithRetry.java
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package step;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.RetryDecision;
+
+/** 1-11: Step with retry (fails then succeeds) */
+public class StepWithRetry extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.step(
+                "retry-step",
+                String.class,
+                stepCtx -> {
+                    // Use the SDK's built-in attempt number (1-based at runtime):
+                    // fail on the first attempt, succeed on the second.
+                    if (stepCtx.getAttempt() < 2) {
+                        throw new RuntimeException("Attempt " + stepCtx.getAttempt() + " failed");
+                    }
+                    return "Operation succeeded";
+                },
+                StepConfig.builder()
+                        .retryStrategy((error, attempt) -> {
+                            if (attempt >= 3) return RetryDecision.fail();
+                            return RetryDecision.retry(Duration.ofSeconds(1));
+                        })
+                        .build());
+    }
+}

--- a/conformance-tests/src/main/java/wait/WaitBasic.java
+++ b/conformance-tests/src/main/java/wait/WaitBasic.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 2-1: Wait basic */
+public class WaitBasic extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        context.wait(null, Duration.ofSeconds(2));
+        return "Wait completed";
+    }
+}

--- a/conformance-tests/src/main/java/wait/WaitDurationUnits.java
+++ b/conformance-tests/src/main/java/wait/WaitDurationUnits.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 2-4: Wait with different duration units (minutes) */
+public class WaitDurationUnits extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        context.wait(null, Duration.ofMinutes(1));
+        return "Wait with minutes completed";
+    }
+}

--- a/conformance-tests/src/main/java/wait/WaitLongDuration.java
+++ b/conformance-tests/src/main/java/wait/WaitLongDuration.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 2-5: Wait with long duration (1 hour) */
+public class WaitLongDuration extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        context.wait(null, Duration.ofHours(1));
+        return "Wait with hours completed";
+    }
+}

--- a/conformance-tests/src/main/java/wait/WaitMultipleSequential.java
+++ b/conformance-tests/src/main/java/wait/WaitMultipleSequential.java
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait;
+
+import java.time.Duration;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 2-3: Multiple sequential waits */
+public class WaitMultipleSequential extends DurableHandler<Object, Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> handleRequest(Object input, DurableContext context) {
+        context.wait("wait-1", Duration.ofSeconds(2));
+        context.wait("wait-2", Duration.ofSeconds(2));
+        return Map.of("completedWaits", 2);
+    }
+}

--- a/conformance-tests/src/main/java/wait/WaitWithName.java
+++ b/conformance-tests/src/main/java/wait/WaitWithName.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 2-2: Wait with name */
+public class WaitWithName extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        context.wait("custom_wait_name", Duration.ofSeconds(2));
+        return "Wait with name completed";
+    }
+}

--- a/conformance-tests/template_step.yaml
+++ b/conformance-tests/template_step.yaml
@@ -1,0 +1,374 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Durable Execution Conformance Test Examples - Java (Step)
+
+Parameters:
+  Architecture:
+    Type: String
+    Default: arm64
+    Description: Lambda Function Architecture
+    AllowedValues:
+      - x86_64
+      - arm64
+  JavaVersion:
+    Type: String
+    Default: 'java21'
+    Description: Java runtime version
+
+Globals:
+  Function:
+    Timeout: 60
+    MemorySize: 512
+    Runtime:
+      Ref: JavaVersion
+    Architectures:
+      - Ref: Architecture
+
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+
+  StepBasic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-1"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepBasic
+      Description: Step basic (succeeds on first attempt)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepWithName:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-2"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepWithName
+      Description: Step with explicit name parameter
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepNested:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-3"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepNested
+      Description: Sequential steps where second depends on first
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepComplexObject:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-4"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepComplexObject
+      Description: Returning complex object with nested structure
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepNullResult:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-5"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepNullResult
+      Description: Undefined/null result
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepCustomSerdes:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-6"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepCustomSerdes
+      Description: Custom serdes (per-step) transforms to uppercase
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepLogging:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-7"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepLogging
+      Description: Step with context logger
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      Environment:
+        Variables:
+          # Log4j2's default configuration logs at ERROR, which suppresses the
+          # logger.info calls that requirement 1-7 asserts on. Raise it to INFO.
+          JAVA_TOOL_OPTIONS: -Dorg.apache.logging.log4j.level=INFO
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepAndWaitReplay:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-8"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepAndWaitReplay
+      Description: Step and wait with replay
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepReplaySkipsSucceeded:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-9"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepReplaySkipsSucceeded
+      Description: Replay skips succeeded step
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepReplayRethrowsFailed:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-10"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepReplayRethrowsFailed
+      Description: Replay re-throws failed step
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepWithRetry:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-11"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepWithRetry
+      Description: Step with retry (fails then succeeds)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepRetryExhaustion:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-12"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepRetryExhaustion
+      Description: Retry exhaustion (max attempts)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepDefaultRetry:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-13"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepDefaultRetry
+      Description: Default retry strategy
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepRetryCustomConfig:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-14"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepRetryCustomConfig
+      Description: Retry with custom config (fixed interval and backoff)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepRetrySpecificException:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-15"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepRetrySpecificException
+      Description: Retry specific exception
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepRetryNonRetryable:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-16"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepRetryNonRetryable
+      Description: Retry specific exception (non-retryable fails)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepAtMostOnceNoRetry:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-17"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepAtMostOnceNoRetry
+      Description: Step with AtMostOncePerRetry semantics (interrupted, no retry)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepAtMostOnceWithRetry:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-18"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepAtMostOnceWithRetry
+      Description: AtMostOnce interrupted (with retry, succeeds on second attempt)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepWithError:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-19"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepWithError
+      Description: Step with error (fails permanently)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  StepErrorCaught:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["1-20"]
+    Properties:
+      CodeUri: .
+      Handler: step.StepErrorCaught
+      Description: Error caught and handled (try/catch)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300

--- a/conformance-tests/template_wait.yaml
+++ b/conformance-tests/template_wait.yaml
@@ -1,0 +1,129 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Durable Execution Conformance Test Examples - Java (Wait)
+
+Parameters:
+  Architecture:
+    Type: String
+    Default: arm64
+    Description: Lambda Function Architecture
+    AllowedValues:
+      - x86_64
+      - arm64
+  JavaVersion:
+    Type: String
+    Default: 'java21'
+    Description: Java runtime version
+
+Globals:
+  Function:
+    Timeout: 60
+    MemorySize: 512
+    Runtime:
+      Ref: JavaVersion
+    Architectures:
+      - Ref: Architecture
+
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+
+  WaitBasic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["2-1"]
+    Properties:
+      CodeUri: .
+      Handler: wait.WaitBasic
+      Description: Wait basic
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitWithName:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["2-2"]
+    Properties:
+      CodeUri: .
+      Handler: wait.WaitWithName
+      Description: Wait with explicit name parameter
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitMultipleSequential:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["2-3"]
+    Properties:
+      CodeUri: .
+      Handler: wait.WaitMultipleSequential
+      Description: Multiple sequential waits
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitDurationUnits:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["2-4"]
+    Properties:
+      CodeUri: .
+      Handler: wait.WaitDurationUnits
+      Description: Wait with different duration units (minutes)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 3700
+
+  WaitLongDuration:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["2-5"]
+    Properties:
+      CodeUri: .
+      Handler: wait.WaitLongDuration
+      Description: Wait with long duration (1 hour)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 7200

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>sdk-integration-tests</module>
         <module>otel-plugin</module>
         <module>examples</module>
+        <module>conformance-tests</module>
         <module>coverage-report</module>
     </modules>
 


### PR DESCRIPTION
## Summary

Adds `conformance-tests/` (artifact `aws-durable-execution-sdk-java-conformance-tests`): Java handlers + SAM templates for the **step** and **wait** conformance suites, exercised by the language-agnostic runner [`aws-durable-execution-conformance-tests`](https://github.com/aws/aws-durable-execution-conformance-tests) (pinned `0.1.0`). Java counterpart of aws/aws-durable-execution-sdk-js#733.

- 20 step handlers + 5 wait handlers, using the SDK's real API — retry counting uses the built-in `StepContext.getAttempt()` (no DynamoDB side channel)
- `template_step.yaml` / `template_wait.yaml` map each handler to requirement IDs via `TestingMetadata.TestDescription`
- `scripts/inject_execution_role.py` (ported from the JS package): CI points every function at the pre-existing `TEST_LAMBDA_EXECUTION_ROLE_ARN` and drops the self-created `DurableFunctionRole`; the checked-in templates stay self-contained for local runs
- `.github/workflows/conformance-tests.yml`: one parallel matrix job per suite (`matrix.suite: [step, wait]`), OIDC via the existing `TEST_ROLE_ARN` / `TEST_ACCOUNT_ID` secrets (same as e2e-tests). Add future suites by extending the matrix and shipping `template_<suite>.yaml` + handlers.

## Testing

- `mvn -B -Dmaven.test.skip=true install` at repo root: green (module included, spotless-formatted)
- Full local runner execution against a live account, both suites:
  - **step: 20/20 PASSED**
  - **wait: 5/5 PASSED**
- `inject_execution_role.py` unit-smoke-tested: rewrites all functions, removes `DurableFunctionRole`