### PR TITLE
fix(otel): correct attempt and operation spans

### DIFF
--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPlugin.java
@@ -134,8 +134,7 @@ public class OtelPlugin implements DurableExecutionPlugin {
             SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor, boolean enableMdc) {
         this.idGenerator = new DeterministicIdGenerator();
 
-        // Set service.name to "invocation" — X-Ray uses this as the display name for SERVER spans,
-        // creating a separate service node in the trace map labeled "invocation".
+        // Set service.name to "invocation" for the exported spans' resource.
         var resource = Resource.create(Attributes.of(ServiceAttributes.SERVICE_NAME, "invocation"));
         tracerProviderBuilder.addResource(resource);
 
@@ -178,10 +177,9 @@ public class OtelPlugin implements DurableExecutionPlugin {
             parentContext = Context.root();
         }
 
-        // Create a SERVER span to establish a separate X-Ray service node.
-        // X-Ray uses service.name for the segment display name.
+        // Create an INTERNAL span for the invocation.
         var spanBuilder = tracer.spanBuilder("invocation")
-                .setSpanKind(SpanKind.SERVER)
+                .setSpanKind(SpanKind.INTERNAL)
                 .setParent(parentContext)
                 .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())
                 .setAttribute(DURABLE_FIRST_INVOCATION, info.isFirstInvocation());
