### PR TITLE
feat(conformance): add remaining suites (child, callback, invoke, parallel, wait_for_callback, wait_for_condition)

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -33,7 +33,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [step, wait]
+        # map is excluded until its handlers land (9-4 divergence + new
+        # uncovered requirements under discussion).
+        suite:
+          - step
+          - wait
+          - child
+          - callback
+          - invoke
+          - parallel
+          - wait_for_callback
+          - wait_for_condition
     defaults:
       run:
         working-directory: conformance-tests

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -100,13 +100,19 @@ jobs:
             --template template_${{ matrix.suite }}.yaml \
             --role-arn "$ROLE_ARN"
 
+      - name: Compute stack-safe suite slug
+        run: |
+          # CloudFormation stack names allow only [a-zA-Z][-a-zA-Z0-9]*;
+          # suite names like wait_for_condition contain underscores.
+          echo "SUITE_SLUG=$(echo '${{ matrix.suite }}' | tr '_' '-')" >> "$GITHUB_ENV"
+
       - name: Run conformance suite
         run: |
           python -m aws_durable_execution_conformance_tests.app \
             --template template_${{ matrix.suite }}.yaml \
             --language java \
             --suite ${{ matrix.suite }} \
-            --name conformance-java-${{ matrix.suite }}-${{ github.run_id }} \
+            --name conformance-java-${SUITE_SLUG}-${{ github.run_id }} \
             --region ${{ env.AWS_REGION }} \
             --history-dir history-${{ matrix.suite }} \
             --report console junit \

--- a/conformance-tests/pom.xml
+++ b/conformance-tests/pom.xml
@@ -37,6 +37,14 @@
             <artifactId>aws-lambda-java-core</artifactId>
         </dependency>
 
+        <!-- DynamoDB: attempt tracking for the interrupted-child test (3-12),
+             where the built-in step attempt cannot survive a crash without a
+             FAIL/RETRY checkpoint -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+        </dependency>
+
         <!-- Log4j2 for logging with MDC support -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/conformance-tests/scripts/inject_execution_role.py
+++ b/conformance-tests/scripts/inject_execution_role.py
@@ -6,6 +6,9 @@ uses the provided execution role ARN, and removes the self-created
 DurableFunctionRole resource. Used by CI to avoid creating an IAM role per
 deploy; the checked-in template stays self-contained for local runs.
 
+CloudFormation short-form intrinsic tags (!Sub, !GetAtt, !Ref, ...) are
+preserved through a tag-aware load/dump round-trip.
+
 Usage:
     python3 scripts/inject_execution_role.py --template template_step.yaml \
         --role-arn arn:aws:iam::123456789012:role/my-execution-role
@@ -24,10 +27,50 @@ SELF_CREATED_ROLE = "DurableFunctionRole"
 FUNCTION_TYPE = "AWS::Serverless::Function"
 
 
+class CfnTag:
+    """Opaque holder for a CloudFormation short-form tag (e.g. !Sub, !GetAtt)."""
+
+    def __init__(self, tag: str, value: object) -> None:
+        self.tag = tag
+        self.value = value
+
+
+class CfnLoader(yaml.SafeLoader):
+    """SafeLoader that wraps unknown (CloudFormation) tags instead of failing."""
+
+
+def _construct_cfn_tag(loader: CfnLoader, suffix: str, node: yaml.Node) -> CfnTag:
+    if isinstance(node, yaml.ScalarNode):
+        value: object = loader.construct_scalar(node)
+    elif isinstance(node, yaml.SequenceNode):
+        value = loader.construct_sequence(node, deep=True)
+    else:
+        value = loader.construct_mapping(node, deep=True)
+    return CfnTag(node.tag, value)
+
+
+CfnLoader.add_multi_constructor("!", _construct_cfn_tag)
+
+
+class CfnDumper(yaml.SafeDumper):
+    """SafeDumper that re-emits wrapped CloudFormation tags verbatim."""
+
+
+def _represent_cfn_tag(dumper: CfnDumper, data: CfnTag) -> yaml.Node:
+    if isinstance(data.value, str):
+        return dumper.represent_scalar(data.tag, data.value)
+    if isinstance(data.value, list):
+        return dumper.represent_sequence(data.tag, data.value)
+    return dumper.represent_mapping(data.tag, data.value)
+
+
+CfnDumper.add_representer(CfnTag, _represent_cfn_tag)
+
+
 def inject(template_path: str, role_arn: str) -> int:
     """Rewrite template_path in place; return the number of functions updated."""
     with open(template_path, encoding="utf-8") as f:
-        doc = yaml.safe_load(f)
+        doc = yaml.load(f, Loader=CfnLoader)  # noqa: S506 - CfnLoader extends SafeLoader
 
     resources = doc.get("Resources")
     if not isinstance(resources, dict):
