### PR TITLE
test(conformance): add map 9-4 (empty items list)

### DIFF
--- a/conformance-tests/src/main/java/map/MapEmpty.java
+++ b/conformance-tests/src/main/java/map/MapEmpty.java
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package map;
+
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.MapConfig;
+import software.amazon.lambda.durable.model.MapResult;
+
+/** 9-4: Map with an empty items list completes immediately with an empty results list. */
+public class MapEmpty extends DurableHandler<Object, List<String>> {
+
+    @Override
+    public List<String> handleRequest(Object input, DurableContext context) {
+        MapResult<String> result = context.map(
+                "empty",
+                List.<String>of(),
+                String.class,
+                (item, index, ctx) -> item,
+                MapConfig.builder().build());
+        return result.results();
+    }
+}

--- a/conformance-tests/template_map.yaml
+++ b/conformance-tests/template_map.yaml
@@ -95,6 +95,22 @@ Resources:
         RetentionPeriodInDays: 7
         ExecutionTimeout: 300
 
+  MapEmpty:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["9-4"]
+    Properties:
+      CodeUri: .
+      Handler: map.MapEmpty
+      Description: Map with an empty items list
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
   MapFailFast:
     Type: AWS::Serverless::Function
     TestingMetadata:


### PR DESCRIPTION
## Summary

Adds the single remaining map test case: **`MapEmpty` (9-4)** — map invoked with an empty items list. Follow-up to #555, which shipped the map suite without it.

## ⚠️ This test is expected to FAIL

The current SDK diverges from the requirement: an empty-items map completes with `InvocationCompleted` **without** emitting `ContextStarted`/`ContextSucceeded`. Per the conformance suite's follow-the-requirement principle, the handler uses the real `context.map` API and the red test documents the SDK bug — it should stay red until either the SDK behavior is fixed or the requirement is amended.

Expect the **map** CI job on this PR to fail on exactly this requirement.

## Testing

Live validation of this template: **13 PASSED, 1 FAILED (9-4, the expected divergence), 6 NOT_IMPLEMENTED**. Failure detail:

```
9-4: Event[EventId=2].EventType: expected 'ContextStarted', got 'InvocationCompleted'
```