@@ -197,11 +195,11 @@ public class OtelPlugin implements DurableExecutionPlugin {
     public void onInvocationEnd(InvocationEndInfo info) {
         if (invocationSpan == null) return;
 
-        // End any operation spans that are still open (operations that didn't complete in this invocation)
+        // End still-open operation spans without stamping a status — no terminal
+        // durable.operation.status means still running (STARTED). A later invocation's
+        // onOperationEnd emits a continuation span with the real terminal status.
         for (var entry : operationSpans.entrySet()) {
-            var span = entry.getValue();
-            span.setAttribute(DURABLE_OPERATION_STATUS, "PENDING");
-            span.end();
+            entry.getValue().end();
         }
         operationSpans.clear();
         operationContexts.clear();
@@ -287,6 +285,10 @@ public class OtelPlugin implements DurableExecutionPlugin {
             if (info.status() != null) {
                 span.setAttribute(DURABLE_OPERATION_STATUS, info.status());
             }
+            // Total attempts for retriable operations (STEP, WAIT_FOR_CONDITION) — emitted only at end.
+            if (info.attempt() != null) {
+                span.setAttribute(DURABLE_ATTEMPT_NUMBER, info.attempt().longValue());
+            }
             if (info.error() != null) {
                 span.setStatus(StatusCode.ERROR, info.error().getMessage());
                 span.recordException(info.error());
@@ -316,11 +318,18 @@ public class OtelPlugin implements DurableExecutionPlugin {
             if (info.name() != null) {
                 spanBuilder.setAttribute(DURABLE_OPERATION_NAME, info.name());
             }
+            if (info.subType() != null) {
+                spanBuilder.setAttribute(DURABLE_OPERATION_SUBTYPE, info.subType());
+            }
 
             var continuationSpan = spanBuilder.startSpan();
 
             if (info.status() != null) {
                 continuationSpan.setAttribute(DURABLE_OPERATION_STATUS, info.status());
+            }
+            if (info.attempt() != null) {
+                continuationSpan.setAttribute(
+                        DURABLE_ATTEMPT_NUMBER, info.attempt().longValue());
             }
             if (info.error() != null) {
                 continuationSpan.setStatus(StatusCode.ERROR, info.error().getMessage());
@@ -369,6 +378,9 @@ public class OtelPlugin implements DurableExecutionPlugin {
         }
         if (info.name() != null) {
             spanBuilder.setAttribute(DURABLE_OPERATION_NAME, info.name());
+        }
+        if (info.subType() != null) {
+            spanBuilder.setAttribute(DURABLE_OPERATION_SUBTYPE, info.subType());
         }
         if (info.attempt() != null) {
             spanBuilder.setAttribute(DURABLE_ATTEMPT_NUMBER, info.attempt().longValue());

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OtelPluginTest.java
@@ -4,6 +4,7 @@ package software.amazon.lambda.durable.otel;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
@@ -50,15 +51,12 @@ class OtelPluginTest {
     }
 
     @Test
-    void invocationSpan_hasServerKind_forSeparateXRayNode() {
+    void invocationSpan_hasInternalKind() {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var span = spanExporter.getFinishedSpanItems().get(0);
-        assertEquals(
-                SpanKind.SERVER,
-                span.getKind(),
-                "Invocation span must be SERVER kind so X-Ray creates a separate service node");
+        assertEquals(SpanKind.INTERNAL, span.getKind(), "Invocation span must be INTERNAL kind");
     }
 
     @Test
@@ -75,6 +73,7 @@ class OtelPluginTest {
                 Instant.now(),
                 Instant.now(),
                 "SUCCEEDED",
+                null,
                 false,
                 null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
@@ -109,6 +108,67 @@ class OtelPluginTest {
     }
 
     @Test
+    void operationEnd_withAttempt_stampsAttemptNumberOnOperationSpan() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+
+        plugin.onOperationStart(new OperationInfo("op-1", "flaky", "STEP", "Step", null, Instant.now(), null, false));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "flaky", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", 3, false, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var operationSpan = spanExporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().equals("flaky"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(
+                3L,
+                operationSpan.getAttributes().get(AttributeKey.longKey("durable.attempt.number")),
+                "Operation span should carry total attempt count at end");
+    }
+
+    @Test
+    void attemptSpan_carriesOperationSubtype() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onUserFunctionStart(
+                new UserFunctionStartInfo("op-1", "process-order", "STEP", "Step", null, Instant.now(), false, 1));
+        plugin.onUserFunctionEnd(new UserFunctionEndInfo(
+                "op-1", "process-order", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var attemptSpan = spanExporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().contains("process-order"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(
+                "Step",
+                attemptSpan.getAttributes().get(AttributeKey.stringKey("durable.operation.subtype")),
+                "Attempt span should carry durable.operation.subtype from the operation");
+    }
+
+    @Test
+    void operationEnd_withoutMatchingStart_stampsAttemptNumberOnContinuationSpan() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+
+        // No onOperationStart in this invocation → onOperationEnd takes the continuation-span branch.
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "flaky", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", 2, false, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var continuationSpan = spanExporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().equals("flaky"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(
+                2L,
+                continuationSpan.getAttributes().get(AttributeKey.longKey("durable.attempt.number")),
+                "Continuation span should carry the attempt count");
+        assertEquals(
+                "Step",
+                continuationSpan.getAttributes().get(AttributeKey.stringKey("durable.operation.subtype")),
+                "Continuation span should carry durable.operation.subtype");
+    }
+
+    @Test
     void invocationEnd_withFailure_setsErrorStatus() {
         plugin.onInvocationStart(new InvocationInfo("req-123", "arn:exec1", true));
         plugin.onInvocationEnd(new InvocationEndInfo(
@@ -131,7 +191,7 @@ class OtelPluginTest {
 
         // Operation span ended at completion
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-hash-1", "my-step", "STEP", "Step", null, start, end, "SUCCEEDED", false, null));
+                "op-hash-1", "my-step", "STEP", "Step", null, start, end, "SUCCEEDED", null, false, null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -209,7 +269,7 @@ class OtelPluginTest {
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
 
         // Step 2: operation starts, user function runs, operation completes
         plugin.onOperationStart(new OperationInfo("op-2", "step-b", "STEP", "Step", null, Instant.now(), null, false));
@@ -218,7 +278,7 @@ class OtelPluginTest {
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-2", "step-b", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-2", "step-b", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+                "op-2", "step-b", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.SUCCEEDED, null));
 
@@ -287,7 +347,7 @@ class OtelPluginTest {
         sampledPlugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         sampledPlugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+                "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
         sampledPlugin.onInvocationEnd(
                 new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -334,7 +394,7 @@ class OtelPluginTest {
         xrayPlugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         xrayPlugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -416,7 +476,7 @@ class OtelPluginTest {
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-1", "step-1", "STEP", "Step", null, Instant.now(), null, false));
         xrayPlugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-1", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+                "op-1", "step-1", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.PENDING, null));
 
         // Second invocation (same execution, same X-Ray Root from backend)
@@ -424,7 +484,7 @@ class OtelPluginTest {
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-2", "step-2", "STEP", "Step", null, Instant.now(), null, false));
         xrayPlugin.onOperationEnd(new OperationEndInfo(
-                "op-2", "step-2", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+                "op-2", "step-2", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
         xrayPlugin.onInvocationEnd(
                 new InvocationEndInfo("req-2", "arn:exec1", false, InvocationStatus.SUCCEEDED, null));
 
@@ -491,7 +551,17 @@ class OtelPluginTest {
 
         // onOperationEnd without a prior onOperationStart — operation completed between invocations
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-wait-1", "my-wait", "WAIT", "Wait", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+                "op-wait-1",
+                "my-wait",
+                "WAIT",
+                "Wait",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -515,7 +585,17 @@ class OtelPluginTest {
 
         // onOperationEnd without a prior onOperationStart — continuation span
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-wait-1", "my-wait", "WAIT", "Wait", null, operationStart, operationEnd, "SUCCEEDED", false, null));
+                "op-wait-1",
+                "my-wait",
+                "WAIT",
+                "Wait",
+                null,
+                operationStart,
+                operationEnd,
+                "SUCCEEDED",
+                null,
+                false,
+                null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -543,6 +623,7 @@ class OtelPluginTest {
                 Instant.now(),
                 Instant.now(),
                 "FAILED",
+                null,
                 false,
                 new RuntimeException("timed out")));
 
@@ -634,6 +715,7 @@ class OtelPluginTest {
                 Instant.now(),
                 Instant.now(),
                 "SUCCEEDED",
+                null,
                 false,
                 null));
 
@@ -646,6 +728,7 @@ class OtelPluginTest {
                 Instant.now(),
                 Instant.now(),
                 "SUCCEEDED",
+                null,
                 false,
                 null));
 
@@ -682,7 +765,7 @@ class OtelPluginTest {
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step-A", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-A", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+                "op-1", "step-A", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
         plugin.onOperationStart(new OperationInfo("op-2", "pause", "WAIT", "Wait", null, Instant.now(), null, false));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.PENDING, null));
 
@@ -695,14 +778,14 @@ class OtelPluginTest {
         // Invocation 2: wait completed between invocations, new step runs
         plugin.onInvocationStart(new InvocationInfo("req-2", arn, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-2", "pause", "WAIT", "Wait", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+                "op-2", "pause", "WAIT", "Wait", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
         plugin.onOperationStart(new OperationInfo("op-3", "step-B", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-3", "step-B", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-3", "step-B", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-3", "step-B", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+                "op-3", "step-B", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", arn, false, InvocationStatus.SUCCEEDED, null));
 
         var inv2Spans = spanExporter.getFinishedSpanItems();
@@ -787,6 +870,7 @@ class OtelPluginTest {
                 Instant.now(),
                 Instant.now(),
                 "SUCCEEDED",
+                null,
                 false,
                 null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", arn, false, InvocationStatus.SUCCEEDED, null));

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -12,7 +12,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
+import software.amazon.lambda.durable.config.ParallelConfig;
 import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.execution.SuspendExecutionException;
 import software.amazon.lambda.durable.model.ExecutionStatus;
 import software.amazon.lambda.durable.model.WaitForConditionResult;
 import software.amazon.lambda.durable.plugin.*;
@@ -413,10 +415,9 @@ class PluginIntegrationTest {
         var plugin = new RecordingPlugin();
         var config = DurableConfig.builder().withPlugins(plugin).build();
 
-        // When a step fails and retries are exhausted, the step operation's handleStepFailure
-        // sends a FAIL checkpoint. However, from runUserHandler's perspective the wrapped lambda
-        // catches the exception internally, so onUserFunctionEnd still reports succeeded=true
-        // for the step handler wrapper. The actual failure is captured in onOperationEnd and onInvocationEnd.
+        // When a step's user function throws, the exception propagates through the user-function hook
+        // boundary, so onUserFunctionEnd reports succeeded=false with the error. Retry/checkpoint
+        // handling happens outside that boundary.
         var runner = LocalDurableTestRunner.create(
                 String.class,
                 (input, context) -> context.step(
@@ -437,9 +438,17 @@ class PluginIntegrationTest {
         assertEquals(1, plugin.invocationEnds.size());
         assertEquals(InvocationStatus.FAILED, plugin.invocationEnds.get(0).invocationStatus());
 
-        // The user function start/end hooks fire for the step execution thread
-        assertFalse(plugin.userFunctionStarts.isEmpty(), "Should have user function start for the step");
-        assertFalse(plugin.userFunctionEnds.isEmpty(), "Should have user function end for the step");
+        // The failed step's user function end reports the failure through the hook boundary.
+        assertTrue(
+                plugin.userFunctionStarts.stream().anyMatch(info -> "fail-step".equals(info.name())),
+                "Should have user function start for the step");
+        var failStepEnd = plugin.userFunctionEnds.stream()
+                .filter(info -> "fail-step".equals(info.name()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Should have user function end for 'fail-step'"));
+        assertFalse(failStepEnd.succeeded(), "Failed step should report succeeded=false");
+        assertNotNull(failStepEnd.error());
+        assertTrue(failStepEnd.error().getMessage().contains("step failed"));
     }
 
     @Test
@@ -568,6 +577,131 @@ class PluginIntegrationTest {
                 .filter(info -> "poll".equals(info.name()) && info.attempt() != null)
                 .toList();
         assertTrue(conditionStarts.size() >= 2, "Should have at least 2 condition check attempts");
+    }
+
+    // ─── Attempt outcome hooks ───────────────────────────────────────────
+
+    @Test
+    void plugin_reportsFailedThenSucceededAttempts_forRetriedStep() {
+        var attempts = new AtomicInteger(0);
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> context.step(
+                        "flaky",
+                        String.class,
+                        stepCtx -> {
+                            if (attempts.incrementAndGet() == 1) {
+                                throw new RuntimeException("boom");
+                            }
+                            return "ok";
+                        },
+                        StepConfig.builder()
+                                .retryStrategy(RetryStrategies.fixedDelay(3, Duration.ofSeconds(1)))
+                                .build()),
+                config);
+
+        var result = runner.runUntilComplete("input");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+
+        var flakyEnds = plugin.userFunctionEnds.stream()
+                .filter(info -> "flaky".equals(info.name()))
+                .toList();
+        assertEquals(2, flakyEnds.size(), "Expected two attempts: one failed, one succeeded");
+
+        // First attempt failed — its exception is handled internally by StepOperation, but the
+        // onUserFunctionEnd hook must still report it as failed. Look up by attempt number since the
+        // retry may run nested within the failed attempt, making end-hook ordering non-deterministic.
+        var firstAttempt = flakyEnds.stream()
+                .filter(info -> info.attempt() == 1)
+                .findFirst()
+                .orElseThrow();
+        assertFalse(firstAttempt.succeeded());
+        assertNotNull(firstAttempt.error());
+
+        // Retry attempt succeeded.
+        var secondAttempt = flakyEnds.stream()
+                .filter(info -> info.attempt() == 2)
+                .findFirst()
+                .orElseThrow();
+        assertTrue(secondAttempt.succeeded());
+        assertNull(secondAttempt.error());
+
+        // The operation end reports the terminal attempt number = total attempts that ran. The step
+        // succeeded on its second attempt, so the total is 2.
+        var flakyOpEnd = plugin.operationEnds.stream()
+                .filter(info -> "flaky".equals(info.name()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(2, flakyOpEnd.attempt().intValue(), "Operation end should report total attempts run");
+    }
+
+    @Test
+    void plugin_userFunctionEnd_reportsSuspension_asNotSucceeded() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        // A child context whose body suspends (on a wait) throws SuspendExecutionException through the
+        // user-function boundary, so onUserFunctionEnd fires with succeeded=false and the suspend exception.
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> context.runInChildContext("child", TypeToken.get(String.class), child -> {
+                    child.wait("pause", Duration.ofMinutes(1));
+                    return "done";
+                }),
+                config);
+
+        var result = runner.run("input");
+        assertEquals(ExecutionStatus.PENDING, result.getStatus());
+
+        var childEnd = plugin.userFunctionEnds.stream()
+                .filter(info -> "child".equals(info.name()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("onUserFunctionEnd should fire for the suspended child context"));
+        assertFalse(childEnd.succeeded(), "A suspended user function must not report succeeded=true");
+        assertTrue(
+                childEnd.error() instanceof SuspendExecutionException,
+                "Suspension should surface the SuspendExecutionException, not a user error");
+    }
+
+    @Test
+    void plugin_parallelBranches_emitUserFunctionHooks_butConsumerDoesNot() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    var parallel =
+                            context.parallel("proc", ParallelConfig.builder().build());
+                    var futures = new ArrayList<DurableFuture<String>>();
+                    try (parallel) {
+                        futures.add(parallel.branch(
+                                "branch-a", String.class, ctx -> ctx.step("s-a", String.class, sc -> "A")));
+                        futures.add(parallel.branch(
+                                "branch-b", String.class, ctx -> ctx.step("s-b", String.class, sc -> "B")));
+                    }
+                    parallel.get();
+                    return String.join(
+                            ",", futures.stream().map(DurableFuture::get).toList());
+                },
+                config);
+
+        var result = runner.runUntilComplete("input");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+
+        var userFnNames = plugin.userFunctionStarts.stream()
+                .map(UserFunctionStartInfo::name)
+                .toList();
+        // Each branch runs as a child context whose body is a user function → fires the hooks.
+        assertTrue(userFnNames.contains("branch-a"), "branch-a child context should emit a user-function hook");
+        assertTrue(userFnNames.contains("branch-b"), "branch-b child context should emit a user-function hook");
+        // The parallel operation itself is orchestration, not user code → no user-function hook.
+        assertFalse(
+                userFnNames.contains("proc"),
+                "the parallel consumer is orchestration and must not emit a user-function hook");
     }
 
     // ─── Test helper classes ─────────────────────────────────────────────

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/OperationProcessor.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/OperationProcessor.java
@@ -128,6 +128,12 @@ public class OperationProcessor {
                             Instant.now().plusSeconds(update.stepOptions().nextAttemptDelaySeconds()));
         }
 
+        // Record the attempt number on success too, so the terminal operation reflects the number of the
+        // attempt that produced the result (i.e. the total attempts run), matching the durable backend.
+        if (update.action() == OperationAction.SUCCEED) {
+            detailsBuilder.attempt(attempt);
+        }
+
         if (update.payload() != null) {
             detailsBuilder.result(update.payload());
         }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
@@ -267,43 +268,27 @@ public abstract class BaseDurableOperation {
         }
     }
 
-    protected void runUserHandler(Runnable runnable, ThreadType threadType) {
-        runUserHandler(runnable, threadType, null);
-    }
-
     /**
-     * Runs user code in a separate thread with plugin hook instrumentation.
+     * Runs an operation's handler on a user-executor thread, managing thread registration and suspension.
      *
-     * @param runnable the user code to run
+     * <p>This method is responsible only for thread/executor/suspension scaffolding. Plugin user-function hooks are
+     * fired by {@link #runUserFunction(Integer, java.util.function.Supplier)}, which operations wrap around the actual
+     * user function so a user failure is reported through the hook boundary.
+     *
+     * @param runnable the operation handler to run (typically wraps a {@link #runUserFunction} call)
      * @param threadType the thread type (STEP or CONTEXT)
-     * @param attempt the 1-based attempt number for steps/waitForCondition, null for context operations
      */
-    protected void runUserHandler(Runnable runnable, ThreadType threadType, Integer attempt) {
+    protected void runUserHandler(Runnable runnable, ThreadType threadType) {
         String operationId = getOperationId();
         logger.debug("Starting user handler for operation {} ({})", operationId, threadType);
-        var pluginRunner = getPluginRunner();
         Runnable wrapped = () -> {
             executionManager.setCurrentThreadContext(new ThreadContext(operationId, threadType));
 
-            // Fire onUserFunctionStart on the user code thread
-            var userFunctionStartInfo = PluginInfoConverter.toUserFunctionStartInfo(
-                    operationIdentifier, durableContext.getParentId(), durableContext.isReplaying(), attempt);
-            pluginRunner.onUserFunctionStart(userFunctionStartInfo);
-
             try {
                 runnable.run();
-                // Fire onUserFunctionEnd on success
-                pluginRunner.onUserFunctionEnd(
-                        PluginInfoConverter.toUserFunctionEndInfo(userFunctionStartInfo, true, null));
             } catch (Throwable throwable) {
-                // Fire onUserFunctionEnd for all outcomes including suspension.
-                // This allows plugins (e.g., OTel) to properly end the attempt span and record
-                // errors, rather than leaving orphaned spans that only get cleaned up at invocation end.
-                pluginRunner.onUserFunctionEnd(
-                        PluginInfoConverter.toUserFunctionEndInfo(userFunctionStartInfo, false, throwable));
-
-                // Operations always wrap the user's function and handles all possible exceptions except for
-                // SuspendExecutionException.
+                // Operations wrap the user function and handle all outcomes except for SuspendExecutionException.
+                // Anything else reaching here is unexpected and terminates the execution.
                 if (!executionManager.isExecutionCompletedExceptionally()
                         && !(throwable instanceof SuspendExecutionException)) {
                     logger.error("An unhandled exception is thrown from user function: ", throwable);
@@ -346,6 +331,37 @@ public abstract class BaseDurableOperation {
 
         runningUserHandler.set(CompletableFuture.runAsync(
                 wrapped, getContext().getDurableConfig().getExecutorService()));
+    }
+
+    /**
+     * Runs a user-provided function inside the plugin user-function hook boundary.
+     *
+     * <p>Fires {@code onUserFunctionStart} before invoking the function and {@code onUserFunctionEnd} after. The
+     * function's exception propagates through this boundary so the end hook reports the true outcome, mirroring the
+     * JS/Python SDKs. Retry and checkpoint handling stays in the caller's surrounding try/catch, outside this boundary.
+     *
+     * <p>{@code onUserFunctionEnd} fires for failures and suspensions alike so plugins (e.g. OTel) can end/clean up the
+     * attempt rather than leak state; the original throwable is always re-thrown to the caller.
+     *
+     * @param attempt the 1-based attempt number for steps/waitForCondition, or null for context operations
+     * @param userFunction the user function to invoke
+     * @param <T> the user function's result type
+     * @return the user function's result
+     */
+    protected <T> T runUserFunction(Integer attempt, Supplier<T> userFunction) {
+        var pluginRunner = getPluginRunner();
+        var startInfo = PluginInfoConverter.toUserFunctionStartInfo(
+                operationIdentifier, durableContext.getParentId(), durableContext.isReplaying(), attempt);
+        pluginRunner.onUserFunctionStart(startInfo);
+        try {
+            T result = userFunction.get();
+            pluginRunner.onUserFunctionEnd(PluginInfoConverter.toUserFunctionEndInfo(startInfo, true, null));
+            return result;
+        } catch (Throwable e) {
+            pluginRunner.onUserFunctionEnd(PluginInfoConverter.toUserFunctionEndInfo(startInfo, false, e));
+            ExceptionHelper.sneakyThrow(e);
+            return null; // unreachable — sneakyThrow always throws
+        }
     }
 
     /**

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ChildContextOperation.java
@@ -135,7 +135,9 @@ public class ChildContextOperation<T> extends SerializableDurableOperation<T> {
             DurableContextImpl.setCurrentContext(childContext);
             try (var ignored = DurableLogger.attachContext()) {
                 try {
-                    T result = function.apply(childContext);
+                    // Run the user function inside the plugin hook boundary (attempt is null for contexts)
+                    // so a failure is reported through onUserFunctionEnd; checkpointing stays outside.
+                    T result = runUserFunction(null, () -> function.apply(childContext));
 
                     handleChildContextSuccess(result);
                 } catch (Throwable e) {

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/StepOperation.java
@@ -113,8 +113,9 @@ public class StepOperation<T> extends SerializableDurableOperation<T> {
                 try {
                     checkpointStarted();
 
-                    // Execute the function
-                    T result = function.apply(stepContext);
+                    // Execute the user function inside the plugin hook boundary so a failure is reported
+                    // through onUserFunctionEnd; retry/checkpoint handling stays outside the boundary.
+                    T result = runUserFunction(attempt, () -> function.apply(stepContext));
 
                     handleStepSucceeded(result);
                 } catch (Throwable e) {
@@ -124,7 +125,7 @@ public class StepOperation<T> extends SerializableDurableOperation<T> {
         };
 
         // Execute user provided step code in user-configured executor
-        runUserHandler(userHandler, ThreadType.STEP, attempt);
+        runUserHandler(userHandler, ThreadType.STEP);
     }
 
     private void checkpointStarted() {

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitForConditionOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitForConditionOperation.java
@@ -125,8 +125,10 @@ public class WaitForConditionOperation<T> extends SerializableDurableOperation<T
                         sendOperationUpdateAsync(startUpdate);
                     }
 
-                    // Execute check function in user executor
-                    WaitForConditionResult<T> result = checkFunc.apply(currentState, stepContext);
+                    // Execute check function inside the plugin hook boundary so a failure is reported
+                    // through onUserFunctionEnd; checkpoint/poll handling stays outside the boundary.
+                    WaitForConditionResult<T> result =
+                            runUserFunction(attempt, () -> checkFunc.apply(currentState, stepContext));
 
                     // Normalize the value through SerDes so first execution matches replay.
                     var serializedState = serializeAndDeserializeResult(result.value());
@@ -164,7 +166,7 @@ public class WaitForConditionOperation<T> extends SerializableDurableOperation<T
             }
         };
 
-        runUserHandler(userHandler, ThreadType.STEP, attempt);
+        runUserHandler(userHandler, ThreadType.STEP);
     }
 
     private void handleCheckFailure(Throwable exception) {

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPlugin.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPlugin.java
@@ -45,9 +45,16 @@ public interface DurableExecutionPlugin {
     default void onOperationStart(OperationInfo info) {}
 
     /**
-     * Called when an operation reaches a terminal status for the first time (not on replay).
+     * Called once when an operation's terminal status is first observed.
      *
-     * <p>The OTel plugin creates operation spans here with backfilled start/end timestamps.
+     * <p>This is usually the invocation that completes the operation, but it can also be a later invocation that first
+     * observes a completion which happened while the execution was suspended (for example an operation that finished
+     * during a wait). In that case {@link OperationEndInfo#isReplay()} is {@code true}, so do not assume this hook only
+     * fires with {@code isReplay() == false}. It does not fire again on subsequent replays of an already-observed
+     * completion.
+     *
+     * <p>The OTel plugin creates operation spans here with backfilled start/end timestamps (emitting a linked
+     * continuation span when the completion is observed on a replaying invocation).
      */
     default void onOperationEnd(OperationEndInfo info) {}
 
@@ -74,6 +81,12 @@ public interface DurableExecutionPlugin {
      * functions.
      *
      * <p>This hook fires on the same thread as user code, so plugins can close OTel scopes here.
+     *
+     * <p>It fires for every terminal outcome of the user function: normal return, a thrown failure, and suspension.
+     * {@link UserFunctionEndInfo#succeeded()} is {@code true} only on normal return; it is {@code false} for both a
+     * genuine failure and a suspension. On suspension the {@link UserFunctionEndInfo#error()} is the SDK's internal
+     * {@code SuspendExecutionException}, which is not a user error — plugins that count failures should treat a
+     * suspension as a neutral outcome (for example by checking the error type) rather than a failure.
      */
     default void onUserFunctionEnd(UserFunctionEndInfo info) {}
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationEndInfo.java
@@ -15,6 +15,7 @@ import java.time.Instant;
  * @param startTimestamp when the operation started
  * @param endTimestamp when the operation ended
  * @param status the operation's terminal status (e.g., SUCCEEDED, FAILED, TIMED_OUT) — may be null for virtual ops
+ * @param attempt the total number of attempts for retriable operations (STEP, WAIT_FOR_CONDITION) — null for others
  * @param isReplay true if this operation already existed in the execution state (completed in a prior invocation)
  * @param error non-null if the operation failed
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
@@ -29,5 +30,6 @@ public record OperationEndInfo(
         Instant startTimestamp,
         Instant endTimestamp,
         String status,
+        Integer attempt,
         boolean isReplay,
         Throwable error) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
@@ -62,6 +62,9 @@ public final class PluginInfoConverter {
                 operation != null && operation.status() != null
                         ? operation.status().toString()
                         : null,
+                operation != null && operation.stepDetails() != null
+                        ? operation.stepDetails().attempt()
+                        : null,
                 isReplay,
                 error);
     }

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
@@ -150,7 +150,7 @@ class PluginRunnerTest {
 
     private static OperationEndInfo operationEndInfo() {
         return new OperationEndInfo(
-                "op-1", "test-step", "STEP", null, null, Instant.now(), Instant.now(), "SUCCEEDED", false, null);
+                "op-1", "test-step", "STEP", null, null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null);
     }
 
     private static OperationChangeInfo operationChangeInfo() {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
https://github.com/aws/aws-durable-execution-conformance-tests/issues/23

### Description
#### Summary
Aligns the Java OTel plugin's span reporting with the JS and Python SDKs, and fixes user-function outcome reporting so failed attempts are reported correctly. Also adds the operation's attempt count to the operation span at completion.

  1. Invocation span kind: SERVER → INTERNAL
  2. Open operation spans at invocation-end no longer stamped with durable.operation.status = "PENDING"
  3. Attempt spans now carry durable.operation.subtype
  4. OperationEndInfo gains an attempt field (persisted counter from stepDetails)
  5. Failed step/waitForCondition attempts now correctly report succeeded=false

#### Changes
OTel span reporting (otel-plugin)
- Invocation span now uses SpanKind.INTERNAL instead of SERVER.
- Open operation spans at invocation end are no longer stamped with durable.operation.status = "PENDING" - a missing terminal status means "still running (STARTED)."
- Attempt spans now carry durable.operation.subtype, so they include the full operation attribute set plus durable.attempt.number and durable.attempt.outcome.
- STEP and WAIT_FOR_CONDITION operation spans now emit durable.attempt.number (attempt count) at completion.

User-function hook boundary (core SDK)
- Plugin user-function hooks (onUserFunctionStart / onUserFunctionEnd) now fire around only the user function, and the exception propagates through that boundary. Retry/checkpoint handling stays outside the boundary.
- Result: a failed step / wait-for-condition attempt now reports succeeded=false (previously reported succeeded=true because the exception was caught internally for retry).
- runUserHandler is now responsible only for thread/executor/suspension management. ConcurrencyOperation's consumer (orchestration, not user code) no longer emits user-function hooks.

Plugin interface
- Added OperationEndInfo.attempt (Integer), populated from the operation's persisted stepDetails.attempt. Exposed only at operation end; null for non-retriable operations.

Behavior / compatibility notes
- durable.attempt.number on the operation span reflects the model's persisted attempt counter (bumped on RETRY/FAIL, not SUCCEED). A step that succeeds on its 2nd try reports 1; a step that fails after 3 tries reports 3.
- On suspension the end hook still fires so thread-bound OTel scopes are cleaned up - a deliberate platform difference.
- Doc update to clarify DurableExecutionPlugin.onOperationEnd behavior.

### Demo/Screenshots
N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Updated

#### Integration Tests

Have integration tests been written for these changes? Added/updated

#### Examples

Has a new example been added for the change? (if applicable) N/A