@@ -45,7 +88,7 @@ def inject(template_path: str, role_arn: str) -> int:
         raise SystemExit(f"{template_path}: no {FUNCTION_TYPE} resources found")
 
     with open(template_path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(doc, f, sort_keys=False)
+        yaml.dump(doc, f, Dumper=CfnDumper, sort_keys=False)
 
     return updated
 

--- a/conformance-tests/src/main/java/callback/CallbackBasic.java
+++ b/conformance-tests/src/main/java/callback/CallbackBasic.java
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 4-1: Callback basic - success via external callback. */
+public class CallbackBasic extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var callback = context.createCallback(input, String.class);
+        return callback.get();
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackFailure.java
+++ b/conformance-tests/src/main/java/callback/CallbackFailure.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 4-6: Callback failure (external system reports failure). */
+public class CallbackFailure extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var callback = context.createCallback(input, String.class);
+        // Do not catch — let the exception propagate so the execution fails.
+        return callback.get();
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackHeartbeatSuccess.java
+++ b/conformance-tests/src/main/java/callback/CallbackHeartbeatSuccess.java
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.CallbackConfig;
+
+/** 4-5: Callback with heartbeat then success. */
+public class CallbackHeartbeatSuccess extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var config = CallbackConfig.builder()
+                .heartbeatTimeout(Duration.ofSeconds(10))
+                .build();
+        var callback = context.createCallback(input, String.class, config);
+        return callback.get();
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackHeartbeatTimeout.java
+++ b/conformance-tests/src/main/java/callback/CallbackHeartbeatTimeout.java
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.CallbackConfig;
+
+/** 4-4: Callback heartbeat timeout (no heartbeat sent). */
+public class CallbackHeartbeatTimeout extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var config =
+                CallbackConfig.builder().heartbeatTimeout(Duration.ofSeconds(5)).build();
+        var callback = context.createCallback(input, String.class, config);
+        return callback.get();
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackReplayFailure.java
+++ b/conformance-tests/src/main/java/callback/CallbackReplayFailure.java
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.exception.CallbackException;
+
+/** 4-13: Callback failure caught, then wait. */
+public class CallbackReplayFailure extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var callback = context.createCallback(input, String.class);
+
+        String outcome;
+        try {
+            outcome = callback.get();
+        } catch (CallbackException e) {
+            outcome = "caught_failure:" + e.getMessage();
+        } catch (RuntimeException e) {
+            outcome = "caught_other:" + e.getClass().getSimpleName() + ":" + e.getMessage();
+        }
+
+        context.wait("after-cb", Duration.ofSeconds(2));
+        return outcome;
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackReplayTimeout.java
+++ b/conformance-tests/src/main/java/callback/CallbackReplayTimeout.java
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.CallbackConfig;
+import software.amazon.lambda.durable.exception.CallbackException;
+
+/** 4-14: Callback timeout caught, then wait. */
+public class CallbackReplayTimeout extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var config = CallbackConfig.builder().timeout(Duration.ofSeconds(3)).build();
+        var callback = context.createCallback(input, String.class, config);
+
+        String outcome;
+        try {
+            outcome = callback.get();
+        } catch (CallbackException e) {
+            outcome = "caught_timeout:" + e.getMessage();
+        } catch (RuntimeException e) {
+            outcome = "caught_other:" + e.getClass().getSimpleName() + ":" + e.getMessage();
+        }
+
+        context.wait("after-cb", Duration.ofSeconds(2));
+        return outcome;
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackReplayWithWait.java
+++ b/conformance-tests/src/main/java/callback/CallbackReplayWithWait.java
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 4-12: Callback success then wait, multi-invocation replay. */
+public class CallbackReplayWithWait extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var callback = context.createCallback(input, String.class);
+        var cbResult = callback.get();
+        context.wait("after-cb", Duration.ofSeconds(2));
+        return cbResult;
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackSerdesHappy.java
+++ b/conformance-tests/src/main/java/callback/CallbackSerdesHappy.java
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.CallbackConfig;
+import software.amazon.lambda.durable.serde.SerDes;
+
+/** 4-15: Custom serdes (Date roundtrip - happy path). */
+public class CallbackSerdesHappy extends DurableHandler<String, Map<String, Object>> {
+
+    /** A simple POJO for the test data. */
+    public static class CustomData {
+        public String id;
+        public String message;
+        public Instant timestamp;
+    }
+
+    private static final SerDes CUSTOM_SERDES = new SerDes() {
+        @Override
+        @SuppressWarnings("unchecked")
+        public String serialize(Object value) {
+            if (value == null) {
+                return null;
+            }
+            CustomData d = (CustomData) value;
+            return String.format(
+                    "{\"id\":\"%s\",\"message\":\"%s\",\"timestamp\":\"%s\"}", d.id, d.message, d.timestamp.toString());
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            if (data == null) {
+                return null;
+            }
+            CustomData out = new CustomData();
+            String s = data;
+            out.id = extractString(s, "id");
+            out.message = extractString(s, "message");
+            out.timestamp = Instant.parse(extractString(s, "timestamp"));
+            return (T) out;
+        }
+
+        private static String extractString(String s, String field) {
+            // Match "field": "value" or "field":"value" (with or without space)
+            String key = "\"" + field + "\":";
+            int i = s.indexOf(key);
+            if (i < 0) {
+                return "";
+            }
+            int start = i + key.length();
+            // Skip optional whitespace
+            while (start < s.length() && s.charAt(start) == ' ') {
+                start++;
+            }
+            // Skip opening quote
+            if (start < s.length() && s.charAt(start) == '"') {
+                start++;
+            }
+            int j = s.indexOf("\"", start);
+            return j < 0 ? s.substring(start) : s.substring(start, j);
+        }
+    };
+
+    @Override
+    public Map<String, Object> handleRequest(String input, DurableContext context) {
+        var config = CallbackConfig.builder().serDes(CUSTOM_SERDES).build();
+        var callback = context.createCallback(input, CustomData.class, config);
+        CustomData result = callback.get();
+
+        Map<String, Object> received = new HashMap<>();
+        received.put("id", result.id);
+        received.put("message", result.message);
+        received.put("timestamp", result.timestamp.getEpochSecond());
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("received", received);
+        return response;
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackSerdesNumeric.java
+++ b/conformance-tests/src/main/java/callback/CallbackSerdesNumeric.java
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.CallbackConfig;
+import software.amazon.lambda.durable.serde.SerDes;
+
+/** 4-16: Custom serdes (numeric type). */
+public class CallbackSerdesNumeric extends DurableHandler<String, Map<String, Object>> {
+
+    private static final SerDes NUMERIC_SERDES = new SerDes() {
+        @Override
+        public String serialize(Object value) {
+            return value == null ? null : String.valueOf((Integer) value);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            return data == null ? null : (T) Integer.valueOf(data.trim());
+        }
+    };
+
+    @Override
+    public Map<String, Object> handleRequest(String input, DurableContext context) {
+        var config = CallbackConfig.builder().serDes(NUMERIC_SERDES).build();
+        var callback = context.createCallback(input, Integer.class, config);
+        int value = callback.get();
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("count", value);
+        response.put("doubled", value * 2);
+        return response;
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackStepFailure.java
+++ b/conformance-tests/src/main/java/callback/CallbackStepFailure.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 4-7: Callback + Step + failure. */
+public class CallbackStepFailure extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var callback = context.createCallback(input, String.class);
+        context.step("notify-external", String.class, ctx -> "notified");
+        return callback.get();
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackStepTimeout.java
+++ b/conformance-tests/src/main/java/callback/CallbackStepTimeout.java
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.CallbackConfig;
+
+/** 4-8: Callback + Step + timeout. */
+public class CallbackStepTimeout extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var config = CallbackConfig.builder().timeout(Duration.ofSeconds(5)).build();
+        var callback = context.createCallback(input, String.class, config);
+        context.step("notify-external", String.class, ctx -> "notified");
+        return callback.get();
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackTimeout.java
+++ b/conformance-tests/src/main/java/callback/CallbackTimeout.java
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.CallbackConfig;
+
+/** 4-3: Callback general timeout (no external callback sent). */
+public class CallbackTimeout extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var config = CallbackConfig.builder().timeout(Duration.ofSeconds(5)).build();
+        var callback = context.createCallback(input, String.class, config);
+        return callback.get();
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackTwoParallel.java
+++ b/conformance-tests/src/main/java/callback/CallbackTwoParallel.java
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 4-18: Two callbacks — create both then wait in order (cbA, cbB, wcbA, wcbB). */
+public class CallbackTwoParallel extends DurableHandler<List<String>, Map<String, String>> {
+    @Override
+    public Map<String, String> handleRequest(List<String> input, DurableContext context) {
+        String nameA = input.get(0);
+        String nameB = input.get(1);
+
+        var callbackA = context.createCallback(nameA, String.class);
+        var callbackB = context.createCallback(nameB, String.class);
+
+        String resultA = callbackA.get();
+        String resultB = callbackB.get();
+
+        Map<String, String> response = new HashMap<>();
+        response.put("a", resultA);
+        response.put("b", resultB);
+        return response;
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackTwoParallelReverse.java
+++ b/conformance-tests/src/main/java/callback/CallbackTwoParallelReverse.java
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 4-19: Two callbacks — create both then wait in reverse order (cbA, cbB, wcbB, wcbA). */
+public class CallbackTwoParallelReverse extends DurableHandler<List<String>, Map<String, String>> {
+    @Override
+    public Map<String, String> handleRequest(List<String> input, DurableContext context) {
+        String nameA = input.get(0);
+        String nameB = input.get(1);
+
+        var callbackA = context.createCallback(nameA, String.class);
+        var callbackB = context.createCallback(nameB, String.class);
+
+        String resultB = callbackB.get();
+        String resultA = callbackA.get();
+
+        Map<String, String> response = new HashMap<>();
+        response.put("a", resultA);
+        response.put("b", resultB);
+        return response;
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackTwoSequential.java
+++ b/conformance-tests/src/main/java/callback/CallbackTwoSequential.java
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 4-17: Two callbacks — sequential create and wait (cbA, wcbA, cbB, wcbB). */
+public class CallbackTwoSequential extends DurableHandler<List<String>, Map<String, String>> {
+    @Override
+    public Map<String, String> handleRequest(List<String> input, DurableContext context) {
+        String nameA = input.get(0);
+        String nameB = input.get(1);
+
+        var callbackA = context.createCallback(nameA, String.class);
+        String resultA = callbackA.get();
+
+        var callbackB = context.createCallback(nameB, String.class);
+        String resultB = callbackB.get();
+
+        Map<String, String> response = new HashMap<>();
+        response.put("a", resultA);
+        response.put("b", resultB);
+        return response;
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackWaitFailure.java
+++ b/conformance-tests/src/main/java/callback/CallbackWaitFailure.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 4-10: Callback + Wait + failure. */
+public class CallbackWaitFailure extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var callback = context.createCallback(input, String.class);
+        context.wait("delay", Duration.ofSeconds(5));
+        return callback.get();
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackWaitSuccess.java
+++ b/conformance-tests/src/main/java/callback/CallbackWaitSuccess.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 4-9: Callback + Wait + success. */
+public class CallbackWaitSuccess extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var callback = context.createCallback(input, String.class);
+        context.wait("delay", Duration.ofSeconds(5));
+        return callback.get();
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackWaitTimeout.java
+++ b/conformance-tests/src/main/java/callback/CallbackWaitTimeout.java
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.CallbackConfig;
+
+/** 4-11: Callback + Wait + timeout (callback timeout < wait duration). */
+public class CallbackWaitTimeout extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var config = CallbackConfig.builder().timeout(Duration.ofSeconds(3)).build();
+        var callback = context.createCallback(input, String.class, config);
+        context.wait("delay", Duration.ofSeconds(6));
+        return callback.get();
+    }
+}

--- a/conformance-tests/src/main/java/callback/CallbackWithName.java
+++ b/conformance-tests/src/main/java/callback/CallbackWithName.java
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 4-2: Callback with explicit name. */
+public class CallbackWithName extends DurableHandler<Object, String> {
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        var callback = context.createCallback("approval", String.class);
+        return callback.get();
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildBasic.java
+++ b/conformance-tests/src/main/java/child/ChildBasic.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 3-1: Child context basic (single step inside) */
+public class ChildBasic extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        return context.runInChildContext(
+                "child-basic", String.class, child -> child.step("inner-step", String.class, stepCtx -> input));
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildCustomSerdes.java
+++ b/conformance-tests/src/main/java/child/ChildCustomSerdes.java
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.RunInChildContextConfig;
+import software.amazon.lambda.durable.serde.SerDes;
+
+/** 3-14: Child context with custom serdes (succeed) */
+public class ChildCustomSerdes extends DurableHandler<String, String> {
+
+    private static final SerDes UPPERCASE_SERDES = new SerDes() {
+        @Override
+        public String serialize(Object value) {
+            return value != null ? ((String) value).toUpperCase() : null;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            return (T) data;
+        }
+    };
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        return context.runInChildContext(
+                "serdes-child",
+                String.class,
+                child -> child.step("return-input", String.class, stepCtx -> input),
+                RunInChildContextConfig.builder().serDes(UPPERCASE_SERDES).build());
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildErrorCaught.java
+++ b/conformance-tests/src/main/java/child/ChildErrorCaught.java
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+
+/** 3-5: Child context error caught (try/catch, execution succeeds) */
+public class ChildErrorCaught extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        try {
+            context.runInChildContext(
+                    "failing-child",
+                    String.class,
+                    child -> child.step(
+                            "failing-step",
+                            String.class,
+                            stepCtx -> {
+                                throw new RuntimeException("Something went wrong");
+                            },
+                            StepConfig.builder()
+                                    .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                                    .build()));
+        } catch (RuntimeException e) {
+            // Error caught, continue with recovery
+        }
+
+        return context.step("recovery-step", String.class, stepCtx -> input);
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildErrorNoStep.java
+++ b/conformance-tests/src/main/java/child/ChildErrorNoStep.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 3-15: Child context error without step (error thrown directly in child body) */
+public class ChildErrorNoStep extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.runInChildContext("direct-error", String.class, child -> {
+            throw new RuntimeException("direct error");
+        });
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildInterrupted.java
+++ b/conformance-tests/src/main/java/child/ChildInterrupted.java
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+
+/** 3-12: Child context interrupted and re-executed */
+public class ChildInterrupted extends DurableHandler<String, String> {
+
+    private static final DynamoDbClient DDB_CLIENT = DynamoDbClient.create();
+    private static final String TABLE_NAME =
+            System.getenv("ATTEMPTS_TABLE_NAME") != null ? System.getenv("ATTEMPTS_TABLE_NAME") : "JavaAttempts";
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        String executionId = context.getExecutionArn();
+
+        return context.runInChildContext(
+                "interrupted-child",
+                String.class,
+                child -> child.step(
+                        "crashable-step",
+                        String.class,
+                        stepCtx -> {
+                            UpdateItemResponse response = DDB_CLIENT.updateItem(UpdateItemRequest.builder()
+                                    .tableName(TABLE_NAME)
+                                    .key(Map.of(
+                                            "executionId",
+                                            AttributeValue.builder()
+                                                    .s(executionId)
+                                                    .build()))
+                                    .updateExpression("SET attemptCount = if_not_exists(attemptCount, :zero) + :inc")
+                                    .expressionAttributeValues(Map.of(
+                                            ":zero",
+                                                    AttributeValue.builder()
+                                                            .n("0")
+                                                            .build(),
+                                            ":inc",
+                                                    AttributeValue.builder()
+                                                            .n("1")
+                                                            .build()))
+                                    .returnValues(ReturnValue.UPDATED_NEW)
+                                    .build());
+
+                            int attemptCount = Integer.parseInt(
+                                    response.attributes().get("attemptCount").n());
+                            if (attemptCount < 2) {
+                                // Sleep to allow checkpoint to be sent before crash
+                                try {
+                                    Thread.sleep(1000);
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
+                                // Simulate a crash/interrupt on first attempt
+                                System.exit(1);
+                            }
+                            return input;
+                        },
+                        StepConfig.builder().build()));
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildLargePayload.java
+++ b/conformance-tests/src/main/java/child/ChildLargePayload.java
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 3-11: Child context large payload (ReplayChildren mode) */
+public class ChildLargePayload extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String largeResult = context.runInChildContext("large-data-processor", String.class, child -> {
+            System.out.println(input);
+            System.out.flush();
+
+            String seed = child.step("fetch-seed", String.class, stepCtx -> "seed");
+
+            // Build a large result (>256KB) from the small seed value
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 300000; i++) {
+                sb.append(seed);
+            }
+            return sb.toString();
+        });
+
+        context.wait(null, Duration.ofSeconds(2));
+
+        return largeResult;
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildMultipleSteps.java
+++ b/conformance-tests/src/main/java/child/ChildMultipleSteps.java
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 3-3: Child context with multiple sequential steps */
+public class ChildMultipleSteps extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        return context.runInChildContext("multi-step", String.class, child -> {
+            String first = child.step("step-one", String.class, stepCtx -> input);
+            String second = child.step("step-two", String.class, stepCtx -> first);
+            return second;
+        });
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildNested.java
+++ b/conformance-tests/src/main/java/child/ChildNested.java
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 3-6: Nested child contexts */
+public class ChildNested extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        return context.runInChildContext("outer", String.class, outerChild -> {
+            outerChild.step("outer-step", String.class, stepCtx -> input);
+
+            String innerResult = outerChild.runInChildContext(
+                    "inner", String.class, innerChild -> innerChild.step("inner-step", String.class, stepCtx -> input));
+
+            return innerResult;
+        });
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildNullResult.java
+++ b/conformance-tests/src/main/java/child/ChildNullResult.java
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 3-16: Child context returning null */
+public class ChildNullResult extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.runInChildContext("null-child", String.class, child -> null);
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildPrintOnly.java
+++ b/conformance-tests/src/main/java/child/ChildPrintOnly.java
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 3-17: Child context with print only (verify no re-execution on replay) */
+public class ChildPrintOnly extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        String result = context.runInChildContext("print-child", String.class, child -> {
+            System.out.println(input);
+            System.out.flush();
+            return input;
+        });
+
+        context.wait(null, Duration.ofSeconds(1));
+
+        return result;
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildReplay.java
+++ b/conformance-tests/src/main/java/child/ChildReplay.java
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 3-9: Child context replay (returns cached result) */
+public class ChildReplay extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        String childResult = context.runInChildContext(
+                "cached-child", String.class, child -> child.step("compute", String.class, stepCtx -> input));
+
+        context.wait(null, Duration.ofSeconds(2));
+
+        return childResult;
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildRetryExhaustion.java
+++ b/conformance-tests/src/main/java/child/ChildRetryExhaustion.java
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.JitterStrategy;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+
+/** 3-8: Child context with step retry exhaustion (child fails) */
+public class ChildRetryExhaustion extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.runInChildContext(
+                "exhaust-child",
+                String.class,
+                child -> child.step(
+                        "always-fails",
+                        String.class,
+                        stepCtx -> {
+                            throw new RuntimeException("Always fails");
+                        },
+                        StepConfig.builder()
+                                .retryStrategy(RetryStrategies.exponentialBackoff(
+                                        2, Duration.ofSeconds(1), Duration.ofSeconds(10), 1.0, JitterStrategy.NONE))
+                                .build()));
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildStepAndWait.java
+++ b/conformance-tests/src/main/java/child/ChildStepAndWait.java
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 3-10: Child context with step and wait inside */
+public class ChildStepAndWait extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        return context.runInChildContext("mixed-ops", String.class, child -> {
+            child.step("do-work", String.class, stepCtx -> input);
+            child.wait(null, Duration.ofSeconds(2));
+            return input;
+        });
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildStepWaitAfter.java
+++ b/conformance-tests/src/main/java/child/ChildStepWaitAfter.java
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 3-18: Child context with step and wait inside, step and wait after */
+public class ChildStepWaitAfter extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        context.runInChildContext("step-wait-child", String.class, child -> {
+            child.step("inner-work", String.class, stepCtx -> input);
+            child.wait(null, Duration.ofSeconds(2));
+            return input;
+        });
+
+        String result = context.step("outer-work", String.class, stepCtx -> input);
+        context.wait(null, Duration.ofSeconds(2));
+        return result;
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildWaitReplay.java
+++ b/conformance-tests/src/main/java/child/ChildWaitReplay.java
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 3-13: Child context with wait inside - verify replay */
+public class ChildWaitReplay extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        context.runInChildContext("wait-child", String.class, child -> {
+            child.wait(null, Duration.ofSeconds(1));
+            return input;
+        });
+
+        return context.step("after-child", String.class, stepCtx -> input);
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildWithError.java
+++ b/conformance-tests/src/main/java/child/ChildWithError.java
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+
+/** 3-4: Child context error (step fails, execution fails) */
+public class ChildWithError extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.runInChildContext(
+                "failing-child",
+                String.class,
+                child -> child.step(
+                        "failing-step",
+                        String.class,
+                        stepCtx -> {
+                            throw new RuntimeException("Something went wrong in child");
+                        },
+                        StepConfig.builder()
+                                .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                                .build()));
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildWithName.java
+++ b/conformance-tests/src/main/java/child/ChildWithName.java
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 3-2: Child context with name */
+public class ChildWithName extends DurableHandler<Map<String, String>, String> {
+
+    @Override
+    public String handleRequest(Map<String, String> input, DurableContext context) {
+        String name = input.get("name");
+        String value = input.get("value");
+        return context.runInChildContext(
+                name, String.class, child -> child.step("step", String.class, stepCtx -> value));
+    }
+}

--- a/conformance-tests/src/main/java/child/ChildWithRetry.java
+++ b/conformance-tests/src/main/java/child/ChildWithRetry.java
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package child;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.retry.RetryDecision;
+
+/** 3-7: Child context with step retry (fails then succeeds) */
+public class ChildWithRetry extends DurableHandler<String, String> {
+
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        return context.runInChildContext(
+                "retry-child",
+                String.class,
+                child -> child.step(
+                        "retry-step",
+                        String.class,
+                        stepCtx -> {
+                            // Use the SDK's built-in attempt number (1-based at runtime):
+                            // fail on the first attempt, succeed on the second.
+                            if (stepCtx.getAttempt() < 2) {
+                                throw new RuntimeException("Attempt " + stepCtx.getAttempt() + " failed");
+                            }
+                            return input;
+                        },
+                        StepConfig.builder()
+                                .retryStrategy((error, attempt) -> {
+                                    if (attempt >= 3) return RetryDecision.fail();
+                                    return RetryDecision.retry(Duration.ofSeconds(1));
+                                })
+                                .build()));
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeBasic.java
+++ b/conformance-tests/src/main/java/invoke/InvokeBasic.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 5-1: Invoke basic (target function succeeds) */
+public class InvokeBasic extends DurableHandler<Object, Object> {
+
+    @Override
+    public Object handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        return context.invoke("invoke-basic", functionName, input, Object.class);
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeComplexObject.java
+++ b/conformance-tests/src/main/java/invoke/InvokeComplexObject.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 5-3: Invoke returning complex object (nested JSON) */
+public class InvokeComplexObject extends DurableHandler<Object, Object> {
+
+    @Override
+    public Object handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        return context.invoke("invoke-complex", functionName, input, Object.class);
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeCustomPayloadSerdes.java
+++ b/conformance-tests/src/main/java/invoke/InvokeCustomPayloadSerdes.java
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.InvokeConfig;
+import software.amazon.lambda.durable.serde.SerDes;
+
+/** 5-15: Invoke with custom payload serdes */
+public class InvokeCustomPayloadSerdes extends DurableHandler<Object, String> {
+
+    private static final SerDes UPPERCASE_PAYLOAD_SERDES = new SerDes() {
+        @Override
+        public String serialize(Object value) {
+            return value != null ? "\"" + value.toString().toUpperCase() + "\"" : null;
+        }
+
+        @Override
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            @SuppressWarnings("unchecked")
+            T result = (T) data;
+            return result;
+        }
+    };
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        return context.invoke(
+                "invoke-custom-payload",
+                functionName,
+                "hello",
+                String.class,
+                InvokeConfig.builder().payloadSerDes(UPPERCASE_PAYLOAD_SERDES).build());
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeCustomResultSerdes.java
+++ b/conformance-tests/src/main/java/invoke/InvokeCustomResultSerdes.java
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.InvokeConfig;
+import software.amazon.lambda.durable.serde.SerDes;
+
+/** 5-16: Invoke with custom result serdes */
+public class InvokeCustomResultSerdes extends DurableHandler<Object, String> {
+
+    private static final SerDes UPPERCASE_RESULT_SERDES = new SerDes() {
+        @Override
+        public String serialize(Object value) {
+            return value != null ? "\"" + value.toString() + "\"" : null;
+        }
+
+        @Override
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            @SuppressWarnings("unchecked")
+            T result = (T) (data != null ? data.toUpperCase() : null);
+            return result;
+        }
+    };
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        return context.invoke(
+                "invoke-custom-result",
+                functionName,
+                input,
+                String.class,
+                InvokeConfig.builder().serDes(UPPERCASE_RESULT_SERDES).build());
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeInChildContext.java
+++ b/conformance-tests/src/main/java/invoke/InvokeInChildContext.java
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 5-13: Invoke inside child context */
+public class InvokeInChildContext extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        return context.runInChildContext(
+                "child-invoke",
+                String.class,
+                child -> child.invoke("invoke-in-child", functionName, null, String.class));
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeLargePayload.java
+++ b/conformance-tests/src/main/java/invoke/InvokeLargePayload.java
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 5-7: Invoke large payload (payload near size limit) */
+public class InvokeLargePayload extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        // Build a large payload string (~200KB)
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 200000; i++) {
+            sb.append("x");
+        }
+        String largePayload = sb.toString();
+        return context.invoke("invoke-large", functionName, largePayload, String.class);
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeMultipleSequential.java
+++ b/conformance-tests/src/main/java/invoke/InvokeMultipleSequential.java
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 5-14: Multiple sequential invokes */
+public class InvokeMultipleSequential extends DurableHandler<Map<String, Object>, String> {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public String handleRequest(Map<String, Object> input, DurableContext context) {
+        String functionName1 = System.getenv("TARGET_FUNCTION_NAME_1");
+        String functionName2 = System.getenv("TARGET_FUNCTION_NAME_2");
+        String result1 = context.invoke("invoke-first", functionName1, null, String.class);
+        String result2 = context.invoke("invoke-second", functionName2, null, String.class);
+        return result1 + "," + result2;
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeNullResult.java
+++ b/conformance-tests/src/main/java/invoke/InvokeNullResult.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 5-4: Invoke returning null (target returns null) */
+public class InvokeNullResult extends DurableHandler<Object, Object> {
+
+    @Override
+    public Object handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        return context.invoke("invoke-null", functionName, null, Object.class);
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeReplayRethrows.java
+++ b/conformance-tests/src/main/java/invoke/InvokeReplayRethrows.java
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.exception.InvokeException;
+
+/** 5-10: Invoke replay re-throws (failed invoke error re-thrown from cache) */
+public class InvokeReplayRethrows extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        try {
+            context.invoke("invoke-failing", functionName, null, String.class);
+        } catch (InvokeException e) {
+            // Caught on first execution and on replay
+        }
+        context.wait(null, Duration.ofSeconds(1));
+        return "done";
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeReplaySkips.java
+++ b/conformance-tests/src/main/java/invoke/InvokeReplaySkips.java
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 5-9: Invoke replay skips (invoke result cached on replay) */
+public class InvokeReplaySkips extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        String result = context.invoke("invoke-target", functionName, null, String.class);
+        context.wait(null, Duration.ofSeconds(1));
+        return result;
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeTargetFails.java
+++ b/conformance-tests/src/main/java/invoke/InvokeTargetFails.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 5-5: Invoke target fails (execution fails with InvokeError) */
+public class InvokeTargetFails extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        return context.invoke("invoke-failing", functionName, null, String.class);
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeTargetFailsCaught.java
+++ b/conformance-tests/src/main/java/invoke/InvokeTargetFailsCaught.java
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.exception.InvokeException;
+
+/** 5-6: Invoke target fails, caught (try/catch, execution succeeds) */
+public class InvokeTargetFailsCaught extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        try {
+            context.invoke("invoke-failing", functionName, null, String.class);
+        } catch (InvokeException e) {
+            // Error caught
+        }
+        return "fallback";
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeThenStep.java
+++ b/conformance-tests/src/main/java/invoke/InvokeThenStep.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 5-12: Invoke then step (invoke result used by subsequent step) */
+public class InvokeThenStep extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        String invokeResult = context.invoke("invoke-target", functionName, null, String.class);
+        return context.step("process", String.class, stepCtx -> "processed: " + invokeResult);
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeTimeout.java
+++ b/conformance-tests/src/main/java/invoke/InvokeTimeout.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 5-7: Invoke timeout (target takes too long) */
+public class InvokeTimeout extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        return context.invoke("invoke-slow", functionName, null, String.class);
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeTimeoutCaught.java
+++ b/conformance-tests/src/main/java/invoke/InvokeTimeoutCaught.java
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.exception.InvokeException;
+
+/** 5-8: Invoke timeout, caught (timeout caught, execution continues) */
+public class InvokeTimeoutCaught extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        try {
+            context.invoke("invoke-slow", functionName, null, String.class);
+        } catch (InvokeException e) {
+            // Timeout caught
+        }
+        return "fallback";
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeWithName.java
+++ b/conformance-tests/src/main/java/invoke/InvokeWithName.java
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 5-2: Invoke with name (explicit name parameter from input) */
+public class InvokeWithName extends DurableHandler<Map<String, Object>, Object> {
+
+    @Override
+    public Object handleRequest(Map<String, Object> input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        String name = (String) input.get("name");
+        Object payload = input.get("payload");
+        return context.invoke(name, functionName, payload, Object.class);
+    }
+}

--- a/conformance-tests/src/main/java/invoke/InvokeWithTenantId.java
+++ b/conformance-tests/src/main/java/invoke/InvokeWithTenantId.java
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.InvokeConfig;
+
+/** 5-8: Invoke with tenantId (tenant-isolated invocation) */
+public class InvokeWithTenantId extends DurableHandler<Map<String, String>, String> {
+
+    @Override
+    public String handleRequest(Map<String, String> input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        String tenantId = input.get("tenantId");
+        String payload = input.get("payload");
+        return context.invoke(
+                "invoke-tenant",
+                functionName,
+                payload,
+                String.class,
+                InvokeConfig.builder().tenantId(tenantId).build());
+    }
+}

--- a/conformance-tests/src/main/java/invoke/StepThenInvoke.java
+++ b/conformance-tests/src/main/java/invoke/StepThenInvoke.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 5-11: Step then invoke (sequential operations) */
+public class StepThenInvoke extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        String functionName = System.getenv("TARGET_FUNCTION_NAME");
+        String stepResult = context.step("compute", String.class, stepCtx -> "step-data");
+        return context.invoke("invoke-with-step", functionName, stepResult, String.class);
+    }
+}

--- a/conformance-tests/src/main/java/invoke/TargetEcho.java
+++ b/conformance-tests/src/main/java/invoke/TargetEcho.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** Target function that echoes back whatever it receives (with a short wait to ensure caller suspends). */
+public class TargetEcho extends DurableHandler<Object, Object> {
+
+    @Override
+    public Object handleRequest(Object input, DurableContext context) {
+        context.wait(null, Duration.ofSeconds(1));
+        return input;
+    }
+}

--- a/conformance-tests/src/main/java/invoke/TargetError.java
+++ b/conformance-tests/src/main/java/invoke/TargetError.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** Target function that waits briefly then throws an exception. */
+public class TargetError extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        context.wait(null, Duration.ofSeconds(1));
+        throw new RuntimeException("Target function error");
+    }
+}

--- a/conformance-tests/src/main/java/invoke/TargetNonDurable.java
+++ b/conformance-tests/src/main/java/invoke/TargetNonDurable.java
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+/** Plain Lambda handler (non-durable) used as an invoke target. */
+public class TargetNonDurable implements RequestHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, Context context) {
+        return "non-durable-result";
+    }
+}

--- a/conformance-tests/src/main/java/invoke/TargetSlow.java
+++ b/conformance-tests/src/main/java/invoke/TargetSlow.java
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package invoke;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** Target function that takes longer than the invoke timeout. */
+public class TargetSlow extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        try {
+            Thread.sleep(60000); // Sleep 60 seconds to exceed timeout
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return "should-not-reach";
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelAccessors.java
+++ b/conformance-tests/src/main/java/parallel/ParallelAccessors.java
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.CompletionConfig;
+import software.amazon.lambda.durable.config.ParallelConfig;
+import software.amazon.lambda.durable.model.ParallelResult;
+
+/**
+ * 8-20: Parallel ParallelResult accessors
+ *
+ * <p>One failure within tolerance so all branches run. Projects hasFailure/successCount/failureCount/errorCount from
+ * the ParallelResult counts. Java's ParallelResult exposes counts (succeeded/failed) rather than an errors list, so
+ * errorCount is derived from failed().
+ */
+public class ParallelAccessors extends DurableHandler<Object, Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder()
+                .maxConcurrency(1)
+                .completionConfig(CompletionConfig.toleratedFailureCount(1))
+                .build();
+        ParallelDurableFuture parallel = context.parallel("accessors", config);
+        try (parallel) {
+            parallel.branch("branch-0", String.class, branch -> "ok0");
+            parallel.branch("branch-1", String.class, branch -> {
+                throw new RuntimeException("branch 1 failed");
+            });
+            parallel.branch("branch-2", String.class, branch -> "ok2");
+        }
+        ParallelResult result = parallel.get();
+
+        var out = new LinkedHashMap<String, Object>();
+        out.put("hasFailure", result.failed() > 0);
+        out.put("successCount", result.succeeded());
+        out.put("failureCount", result.failed());
+        out.put("errorCount", result.failed());
+        return out;
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelAllFail.java
+++ b/conformance-tests/src/main/java/parallel/ParallelAllFail.java
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.CompletionConfig;
+import software.amazon.lambda.durable.config.ParallelConfig;
+import software.amazon.lambda.durable.model.ParallelResult;
+
+/**
+ * 8-16: Parallel where all branches fail (within tolerance, ALL_COMPLETED)
+ *
+ * <p>Three branches all fail; tolerated-failure-count=3 accommodates them so all run and none is skipped. Completion
+ * reason is ALL_COMPLETED but status is FAILED (no successes).
+ */
+public class ParallelAllFail extends DurableHandler<Object, Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder()
+                .maxConcurrency(1)
+                .completionConfig(CompletionConfig.toleratedFailureCount(3))
+                .build();
+        ParallelDurableFuture parallel = context.parallel("all-fail", config);
+        try (parallel) {
+            parallel.branch("branch-0", String.class, branch -> {
+                throw new RuntimeException("branch 0 failed");
+            });
+            parallel.branch("branch-1", String.class, branch -> {
+                throw new RuntimeException("branch 1 failed");
+            });
+            parallel.branch("branch-2", String.class, branch -> {
+                throw new RuntimeException("branch 2 failed");
+            });
+        }
+        ParallelResult result = parallel.get();
+
+        var out = new LinkedHashMap<String, Object>();
+        out.put("completionReason", result.completionStatus().name());
+        out.put("status", result.failed() > 0 ? "FAILED" : "SUCCEEDED");
+        out.put("successCount", result.succeeded());
+        out.put("failureCount", result.failed());
+        out.put("totalCount", result.succeeded() + result.failed());
+        return out;
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelBadConcurrency.java
+++ b/conformance-tests/src/main/java/parallel/ParallelBadConcurrency.java
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableFuture;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.ParallelConfig;
+
+/**
+ * 8-19: Parallel with invalid max-concurrency raises a validation error
+ *
+ * <p>max-concurrency 0 is invalid; the SDK is expected to reject it and the execution fails.
+ */
+public class ParallelBadConcurrency extends DurableHandler<Object, List<String>> {
+
+    @Override
+    public List<String> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder().maxConcurrency(0).build();
+        var futures = new ArrayList<DurableFuture<String>>();
+        ParallelDurableFuture parallel = context.parallel("bad-concurrency", config);
+        try (parallel) {
+            futures.add(parallel.branch("branch-0", String.class, branch -> "a"));
+            futures.add(parallel.branch("branch-1", String.class, branch -> "b"));
+        }
+        return futures.stream().map(DurableFuture::get).toList();
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelBasic.java
+++ b/conformance-tests/src/main/java/parallel/ParallelBasic.java
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableFuture;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.ParallelConfig;
+
+/** 8-1: Parallel basic (two branches, each a single step, all succeed) */
+public class ParallelBasic extends DurableHandler<Object, List<String>> {
+
+    @Override
+    public List<String> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder().maxConcurrency(1).build();
+        var futures = new ArrayList<DurableFuture<String>>();
+        ParallelDurableFuture parallel = context.parallel("parallel", config);
+        try (parallel) {
+            futures.add(parallel.branch(
+                    "branch-0", String.class, branch -> branch.step("step-0", String.class, stepCtx -> "task-1")));
+            futures.add(parallel.branch(
+                    "branch-1", String.class, branch -> branch.step("step-1", String.class, stepCtx -> "task-2")));
+        }
+        return futures.stream().map(DurableFuture::get).toList();
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelBranchesOnly.java
+++ b/conformance-tests/src/main/java/parallel/ParallelBranchesOnly.java
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableFuture;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.ParallelConfig;
+
+/**
+ * 8-2: Parallel invoked with the branches-only form (no name argument)
+ *
+ * <p>DIVERGENCE NOTE: The Java SDK has no branches-only {@code parallel()} overload — {@code parallel(String name,
+ * ...)} always requires a name. A name is supplied here ("branches-only") but it does not appear in the asserted
+ * execution history, so behavior and result are identical to the named form. Each branch returns its constant directly
+ * (no inner step), matching the requirement's step-free history.
+ */
+public class ParallelBranchesOnly extends DurableHandler<Object, List<String>> {
+
+    @Override
+    public List<String> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder().maxConcurrency(1).build();
+        var futures = new ArrayList<DurableFuture<String>>();
+        ParallelDurableFuture parallel = context.parallel("branches-only", config);
+        try (parallel) {
+            futures.add(parallel.branch("branch-0", String.class, branch -> "alpha"));
+            futures.add(parallel.branch("branch-1", String.class, branch -> "beta"));
+        }
+        return futures.stream().map(DurableFuture::get).toList();
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelCombinedConfig.java
+++ b/conformance-tests/src/main/java/parallel/ParallelCombinedConfig.java
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.CompletionConfig;
+import software.amazon.lambda.durable.config.ParallelConfig;
+import software.amazon.lambda.durable.model.ParallelResult;
+
+/**
+ * 8-18: Parallel with combined completion config (min-successful + tolerated-failure-count)
+ *
+ * <p>min-successful=3 and tolerated-failure-count=1 together. Branches 0 and 1 fail; the failure tolerance is exceeded
+ * (2 > 1) before the min-successful target could be met, so the operation stops and branches 2 and 3 never start.
+ * Completion reason is FAILURE_TOLERANCE_EXCEEDED. Combined config uses the CompletionConfig record constructor.
+ */
+public class ParallelCombinedConfig extends DurableHandler<Object, Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder()
+                .maxConcurrency(1)
+                .completionConfig(new CompletionConfig(3, 1, null))
+                .build();
+        ParallelDurableFuture parallel = context.parallel("combined", config);
+        try (parallel) {
+            parallel.branch("branch-0", String.class, branch -> {
+                throw new RuntimeException("branch 0 failed");
+            });
+            parallel.branch("branch-1", String.class, branch -> {
+                throw new RuntimeException("branch 1 failed");
+            });
+            parallel.branch("branch-2", String.class, branch -> "ok2");
+            parallel.branch("branch-3", String.class, branch -> "ok3");
+        }
+        ParallelResult result = parallel.get();
+
+        var out = new LinkedHashMap<String, Object>();
+        out.put("completionReason", result.completionStatus().name());
+        out.put("successCount", result.succeeded());
+        out.put("failureCount", result.failed());
+        out.put("totalCount", result.succeeded() + result.failed());
+        return out;
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelConcurrent.java
+++ b/conformance-tests/src/main/java/parallel/ParallelConcurrent.java
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableFuture;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.ParallelConfig;
+
+/**
+ * 8-11: Parallel executing branches concurrently returns results in branch index order
+ *
+ * <p>Three branches with max-concurrency=2, so up to two branches run concurrently and complete in a nondeterministic
+ * order. Results are collected from the branch futures in registration (index) order, which the SDK guarantees
+ * regardless of completion order.
+ */
+public class ParallelConcurrent extends DurableHandler<Object, List<String>> {
+
+    @Override
+    public List<String> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder().maxConcurrency(2).build();
+        var futures = new ArrayList<DurableFuture<String>>();
+        ParallelDurableFuture parallel = context.parallel("concurrent", config);
+        try (parallel) {
+            futures.add(parallel.branch("branch-0", String.class, branch -> "r0"));
+            futures.add(parallel.branch("branch-1", String.class, branch -> "r1"));
+            futures.add(parallel.branch("branch-2", String.class, branch -> "r2"));
+        }
+        return futures.stream().map(DurableFuture::get).toList();
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelEmpty.java
+++ b/conformance-tests/src/main/java/parallel/ParallelEmpty.java
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+
+/**
+ * 8-5: Parallel invoked with an empty branches list completes immediately with no branches
+ *
+ * <p>No branches are registered; the parallel context is opened and immediately closed (join). The batch completes with
+ * ALL_COMPLETED and zero branches, and the handler returns an empty list.
+ */
+public class ParallelEmpty extends DurableHandler<Object, List<Object>> {
+
+    @Override
+    public List<Object> handleRequest(Object input, DurableContext context) {
+        ParallelDurableFuture parallel = context.parallel("empty");
+        try (parallel) {
+            // no branches registered
+        }
+        parallel.get();
+        return List.of();
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelFailFast.java
+++ b/conformance-tests/src/main/java/parallel/ParallelFailFast.java
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.CompletionConfig;
+import software.amazon.lambda.durable.config.ParallelConfig;
+import software.amazon.lambda.durable.model.ParallelResult;
+
+/**
+ * 8-6: Parallel with a fail-fast completion config (tolerated-failure-count=0) stops on the first branch failure and
+ * does not start remaining branches
+ *
+ * <p>Fail-fast is configured explicitly via {@code CompletionConfig.allSuccessful()} (toleratedFailureCount=0),
+ * matching the requirement's fail-fast completion config. Note: Java's default {@code ParallelConfig} is
+ * {@code allCompleted()} (run every branch, tolerate all failures), so fail-fast must be requested explicitly — unlike
+ * the JS/Python default. The reframed requirement specifies the explicit config, so all SDKs are uniform.
+ *
+ * <p>Branches return/throw directly (no inner step), matching the step-free branch history. The parallel operation
+ * itself does not rethrow; the handler projects the batch summary.
+ */
+public class ParallelFailFast extends DurableHandler<Object, Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder()
+                .maxConcurrency(1)
+                .completionConfig(CompletionConfig.allSuccessful())
+                .build();
+        ParallelDurableFuture parallel = context.parallel("failfast", config);
+        try (parallel) {
+            parallel.branch("branch-0", String.class, branch -> "ok");
+            parallel.branch("branch-1", String.class, branch -> {
+                throw new RuntimeException("branch 1 failed");
+            });
+            parallel.branch("branch-2", String.class, branch -> "never");
+        }
+        ParallelResult result = parallel.get();
+
+        var out = new LinkedHashMap<String, Object>();
+        out.put("completionReason", result.completionStatus().name());
+        out.put("status", result.failed() > 0 ? "FAILED" : "SUCCEEDED");
+        out.put("successCount", result.succeeded());
+        out.put("failureCount", result.failed());
+        out.put("totalCount", result.succeeded() + result.failed());
+        return out;
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelFlat.java
+++ b/conformance-tests/src/main/java/parallel/ParallelFlat.java
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableFuture;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.NestingType;
+import software.amazon.lambda.durable.config.ParallelConfig;
+
+/**
+ * 8-12: Parallel with FLAT nesting executes branches in virtual contexts, omitting per-branch
+ * ContextStarted/ContextSucceeded events
+ *
+ * <p>Two branches, each running a single step ("fa"/"fb"), max-concurrency=1, nesting {@link NestingType#FLAT}. With
+ * FLAT nesting the branches use virtual contexts, so no ParallelBranch context events are checkpointed; each branch's
+ * step is checkpointed directly under the parent Parallel context.
+ */
+public class ParallelFlat extends DurableHandler<Object, List<String>> {
+
+    @Override
+    public List<String> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder()
+                .maxConcurrency(1)
+                .nestingType(NestingType.FLAT)
+                .build();
+        var futures = new ArrayList<DurableFuture<String>>();
+        ParallelDurableFuture parallel = context.parallel("flat", config);
+        try (parallel) {
+            futures.add(parallel.branch(
+                    "branch-0", String.class, branch -> branch.step("step-0", String.class, stepCtx -> "fa")));
+            futures.add(parallel.branch(
+                    "branch-1", String.class, branch -> branch.step("step-1", String.class, stepCtx -> "fb")));
+        }
+        return futures.stream().map(DurableFuture::get).toList();
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelHeterogeneous.java
+++ b/conformance-tests/src/main/java/parallel/ParallelHeterogeneous.java
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.List;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableFuture;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.ParallelConfig;
+
+/**
+ * 8-4: Parallel whose branches return different types (string, number, object)
+ *
+ * <p>Each branch declares its own result type token (String, Integer, Map) so every branch result is serialized and
+ * deserialized with its own type preserved. Results are collected in branch index order.
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class ParallelHeterogeneous extends DurableHandler<Object, List<Object>> {
+
+    @Override
+    public List<Object> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder().maxConcurrency(1).build();
+        ParallelDurableFuture parallel = context.parallel("hetero", config);
+        DurableFuture<String> f0;
+        DurableFuture<Integer> f1;
+        DurableFuture<Map> f2;
+        try (parallel) {
+            f0 = parallel.branch("branch-0", String.class, branch -> "hello");
+            f1 = parallel.branch("branch-1", Integer.class, branch -> 42);
+            f2 = parallel.branch("branch-2", Map.class, branch -> Map.of("k", "v"));
+        }
+        return List.of(f0.get(), f1.get(), f2.get());
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelMinNotReached.java
+++ b/conformance-tests/src/main/java/parallel/ParallelMinNotReached.java
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.CompletionConfig;
+import software.amazon.lambda.durable.config.ParallelConfig;
+import software.amazon.lambda.durable.model.ParallelResult;
+
+/**
+ * 8-17: Parallel min-successful not reached (all branches run)
+ *
+ * <p>Branch 0 succeeds, branch 1 fails, branch 2 succeeds; min-successful=3 is never reached and there is no failure
+ * tolerance, so all branches run. Completion reason is ALL_COMPLETED and status is FAILED.
+ */
+public class ParallelMinNotReached extends DurableHandler<Object, Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder()
+                .maxConcurrency(1)
+                .completionConfig(CompletionConfig.minSuccessful(3))
+                .build();
+        ParallelDurableFuture parallel = context.parallel("min-not-reached", config);
+        try (parallel) {
+            parallel.branch("branch-0", String.class, branch -> "ok0");
+            parallel.branch("branch-1", String.class, branch -> {
+                throw new RuntimeException("branch 1 failed");
+            });
+            parallel.branch("branch-2", String.class, branch -> "ok2");
+        }
+        ParallelResult result = parallel.get();
+
+        var out = new LinkedHashMap<String, Object>();
+        out.put("completionReason", result.completionStatus().name());
+        out.put("status", result.failed() > 0 ? "FAILED" : "SUCCEEDED");
+        out.put("successCount", result.succeeded());
+        out.put("failureCount", result.failed());
+        out.put("totalCount", result.succeeded() + result.failed());
+        return out;
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelMinSuccessful.java
+++ b/conformance-tests/src/main/java/parallel/ParallelMinSuccessful.java
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.CompletionConfig;
+import software.amazon.lambda.durable.config.ParallelConfig;
+import software.amazon.lambda.durable.model.ParallelResult;
+
+/**
+ * 8-8: Parallel with a min-successful completion config stops early once enough branches succeed
+ *
+ * <p>Four branches, min-successful=2, max-concurrency=1. After branches 0 and 1 succeed the threshold is reached and
+ * branches 2 and 3 are never started. {@code totalCount} is projected as succeeded+failed (started branches), which is
+ * 2 here — the Java {@code ParallelResult.size()} would instead include the SKIPPED branches.
+ */
+public class ParallelMinSuccessful extends DurableHandler<Object, Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder()
+                .maxConcurrency(1)
+                .completionConfig(CompletionConfig.minSuccessful(2))
+                .build();
+        ParallelDurableFuture parallel = context.parallel("min-successful", config);
+        try (parallel) {
+            parallel.branch("branch-0", String.class, branch -> "v0");
+            parallel.branch("branch-1", String.class, branch -> "v1");
+            parallel.branch("branch-2", String.class, branch -> "v2");
+            parallel.branch("branch-3", String.class, branch -> "v3");
+        }
+        ParallelResult result = parallel.get();
+
+        var out = new LinkedHashMap<String, Object>();
+        out.put("completionReason", result.completionStatus().name());
+        out.put("successCount", result.succeeded());
+        out.put("totalCount", result.succeeded() + result.failed());
+        return out;
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelNamedBranches.java
+++ b/conformance-tests/src/main/java/parallel/ParallelNamedBranches.java
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableFuture;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.ParallelConfig;
+
+/**
+ * 8-3: Parallel invoked with named-branch objects (a name plus a function)
+ *
+ * <p>In the Java SDK every branch is created via {@code branch(name, type, func)}, so each branch is inherently named.
+ * The branch names "first" and "second" are supplied; each function returns its constant directly.
+ */
+public class ParallelNamedBranches extends DurableHandler<Object, List<String>> {
+
+    @Override
+    public List<String> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder().maxConcurrency(1).build();
+        var futures = new ArrayList<DurableFuture<String>>();
+        ParallelDurableFuture parallel = context.parallel("named", config);
+        try (parallel) {
+            futures.add(parallel.branch("first", String.class, branch -> "one"));
+            futures.add(parallel.branch("second", String.class, branch -> "two"));
+        }
+        return futures.stream().map(DurableFuture::get).toList();
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelNested.java
+++ b/conformance-tests/src/main/java/parallel/ParallelNested.java
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableFuture;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.ParallelConfig;
+
+/**
+ * 8-21: Nested parallel (a parallel operation inside a parallel branch)
+ *
+ * <p>The outer parallel has a single branch that itself runs an inner parallel of two steps ("i1", "i2") and returns
+ * the inner ordered results. The outer result is therefore a single-element list containing the inner list.
+ */
+public class ParallelNested extends DurableHandler<Object, Object> {
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Object handleRequest(Object input, DurableContext context) {
+        var outerConfig = ParallelConfig.builder().maxConcurrency(1).build();
+        ParallelDurableFuture outer = context.parallel("outer", outerConfig);
+        DurableFuture<List> branchAFuture;
+        try (outer) {
+            branchAFuture = outer.branch("branchA", List.class, branch -> {
+                var innerConfig = ParallelConfig.builder().maxConcurrency(1).build();
+                var innerFutures = new ArrayList<DurableFuture<String>>();
+                ParallelDurableFuture inner = branch.parallel("inner", innerConfig);
+                try (inner) {
+                    innerFutures.add(
+                            inner.branch("inner-0", String.class, c2 -> c2.step("step-0", String.class, sc -> "i1")));
+                    innerFutures.add(
+                            inner.branch("inner-1", String.class, c2 -> c2.step("step-1", String.class, sc -> "i2")));
+                }
+                return (List) innerFutures.stream().map(DurableFuture::get).toList();
+            });
+        }
+        return List.of(branchAFuture.get());
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelReplaySkipsSucceeded.java
+++ b/conformance-tests/src/main/java/parallel/ParallelReplaySkipsSucceeded.java
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableFuture;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.ParallelConfig;
+
+/**
+ * 8-14: Parallel replay skips succeeded branches across a wait suspension
+ *
+ * <p>Branch 0 runs a step and succeeds; branch 1 waits 2s then returns. With max-concurrency 1 the first invocation
+ * completes branch 0 and suspends on branch 1's wait; on replay branch 0 is skipped and reconstructed.
+ */
+public class ParallelReplaySkipsSucceeded extends DurableHandler<Object, List<String>> {
+
+    @Override
+    public List<String> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder().maxConcurrency(1).build();
+        var futures = new ArrayList<DurableFuture<String>>();
+        ParallelDurableFuture parallel = context.parallel("replay", config);
+        try (parallel) {
+            futures.add(parallel.branch(
+                    "branch-0", String.class, branch -> branch.step("step-0", String.class, stepCtx -> "b0")));
+            futures.add(parallel.branch("branch-1", String.class, branch -> {
+                branch.wait(null, Duration.ofSeconds(2));
+                return "b1";
+            }));
+        }
+        return futures.stream().map(DurableFuture::get).toList();
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelThrowIfError.java
+++ b/conformance-tests/src/main/java/parallel/ParallelThrowIfError.java
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableFuture;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.CompletionConfig;
+import software.amazon.lambda.durable.config.ParallelConfig;
+
+/**
+ * 8-7: Parallel where the handler asks the batch result to rethrow, propagating a branch failure so the execution fails
+ *
+ * <p>DIVERGENCE NOTES:
+ *
+ * <ul>
+ *   <li>Fail-fast is configured explicitly via {@code CompletionConfig.allSuccessful()} (toleratedFailureCount=0),
+ *       matching the reframed requirement; Java's default is {@code allCompleted()}, so it must be requested
+ *       explicitly.
+ *   <li>The Java {@code ParallelResult} record has no "throw-if-error" method. To propagate the branch failure, the
+ *       handler calls {@code get()} on the failed branch's {@link DurableFuture}, which rethrows the branch exception.
+ *       The uncaught exception fails the execution.
+ * </ul>
+ */
+public class ParallelThrowIfError extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder()
+                .maxConcurrency(1)
+                .completionConfig(CompletionConfig.allSuccessful())
+                .build();
+        ParallelDurableFuture parallel = context.parallel("throwing", config);
+        DurableFuture<String> branch0;
+        try (parallel) {
+            branch0 = parallel.branch("branch-0", String.class, branch -> {
+                throw new RuntimeException("branch 0 failed");
+            });
+            parallel.branch("branch-1", String.class, branch -> "never");
+        }
+        parallel.get();
+        // Rethrow the first branch failure (Java has no batch-level throw-if-error); propagates uncaught.
+        return branch0.get();
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelToleratedExceeded.java
+++ b/conformance-tests/src/main/java/parallel/ParallelToleratedExceeded.java
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.CompletionConfig;
+import software.amazon.lambda.durable.config.ParallelConfig;
+import software.amazon.lambda.durable.model.ParallelResult;
+
+/**
+ * 8-10: Parallel stops early once the failure count exceeds the tolerated-failure-count
+ *
+ * <p>Three branches, tolerated-failure-count=1, max-concurrency=1. Branch 0 fails (count 1, within tolerance), branch 1
+ * fails (count 2, exceeding tolerance), so the operation stops and branch 2 is never started
+ * (FAILURE_TOLERANCE_EXCEEDED). {@code totalCount} is projected as succeeded+failed (2 started branches).
+ */
+public class ParallelToleratedExceeded extends DurableHandler<Object, Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder()
+                .maxConcurrency(1)
+                .completionConfig(CompletionConfig.toleratedFailureCount(1))
+                .build();
+        ParallelDurableFuture parallel = context.parallel("tolerated-exceeded", config);
+        try (parallel) {
+            parallel.branch("branch-0", String.class, branch -> {
+                throw new RuntimeException("branch 0 failed");
+            });
+            parallel.branch("branch-1", String.class, branch -> {
+                throw new RuntimeException("branch 1 failed");
+            });
+            parallel.branch("branch-2", String.class, branch -> "never");
+        }
+        ParallelResult result = parallel.get();
+
+        var out = new LinkedHashMap<String, Object>();
+        out.put("completionReason", result.completionStatus().name());
+        out.put("successCount", result.succeeded());
+        out.put("failureCount", result.failed());
+        out.put("totalCount", result.succeeded() + result.failed());
+        return out;
+    }
+}

--- a/conformance-tests/src/main/java/parallel/ParallelToleratedWithin.java
+++ b/conformance-tests/src/main/java/parallel/ParallelToleratedWithin.java
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package parallel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.ParallelDurableFuture;
+import software.amazon.lambda.durable.config.CompletionConfig;
+import software.amazon.lambda.durable.config.ParallelConfig;
+import software.amazon.lambda.durable.model.ParallelResult;
+
+/**
+ * 8-9: Parallel with a tolerated-failure-count tolerating one failure completes all branches
+ *
+ * <p>Three branches, tolerated-failure-count=1, max-concurrency=1. Branch 1 fails but the failure count (1) does not
+ * exceed the tolerance (1), so all branches complete (ALL_COMPLETED). {@code status} is FAILED because at least one
+ * branch failed (derived from failed &gt; 0).
+ */
+public class ParallelToleratedWithin extends DurableHandler<Object, Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> handleRequest(Object input, DurableContext context) {
+        var config = ParallelConfig.builder()
+                .maxConcurrency(1)
+                .completionConfig(CompletionConfig.toleratedFailureCount(1))
+                .build();
+        ParallelDurableFuture parallel = context.parallel("tolerated", config);
+        try (parallel) {
+            parallel.branch("branch-0", String.class, branch -> "s0");
+            parallel.branch("branch-1", String.class, branch -> {
+                throw new RuntimeException("branch 1 failed");
+            });
+            parallel.branch("branch-2", String.class, branch -> "s2");
+        }
+        ParallelResult result = parallel.get();
+
+        var out = new LinkedHashMap<String, Object>();
+        out.put("completionReason", result.completionStatus().name());
+        out.put("status", result.failed() > 0 ? "FAILED" : "SUCCEEDED");
+        out.put("successCount", result.succeeded());
+        out.put("failureCount", result.failed());
+        out.put("totalCount", result.succeeded() + result.failed());
+        return out;
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackAnonymous.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackAnonymous.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 7-3: Wait-for-callback with anonymous submitter (no name). */
+public class WaitForCallbackAnonymous extends DurableHandler<Object, String> {
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.waitForCallback(null, String.class, (callbackId, stepCtx) -> {
+            // Anonymous submitter — no name passed.
+        });
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackBasic.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackBasic.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 7-1: Wait-for-callback basic (success via external callback). */
+public class WaitForCallbackBasic extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        return context.waitForCallback(input, String.class, (callbackId, stepCtx) -> {
+            // Submitter receives the callback id; nothing durable to do.
+        });
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackExplicitName.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackExplicitName.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 7-2: Wait-for-callback with explicit static name ("approval"). */
+public class WaitForCallbackExplicitName extends DurableHandler<Object, String> {
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.waitForCallback("approval", String.class, (callbackId, stepCtx) -> {
+            // Submitter completes without side effects.
+        });
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackExternalFailure.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackExternalFailure.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 7-4: Wait-for-callback external failure (uncaught). */
+public class WaitForCallbackExternalFailure extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        // Do not catch — let the external failure propagate so the execution fails.
+        return context.waitForCallback(input, String.class, (callbackId, stepCtx) -> {
+            // Submitter completes normally.
+        });
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackFailureCaught.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackFailureCaught.java
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.execution.SuspendExecutionException;
+
+/** 7-6: Wait-for-callback external failure caught (recovers). */
+public class WaitForCallbackFailureCaught extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        try {
+            return context.waitForCallback(input, String.class, (callbackId, stepCtx) -> {
+                // Submitter completes normally.
+            });
+        } catch (SuspendExecutionException e) {
+            throw e;
+        } catch (Exception e) {
+            return "recovered";
+        }
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackHeartbeatThenSuccess.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackHeartbeatThenSuccess.java
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.CallbackConfig;
+import software.amazon.lambda.durable.config.WaitForCallbackConfig;
+
+/** 7-13: Wait-for-callback with heartbeat then success. */
+public class WaitForCallbackHeartbeatThenSuccess extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var config = WaitForCallbackConfig.builder()
+                .callbackConfig(CallbackConfig.builder()
+                        .heartbeatTimeout(Duration.ofSeconds(10))
+                        .build())
+                .build();
+        return context.waitForCallback(
+                input,
+                String.class,
+                (callbackId, stepCtx) -> {
+                    // Submitter completes normally.
+                },
+                config);
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackHeartbeatTimeout.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackHeartbeatTimeout.java
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.CallbackConfig;
+import software.amazon.lambda.durable.config.WaitForCallbackConfig;
+
+/** 7-12: Wait-for-callback heartbeat timeout (no heartbeat sent). */
+public class WaitForCallbackHeartbeatTimeout extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var config = WaitForCallbackConfig.builder()
+                .callbackConfig(CallbackConfig.builder()
+                        .heartbeatTimeout(Duration.ofSeconds(5))
+                        .build())
+                .build();
+        // Do not catch — let the heartbeat timeout propagate so the execution fails.
+        return context.waitForCallback(
+                input,
+                String.class,
+                (callbackId, stepCtx) -> {
+                    // Submitter completes normally.
+                },
+                config);
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackInChildContext.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackInChildContext.java
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 7-8: Wait-for-callback inside a child context. */
+public class WaitForCallbackInChildContext extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        return context.runInChildContext(
+                "wrapper",
+                String.class,
+                child -> child.waitForCallback(input, String.class, (callbackId, stepCtx) -> {
+                    // Submitter completes normally inside the child context.
+                }));
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackJsonResult.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackJsonResult.java
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
+
+/** 7-11: Wait-for-callback with structured (JSON) result deserialization. */
+public class WaitForCallbackJsonResult extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        Map<String, String> result =
+                context.waitForCallback(input, new TypeToken<Map<String, String>>() {}, (callbackId, stepCtx) -> {
+                    // Submitter completes normally.
+                });
+        return result.get("status");
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackMixedOps.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackMixedOps.java
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 7-10: Wait-for-callback mixed with wait and step. */
+public class WaitForCallbackMixedOps extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        // 1. Durable wait (1 second)
+        context.wait(null, Duration.ofSeconds(1));
+
+        // 2. Top-level step returning fixed data
+        context.step(null, String.class, stepCtx -> "fixed-data");
+
+        // 3. Wait-for-callback using input as operation name
+        return context.waitForCallback(input, String.class, (callbackId, stepCtx) -> {
+            // Submitter completes normally.
+        });
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackNullResult.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackNullResult.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 7-15: Wait-for-callback success with empty (null) payload. */
+public class WaitForCallbackNullResult extends DurableHandler<String, Object> {
+    @Override
+    public Object handleRequest(String input, DurableContext context) {
+        return context.waitForCallback(input, Object.class, (callbackId, stepCtx) -> {
+            // Submitter completes normally.
+        });
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackSubmitterRetryExhaustion.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackSubmitterRetryExhaustion.java
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.config.WaitForCallbackConfig;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+
+/** 7-7: Wait-for-callback submitter retry exhaustion. */
+public class WaitForCallbackSubmitterRetryExhaustion extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var config = WaitForCallbackConfig.builder()
+                .stepConfig(StepConfig.builder()
+                        .retryStrategy(RetryStrategies.fixedDelay(2, Duration.ofSeconds(1)))
+                        .build())
+                .build();
+        // Submitter always throws; do not catch — let the execution fail.
+        return context.waitForCallback(
+                input,
+                String.class,
+                (callbackId, stepCtx) -> {
+                    throw new RuntimeException("submitter always fails");
+                },
+                config);
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackTimeout.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackTimeout.java
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.CallbackConfig;
+import software.amazon.lambda.durable.config.WaitForCallbackConfig;
+
+/** 7-5: Wait-for-callback timeout (no external completion). */
+public class WaitForCallbackTimeout extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var config = WaitForCallbackConfig.builder()
+                .callbackConfig(
+                        CallbackConfig.builder().timeout(Duration.ofSeconds(3)).build())
+                .build();
+        // Do not catch — let the timeout propagate so the execution fails.
+        return context.waitForCallback(
+                input,
+                String.class,
+                (callbackId, stepCtx) -> {
+                    // Submitter completes normally.
+                },
+                config);
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackTimeoutCaught.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackTimeoutCaught.java
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.CallbackConfig;
+import software.amazon.lambda.durable.config.WaitForCallbackConfig;
+import software.amazon.lambda.durable.execution.SuspendExecutionException;
+
+/** 7-14: Wait-for-callback timeout caught (recovers). */
+public class WaitForCallbackTimeoutCaught extends DurableHandler<String, String> {
+    @Override
+    public String handleRequest(String input, DurableContext context) {
+        var config = WaitForCallbackConfig.builder()
+                .callbackConfig(
+                        CallbackConfig.builder().timeout(Duration.ofSeconds(3)).build())
+                .build();
+        try {
+            return context.waitForCallback(
+                    input,
+                    String.class,
+                    (callbackId, stepCtx) -> {
+                        // Submitter completes normally.
+                    },
+                    config);
+        } catch (SuspendExecutionException e) {
+            throw e;
+        } catch (Exception e) {
+            return "timed-out-handled";
+        }
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackTwoSequential.java
+++ b/conformance-tests/src/main/java/wait_for_callback/WaitForCallbackTwoSequential.java
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_callback;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 7-9: Multiple sequential wait-for-callback operations. */
+public class WaitForCallbackTwoSequential extends DurableHandler<Object, String> {
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        context.waitForCallback("first", String.class, (callbackId, stepCtx) -> {
+            // First submitter completes.
+        });
+
+        String second = context.waitForCallback("second", String.class, (callbackId, stepCtx) -> {
+            // Second submitter completes.
+        });
+
+        return second;
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionBasic.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionBasic.java
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.WaitForConditionConfig;
+import software.amazon.lambda.durable.model.WaitForConditionResult;
+
+/** 6-1: Wait-for-condition basic (polls until threshold met) */
+public class WaitForConditionBasic extends DurableHandler<Integer, Integer> {
+
+    @Override
+    public Integer handleRequest(Integer threshold, DurableContext context) {
+        return context.waitForCondition(
+                null,
+                Integer.class,
+                (state, stepCtx) -> {
+                    int next = state + 1;
+                    if (next >= threshold) {
+                        return WaitForConditionResult.stopPolling(next);
+                    }
+                    return WaitForConditionResult.continuePolling(next);
+                },
+                WaitForConditionConfig.<Integer>builder().initialState(0).build());
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionCheckThrows.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionCheckThrows.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 6-7: Wait-for-condition check function throws (uncaught failure) */
+public class WaitForConditionCheckThrows extends DurableHandler<Object, Object> {
+
+    @Override
+    public Object handleRequest(Object input, DurableContext context) {
+        return context.waitForCondition(null, Object.class, (state, stepCtx) -> {
+            throw new RuntimeException("Check function error");
+        });
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionCheckThrowsCaught.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionCheckThrowsCaught.java
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+/** 6-8: Wait-for-condition check throws, caught by handler (recovers) */
+public class WaitForConditionCheckThrowsCaught extends DurableHandler<Object, String> {
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        try {
+            context.waitForCondition(null, Object.class, (state, stepCtx) -> {
+                throw new RuntimeException("Check function error");
+            });
+        } catch (RuntimeException e) {
+            return "recovered";
+        }
+        // Distinct fallback: if waitForCondition ever stops propagating the check-function
+        // error, this path is hit and the test fails (matching Python None / JS undefined),
+        // so a lost-exception regression is detectable rather than silently passing.
+        return "should_not_reach_here";
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionComplexObject.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionComplexObject.java
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.WaitForConditionConfig;
+import software.amazon.lambda.durable.model.WaitForConditionResult;
+
+/** 6-9: Wait-for-condition with a complex object state */
+@SuppressWarnings("unchecked")
+public class WaitForConditionComplexObject extends DurableHandler<Object, Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> handleRequest(Object input, DurableContext context) {
+        Map<String, Object> initialState = Map.of("status", "PENDING", "attempts", 0);
+
+        return context.waitForCondition(
+                null,
+                new TypeToken<Map<String, Object>>() {},
+                (state, stepCtx) -> {
+                    int attempts = ((Number) state.get("attempts")).intValue() + 1;
+                    if (attempts >= 2) {
+                        Map<String, Object> doneState = Map.of("status", "DONE", "attempts", attempts);
+                        return WaitForConditionResult.stopPolling(doneState);
+                    }
+                    Map<String, Object> nextState = Map.of("status", "PENDING", "attempts", attempts);
+                    return WaitForConditionResult.continuePolling(nextState);
+                },
+                WaitForConditionConfig.<Map<String, Object>>builder()
+                        .initialState(initialState)
+                        .build());
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionCustomSerdes.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionCustomSerdes.java
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.WaitForConditionConfig;
+import software.amazon.lambda.durable.model.WaitForConditionResult;
+import software.amazon.lambda.durable.serde.SerDes;
+
+/** 6-11: Wait-for-condition with custom state serdes */
+public class WaitForConditionCustomSerdes extends DurableHandler<Object, String> {
+
+    /**
+     * Custom SerDes that encodes the string state with a visible "ENC:" prefix and decodes by stripping it, exercising
+     * the serialization round-trip across suspensions. The "ENC:" prefix (matching the JS and Python examples) is a
+     * clearly non-standard encoding, so the test detects a regression where the SDK ignores the configured serdes and
+     * falls back to its default JSON serializer (which would emit a plain JSON-quoted string, not an "ENC:"-prefixed
+     * value).
+     */
+    private static final SerDes CUSTOM_SERDES = new SerDes() {
+        @Override
+        public String serialize(Object value) {
+            if (value == null) {
+                return null;
+            }
+            // Encode: prefix with "ENC:" (non-standard, so custom serdes use is provable)
+            return "ENC:" + value;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            if (data == null) {
+                return null;
+            }
+            // Decode: strip the "ENC:" prefix
+            if (data.startsWith("ENC:")) {
+                return (T) data.substring(4);
+            }
+            return (T) data;
+        }
+    };
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        return context.waitForCondition(
+                null,
+                String.class,
+                (state, stepCtx) -> {
+                    String current = state != null ? state : "";
+                    String next = current + "x";
+                    if (next.length() >= 2) {
+                        return WaitForConditionResult.stopPolling(next);
+                    }
+                    return WaitForConditionResult.continuePolling(next);
+                },
+                WaitForConditionConfig.<String>builder()
+                        .initialState("")
+                        .serDes(CUSTOM_SERDES)
+                        .build());
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionFixedDelay.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionFixedDelay.java
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.WaitForConditionConfig;
+import software.amazon.lambda.durable.model.WaitForConditionResult;
+import software.amazon.lambda.durable.retry.WaitStrategies;
+
+/** 6-5: Wait-for-condition fixed-delay wait strategy */
+public class WaitForConditionFixedDelay extends DurableHandler<Integer, Integer> {
+
+    @Override
+    public Integer handleRequest(Integer threshold, DurableContext context) {
+        return context.waitForCondition(
+                null,
+                Integer.class,
+                (state, stepCtx) -> {
+                    int next = state + 1;
+                    if (next >= threshold) {
+                        return WaitForConditionResult.stopPolling(next);
+                    }
+                    return WaitForConditionResult.continuePolling(next);
+                },
+                WaitForConditionConfig.<Integer>builder()
+                        .initialState(0)
+                        .waitStrategy(WaitStrategies.fixedDelay(60, Duration.ofSeconds(2)))
+                        .build());
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionImmediate.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionImmediate.java
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.WaitForConditionConfig;
+import software.amazon.lambda.durable.model.WaitForConditionResult;
+
+/** 6-2: Wait-for-condition immediate (condition already met on first check) */
+public class WaitForConditionImmediate extends DurableHandler<Integer, Integer> {
+
+    @Override
+    public Integer handleRequest(Integer input, DurableContext context) {
+        return context.waitForCondition(
+                null,
+                Integer.class,
+                (state, stepCtx) -> {
+                    // Convention shared with the Python/JS examples: initial state comes from
+                    // the input and the threshold is a fixed constant (5). For input 5 the
+                    // condition (state >= 5) is already met on the first check.
+                    if (state >= 5) {
+                        return WaitForConditionResult.stopPolling(state);
+                    }
+                    return WaitForConditionResult.continuePolling(state);
+                },
+                WaitForConditionConfig.<Integer>builder().initialState(input).build());
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionInitialState.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionInitialState.java
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.WaitForConditionConfig;
+import software.amazon.lambda.durable.model.WaitForConditionResult;
+
+/** 6-4: Wait-for-condition custom initial state (state threaded across polls) */
+public class WaitForConditionInitialState extends DurableHandler<Integer, Integer> {
+
+    @Override
+    public Integer handleRequest(Integer threshold, DurableContext context) {
+        return context.waitForCondition(
+                null,
+                Integer.class,
+                (state, stepCtx) -> {
+                    int next = state + 1;
+                    if (next >= threshold) {
+                        return WaitForConditionResult.stopPolling(next);
+                    }
+                    return WaitForConditionResult.continuePolling(next);
+                },
+                WaitForConditionConfig.<Integer>builder().initialState(5).build());
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionMaxAttempts.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionMaxAttempts.java
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.WaitForConditionConfig;
+import software.amazon.lambda.durable.model.WaitForConditionResult;
+import software.amazon.lambda.durable.retry.WaitStrategies;
+
+/** 6-6: Wait-for-condition max attempts exceeded (failure) */
+public class WaitForConditionMaxAttempts extends DurableHandler<Object, Integer> {
+
+    @Override
+    public Integer handleRequest(Object input, DurableContext context) {
+        return context.waitForCondition(
+                null,
+                Integer.class,
+                (state, stepCtx) -> {
+                    // Condition is never met; always continue polling
+                    return WaitForConditionResult.continuePolling(state + 1);
+                },
+                WaitForConditionConfig.<Integer>builder()
+                        .initialState(0)
+                        .waitStrategy(WaitStrategies.fixedDelay(3, Duration.ofSeconds(1)))
+                        .build());
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionMultipleSequential.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionMultipleSequential.java
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.WaitForConditionConfig;
+import software.amazon.lambda.durable.model.WaitForConditionResult;
+
+/** 6-13: Multiple sequential wait_for_condition operations — first result seeds second */
+public class WaitForConditionMultipleSequential extends DurableHandler<Object, Integer> {
+
+    @Override
+    public Integer handleRequest(Object input, DurableContext context) {
+        // First wait_for_condition: initial state 0, threshold 2
+        Integer firstResult = context.waitForCondition(
+                null,
+                Integer.class,
+                (state, stepCtx) -> {
+                    int next = state + 1;
+                    if (next >= 2) {
+                        return WaitForConditionResult.stopPolling(next);
+                    }
+                    return WaitForConditionResult.continuePolling(next);
+                },
+                WaitForConditionConfig.<Integer>builder().initialState(0).build());
+
+        // Second wait_for_condition: initial state = firstResult (2), threshold 4
+        Integer secondResult = context.waitForCondition(
+                null,
+                Integer.class,
+                (state, stepCtx) -> {
+                    int next = state + 1;
+                    if (next >= 4) {
+                        return WaitForConditionResult.stopPolling(next);
+                    }
+                    return WaitForConditionResult.continuePolling(next);
+                },
+                WaitForConditionConfig.<Integer>builder()
+                        .initialState(firstResult)
+                        .build());
+
+        return secondResult;
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionNamed.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionNamed.java
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.WaitForConditionConfig;
+import software.amazon.lambda.durable.model.WaitForConditionResult;
+
+/** 6-3: Wait-for-condition with explicit name */
+public class WaitForConditionNamed extends DurableHandler<Integer, Integer> {
+
+    @Override
+    public Integer handleRequest(Integer threshold, DurableContext context) {
+        return context.waitForCondition(
+                "poll-status",
+                Integer.class,
+                (state, stepCtx) -> {
+                    int next = state + 1;
+                    if (next >= threshold) {
+                        return WaitForConditionResult.stopPolling(next);
+                    }
+                    return WaitForConditionResult.continuePolling(next);
+                },
+                WaitForConditionConfig.<Integer>builder().initialState(0).build());
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionNullResult.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionNullResult.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.model.WaitForConditionResult;
+
+/** 6-10: Wait-for-condition null result */
+public class WaitForConditionNullResult extends DurableHandler<Object, Object> {
+
+    @Override
+    public Object handleRequest(Object input, DurableContext context) {
+        return context.waitForCondition(
+                null, Object.class, (state, stepCtx) -> WaitForConditionResult.stopPolling(null));
+    }
+}

--- a/conformance-tests/src/main/java/wait_for_condition/WaitForConditionThenStep.java
+++ b/conformance-tests/src/main/java/wait_for_condition/WaitForConditionThenStep.java
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wait_for_condition;
+
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.WaitForConditionConfig;
+import software.amazon.lambda.durable.model.WaitForConditionResult;
+
+/** 6-12: Wait-for-condition followed by a step (result passed onward) */
+public class WaitForConditionThenStep extends DurableHandler<Integer, Integer> {
+
+    @Override
+    public Integer handleRequest(Integer threshold, DurableContext context) {
+        Integer pollResult = context.waitForCondition(
+                null,
+                Integer.class,
+                (state, stepCtx) -> {
+                    int next = state + 1;
+                    if (next >= threshold) {
+                        return WaitForConditionResult.stopPolling(next);
+                    }
+                    return WaitForConditionResult.continuePolling(next);
+                },
+                WaitForConditionConfig.<Integer>builder().initialState(0).build());
+
+        return context.step(null, Integer.class, stepCtx -> pollResult * 10);
+    }
+}

--- a/conformance-tests/template_callback.yaml
+++ b/conformance-tests/template_callback.yaml
@@ -1,0 +1,314 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Durable Execution Conformance Test Examples - Java (Callback)
+
+Parameters:
+  Architecture:
+    Type: String
+    Default: arm64
+    AllowedValues: [x86_64, arm64]
+  JavaVersion:
+    Type: String
+    Default: 'java21'
+
+Globals:
+  Function:
+    Timeout: 60
+    MemorySize: 512
+    Runtime:
+      Ref: JavaVersion
+    Architectures:
+      - Ref: Architecture
+
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: DurableExecutionPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:CheckpointDurableExecution
+                  - lambda:GetDurableExecutionState
+                  - lambda:SendDurableExecutionCallbackSuccess
+                  - lambda:SendDurableExecutionCallbackFailure
+                  - lambda:SendDurableExecutionCallbackHeartbeat
+                Resource: '*'
+
+  CallbackBasic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-1"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackBasic
+      Description: Callback basic - anonymous, success
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackWithName:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-2"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackWithName
+      Description: Callback with explicit name
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-3"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackTimeout
+      Description: Callback general timeout
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackHeartbeatTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-4"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackHeartbeatTimeout
+      Description: Callback heartbeat timeout
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackHeartbeatSuccess:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-5"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackHeartbeatSuccess
+      Description: Callback with heartbeat then success
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackFailure:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-6"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackFailure
+      Description: Callback failure
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackStepFailure:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-7"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackStepFailure
+      Description: Callback + Step + failure
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackStepTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-8"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackStepTimeout
+      Description: Callback + Step + timeout
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackWaitSuccess:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-9"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackWaitSuccess
+      Description: Callback + Wait + success
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackWaitFailure:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-10"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackWaitFailure
+      Description: Callback + Wait + failure
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackWaitTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-11"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackWaitTimeout
+      Description: Callback + Wait + timeout
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackReplayWithWait:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-12"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackReplayWithWait
+      Description: Callback success then wait
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackReplayFailure:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-13"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackReplayFailure
+      Description: Callback failure caught then wait
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackReplayTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-14"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackReplayTimeout
+      Description: Callback timeout caught then wait
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackSerdesHappy:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-15"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackSerdesHappy
+      Description: Custom serdes (Date roundtrip)
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackSerdesNumeric:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-16"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackSerdesNumeric
+      Description: Custom serdes (numeric)
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackTwoSequential:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-17"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackTwoSequential
+      Description: Two callbacks - sequential create and wait
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackTwoParallel:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-18"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackTwoParallel
+      Description: Two callbacks - create both then wait in order
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackTwoParallelReverse:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["4-19"]
+    Properties:
+      CodeUri: .
+      Handler: callback.CallbackTwoParallelReverse
+      Description: Two callbacks - create both then wait in reverse order
+      Role:
+        Fn::GetAtt: [DurableFunctionRole, Arn]
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300

--- a/conformance-tests/template_child.yaml
+++ b/conformance-tests/template_child.yaml
@@ -1,0 +1,365 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Durable Execution Conformance Test Examples - Java (Child)
+
+Parameters:
+  Architecture:
+    Type: String
+    Default: arm64
+    Description: Lambda Function Architecture
+    AllowedValues:
+      - x86_64
+      - arm64
+  JavaVersion:
+    Type: String
+    Default: 'java21'
+    Description: Java runtime version
+
+Globals:
+  Function:
+    Timeout: 60
+    MemorySize: 512
+    Runtime:
+      Ref: JavaVersion
+    Architectures:
+      - Ref: Architecture
+
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+      - PolicyName: DynamoDBPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - dynamodb:GetItem
+            - dynamodb:PutItem
+            - dynamodb:UpdateItem
+            Resource:
+              Fn::GetAtt:
+              - JavaChildAttemptsTable
+              - Arn
+
+  JavaChildAttemptsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+      - AttributeName: executionId
+        AttributeType: S
+      KeySchema:
+      - AttributeName: executionId
+        KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+
+  ChildBasic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-1"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildBasic
+      Description: Child context basic (single step inside)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildWithName:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-2"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildWithName
+      Description: Child context with name
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildMultipleSteps:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-3"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildMultipleSteps
+      Description: Child context with multiple sequential steps
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildWithError:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-4"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildWithError
+      Description: Child context error (step fails, execution fails)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildErrorCaught:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-5"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildErrorCaught
+      Description: Child context error caught (try/catch, execution succeeds)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildNested:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-6"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildNested
+      Description: Nested child contexts
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildWithRetry:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-7"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildWithRetry
+      Description: Child context with step retry (fails then succeeds)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildRetryExhaustion:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-8"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildRetryExhaustion
+      Description: Child context with step retry exhaustion (child fails)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildReplay:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-9"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildReplay
+      Description: Child context replay (returns cached result)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildStepAndWait:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-10"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildStepAndWait
+      Description: Child context with step and wait inside
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildLargePayload:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-11"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildLargePayload
+      Description: Child context large payload (ReplayChildren mode)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildInterrupted:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-12"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildInterrupted
+      Description: Child context interrupted and re-executed
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      Environment:
+        Variables:
+          ATTEMPTS_TABLE_NAME:
+            Ref: JavaChildAttemptsTable
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildWaitReplay:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-13"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildWaitReplay
+      Description: Child context with wait inside - verify replay
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildCustomSerdes:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-14"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildCustomSerdes
+      Description: Child context with custom serdes (succeed)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildErrorNoStep:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-15"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildErrorNoStep
+      Description: Child context error without step (error thrown directly in child body)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildNullResult:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-16"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildNullResult
+      Description: Child context returning null
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildPrintOnly:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-17"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildPrintOnly
+      Description: Child context with print only (verify no re-execution on replay)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ChildStepWaitAfter:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["3-18"]
+    Properties:
+      CodeUri: .
+      Handler: child.ChildStepWaitAfter
+      Description: Child context with step and wait inside, step and wait after
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300

--- a/conformance-tests/template_invoke.yaml
+++ b/conformance-tests/template_invoke.yaml
@@ -1,0 +1,486 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Durable Execution Conformance Test Examples - Java (Invoke)
+
+Parameters:
+  Architecture:
+    Type: String
+    Default: arm64
+    Description: Lambda Function Architecture
+    AllowedValues:
+      - x86_64
+      - arm64
+  JavaVersion:
+    Type: String
+    Default: 'java21'
+    Description: Java runtime version
+
+Globals:
+  Function:
+    Timeout: 60
+    MemorySize: 512
+    Runtime:
+      Ref: JavaVersion
+    Architectures:
+      - Ref: Architecture
+
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            - lambda:InvokeFunction
+            Resource: '*'
+
+  # Target Functions
+
+  TargetEcho:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Handler: invoke.TargetEcho
+      Description: Echo target function — returns whatever it receives
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  TargetEchoTenant:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Handler: invoke.TargetEcho
+      Description: Echo target function with tenancy enabled
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      TenancyConfig:
+        TenantIsolationMode: PER_TENANT
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  TargetError:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Handler: invoke.TargetError
+      Description: Target function that throws an error
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  TargetSlow:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Handler: invoke.TargetSlow
+      Description: Target function that exceeds timeout
+      Timeout: 120
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 5
+
+  TargetNonDurable:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Handler: invoke.TargetNonDurable::handleRequest
+      Description: Non-durable target function
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+
+  # Invoke Test Handlers
+
+  InvokeBasic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-1"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeBasic
+      Description: Invoke basic (target function succeeds)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+
+  InvokeWithName:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-2"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeWithName
+      Description: Invoke with explicit name parameter
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+
+  InvokeComplexObject:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-3"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeComplexObject
+      Description: Invoke returning complex object
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+
+  InvokeNullResult:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-4"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeNullResult
+      Description: Invoke returning null
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+
+  InvokeTargetFails:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-5"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeTargetFails
+      Description: Invoke target fails (execution fails)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetError.Arn}:$LATEST"
+
+  InvokeTargetFailsCaught:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-6"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeTargetFailsCaught
+      Description: Invoke target fails, caught
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetError.Arn}:$LATEST"
+
+  InvokeTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: [] # ["5-17"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeTimeout
+      Description: Invoke timeout (target takes too long)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetSlow.Arn}:$LATEST"
+
+  InvokeTimeoutCaught:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: [] # ["5-18"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeTimeoutCaught
+      Description: Invoke timeout, caught
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetSlow.Arn}:$LATEST"
+
+  InvokeReplaySkips:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-9"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeReplaySkips
+      Description: Invoke replay skips (cached result)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+
+  InvokeReplayRethrows:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-10"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeReplayRethrows
+      Description: Invoke replay re-throws (cached error)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetError.Arn}:$LATEST"
+
+  StepThenInvoke:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-11"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.StepThenInvoke
+      Description: Step then invoke (sequential)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+
+  InvokeThenStep:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-12"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeThenStep
+      Description: Invoke then step
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+
+  InvokeInChildContext:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-13"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeInChildContext
+      Description: Invoke inside child context
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+
+  InvokeMultipleSequential:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-14"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeMultipleSequential
+      Description: Multiple sequential invokes
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME_1:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+          TARGET_FUNCTION_NAME_2:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+
+  InvokeCustomPayloadSerdes:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-15"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeCustomPayloadSerdes
+      Description: Invoke with custom payload serdes
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+
+  InvokeCustomResultSerdes:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-16"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeCustomResultSerdes
+      Description: Invoke with custom result serdes
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+
+  InvokeLargePayload:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-7"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeLargePayload
+      Description: Invoke large payload
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetEcho.Arn}:$LATEST"
+
+  InvokeWithTenantId:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["5-8"]
+    Properties:
+      CodeUri: .
+      Handler: invoke.InvokeWithTenantId
+      Description: Invoke with tenantId
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME:
+            Fn::Sub: "${TargetEchoTenant.Arn}:$LATEST"

--- a/conformance-tests/template_parallel.yaml
+++ b/conformance-tests/template_parallel.yaml
@@ -1,0 +1,353 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Durable Execution Conformance Test Examples - Java (Parallel)
+
+# NOTE: Skip 8-13 and 8-22 (tolerated-failure-percentage) -- Java's ParallelConfig
+# rejects toleratedFailurePercentage at build() time (IllegalArgumentException).
+# NOTE: Skip 8-15 (custom item serde) -- Java's ParallelConfig exposes no serde option.
+
+Parameters:
+  Architecture:
+    Type: String
+    Default: arm64
+    Description: Lambda Function Architecture
+    AllowedValues:
+      - x86_64
+      - arm64
+  JavaVersion:
+    Type: String
+    Default: 'java21'
+    Description: Java runtime version
+
+Globals:
+  Function:
+    Timeout: 60
+    MemorySize: 512
+    Runtime:
+      Ref: JavaVersion
+    Architectures:
+      - Ref: Architecture
+
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+
+  Parallel8Basic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-1"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelBasic
+      Description: Parallel basic (two branches, each a single step, all succeed)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  Parallel8BranchesOnly:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-2"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelBranchesOnly
+      Description: Parallel invoked with the branches-only form (no name argument)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  Parallel8NamedBranches:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-3"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelNamedBranches
+      Description: Parallel invoked with named-branch objects (a name plus a function)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  Parallel8Heterogeneous:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-4"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelHeterogeneous
+      Description: Parallel whose branches return different types (string, number, object)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  Parallel8Empty:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-5"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelEmpty
+      Description: Parallel invoked with an empty branches list completes immediately
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  Parallel8FailFast:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-6"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelFailFast
+      Description: Parallel fail-fast (via all-successful) stops after first failure
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  Parallel8ThrowIfError:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-7"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelThrowIfError
+      Description: Parallel rethrows a branch failure so the execution fails
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  Parallel8MinSuccessful:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-8"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelMinSuccessful
+      Description: Parallel min-successful early completion
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  Parallel8ToleratedWithinTolerance:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-9"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelToleratedWithin
+      Description: Parallel tolerated-failure-count within tolerance (all branches complete)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  Parallel8ToleratedExceeded:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-10"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelToleratedExceeded
+      Description: Parallel tolerated-failure-count exceeded (stops early)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  Parallel8Concurrent:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-11"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelConcurrent
+      Description: Parallel real concurrency preserves index-ordered results
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  Parallel8Flat:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-12"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelFlat
+      Description: Parallel with FLAT nesting (virtual branch contexts)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  ParallelReplay:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-14"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelReplaySkipsSucceeded
+      Description: Parallel replay skips succeeded branches across a wait suspension
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelAllFail:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-16"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelAllFail
+      Description: Parallel where all branches fail (within tolerance)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelMinNotReached:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-17"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelMinNotReached
+      Description: Parallel min-successful not reached (all branches run)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelCombinedConfig:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-18"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelCombinedConfig
+      Description: Parallel combined completion config (min-successful + tolerated-failure-count)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelBadConcurrency:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-19"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelBadConcurrency
+      Description: Parallel with invalid max-concurrency raises a validation error
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelAccessors:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-20"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelAccessors
+      Description: Parallel ParallelResult accessors
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelNested:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["8-21"]
+    Properties:
+      CodeUri: .
+      Handler: parallel.ParallelNested
+      Description: Nested parallel (parallel inside a parallel branch)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+

--- a/conformance-tests/template_wait_for_callback.yaml
+++ b/conformance-tests/template_wait_for_callback.yaml
@@ -1,0 +1,289 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Durable Execution Conformance Test Examples - Java (WaitForCallback)
+
+Parameters:
+  Architecture:
+    Type: String
+    Default: arm64
+    Description: Lambda Function Architecture
+    AllowedValues:
+      - x86_64
+      - arm64
+  JavaVersion:
+    Type: String
+    Default: 'java21'
+    Description: Java runtime version
+
+Globals:
+  Function:
+    Timeout: 60
+    MemorySize: 512
+    Runtime:
+      Ref: JavaVersion
+    Architectures:
+      - Ref: Architecture
+
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+
+  WaitForCallbackBasic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-1"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackBasic
+      Description: Wait-for-callback basic (success via external callback)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackExplicitName:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-2"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackExplicitName
+      Description: Wait-for-callback with explicit static name
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackAnonymous:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-3"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackAnonymous
+      Description: Wait-for-callback with anonymous submitter (no name)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackExternalFailure:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-4"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackExternalFailure
+      Description: Wait-for-callback external failure (uncaught)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-5"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackTimeout
+      Description: Wait-for-callback timeout (no external completion)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackFailureCaught:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-6"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackFailureCaught
+      Description: Wait-for-callback external failure caught (recovers)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackSubmitterRetryExhaustion:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-7"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackSubmitterRetryExhaustion
+      Description: Wait-for-callback submitter retry exhaustion
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackInChildContext:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-8"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackInChildContext
+      Description: Wait-for-callback inside a child context
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackTwoSequential:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-9"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackTwoSequential
+      Description: Multiple sequential wait-for-callback operations
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackMixedOps:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-10"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackMixedOps
+      Description: Wait-for-callback mixed with wait and step
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackJsonResult:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-11"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackJsonResult
+      Description: Wait-for-callback with structured (JSON) result deserialization
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackHeartbeatTimeout:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-12"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackHeartbeatTimeout
+      Description: Wait-for-callback heartbeat timeout (no heartbeat sent)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackHeartbeatThenSuccess:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-13"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackHeartbeatThenSuccess
+      Description: Wait-for-callback with heartbeat then success
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackTimeoutCaught:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-14"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackTimeoutCaught
+      Description: Wait-for-callback timeout caught (recovers)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForCallbackNullResult:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["7-15"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_callback.WaitForCallbackNullResult
+      Description: Wait-for-callback success with empty (null) payload
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300

--- a/conformance-tests/template_wait_for_condition.yaml
+++ b/conformance-tests/template_wait_for_condition.yaml
@@ -1,0 +1,257 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Durable Execution Conformance Test Examples - Java (WaitForCondition)
+
+Parameters:
+  Architecture:
+    Type: String
+    Default: arm64
+    Description: Lambda Function Architecture
+    AllowedValues:
+      - x86_64
+      - arm64
+  JavaVersion:
+    Type: String
+    Default: 'java21'
+    Description: Java runtime version
+
+Globals:
+  Function:
+    Timeout: 60
+    MemorySize: 512
+    Runtime:
+      Ref: JavaVersion
+    Architectures:
+      - Ref: Architecture
+
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+
+  WaitForConditionBasic:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-1"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionBasic
+      Description: Wait-for-condition basic (polls until threshold met)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForConditionImmediate:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-2"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionImmediate
+      Description: Wait-for-condition immediate (condition already met on first check)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForConditionNamed:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-3"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionNamed
+      Description: Wait-for-condition with explicit name
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForConditionInitialState:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-4"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionInitialState
+      Description: Wait-for-condition custom initial state (state threaded across polls)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForConditionFixedDelay:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-5"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionFixedDelay
+      Description: Wait-for-condition fixed-delay wait strategy
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForConditionMaxAttempts:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-6"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionMaxAttempts
+      Description: Wait-for-condition max attempts exceeded (failure)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForConditionCheckThrows:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-7"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionCheckThrows
+      Description: Wait-for-condition check function throws (uncaught failure)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForConditionCheckThrowsCaught:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-8"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionCheckThrowsCaught
+      Description: Wait-for-condition check throws, caught by handler (recovers)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForConditionComplexObject:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-9"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionComplexObject
+      Description: Wait-for-condition with a complex object state
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForConditionNullResult:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-10"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionNullResult
+      Description: Wait-for-condition null result
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForConditionCustomSerdes:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-11"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionCustomSerdes
+      Description: Wait-for-condition with custom state serdes
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForConditionThenStep:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-12"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionThenStep
+      Description: Wait-for-condition followed by a step (result passed onward)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  WaitForConditionMultipleSequential:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["6-13"]
+    Properties:
+      CodeUri: .
+      Handler: wait_for_condition.WaitForConditionMultipleSequential
+      Description: Multiple sequential wait_for_condition operations — first result seeds second
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300


### PR DESCRIPTION
## Summary

Follow-up to #552: migrates the remaining Java conformance suites into `conformance-tests/` — **child (18), callback (19), invoke (16), parallel (19), wait_for_callback (15), wait_for_condition (13)**.