### PR TITLE
Fix missing checkpoint from map operation with empty items

### DIFF
--- a/conformance-tests/src/main/java/map/MapEmpty.java
+++ b/conformance-tests/src/main/java/map/MapEmpty.java
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package map;
+
+import java.util.List;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.config.MapConfig;
+import software.amazon.lambda.durable.model.MapResult;
+
+/** 9-4: Map with an empty items list completes immediately with an empty results list. */
+public class MapEmpty extends DurableHandler<Object, List<String>> {
+
+    @Override
+    public List<String> handleRequest(Object input, DurableContext context) {
+        MapResult<String> result = context.map(
+                "empty",
+                List.<String>of(),
+                String.class,
+                (item, index, ctx) -> item,
+                MapConfig.builder().build());
+        return result.results();
+    }
+}

--- a/conformance-tests/src/main/java/map/MapEmpty.java
+++ b/conformance-tests/src/main/java/map/MapEmpty.java
@@ -3,6 +3,7 @@
 package map;
 
 import java.util.List;
+import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.config.MapConfig;
@@ -10,6 +11,11 @@ import software.amazon.lambda.durable.model.MapResult;
 
 /** 9-4: Map with an empty items list completes immediately with an empty results list. */
 public class MapEmpty extends DurableHandler<Object, List<String>> {
+
+    @Override
+    protected DurableConfig createConfiguration() {
+        return DurableConfig.builder().withCheckpointEmptyMap(true).build();
+    }
 
     @Override
     public List<String> handleRequest(Object input, DurableContext context) {

--- a/conformance-tests/template_map.yaml
+++ b/conformance-tests/template_map.yaml
@@ -95,6 +95,22 @@ Resources:
         RetentionPeriodInDays: 7
         ExecutionTimeout: 300
 
+  MapEmpty:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["9-4"]
+    Properties:
+      CodeUri: .
+      Handler: map.MapEmpty
+      Description: Map with an empty items list
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
   MapFailFast:
     Type: AWS::Serverless::Function
     TestingMetadata:

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
@@ -1780,8 +1780,10 @@ class MapIntegrationTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"FLAT, 2", "NESTED, 2"})
+    @CsvSource({"FLAT, 0", "NESTED, 0"})
     void testMapWithEmptyItems(NestingType nestingType, int events) {
+        // Default behavior (checkpointEmptyMap disabled): empty map is not checkpointed, so no history events.
+        // Temporary: remove this test along with the checkpointEmptyMap flag in a future major version.
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             List<String> items = List.of();
             var result = context.map(
@@ -1803,8 +1805,10 @@ class MapIntegrationTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"FLAT, 2", "NESTED, 2"})
+    @CsvSource({"FLAT, 0", "NESTED, 0"})
     void testAnyOfMapWithEmptyItems(NestingType nestingType, int events) {
+        // Default behavior (checkpointEmptyMap disabled): empty map is not checkpointed, so no history events.
+        // Temporary: remove this test along with the checkpointEmptyMap flag in a future major version.
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             List<String> items = List.of();
             var result = context.mapAsync(
@@ -1826,24 +1830,53 @@ class MapIntegrationTest {
 
     @ParameterizedTest
     @CsvSource({"FLAT, 2", "NESTED, 2"})
+    void testMapWithEmptyItemsCheckpointed(NestingType nestingType, int events) {
+        var config = DurableConfig.builder().withCheckpointEmptyMap(true).build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    var result = context.map(
+                            "empty-map",
+                            List.<String>of(),
+                            String.class,
+                            (item, index, ctx) -> item,
+                            MapConfig.builder().nestingType(nestingType).build());
+
+                    assertTrue(result.allSucceeded());
+                    assertEquals(0, result.size());
+                    return "done";
+                },
+                config);
+
+        var result = runner.runUntilComplete("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(events, result.getHistoryEvents().size());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"FLAT, 2", "NESTED, 2"})
     void testEmptyMapReplayUsesCheckpoint(NestingType nestingType, int events) {
+        var config = DurableConfig.builder().withCheckpointEmptyMap(true).build();
         var executionCount = new AtomicInteger(0);
 
-        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
-            var result = context.map(
-                    "empty-map",
-                    List.<String>of(),
-                    String.class,
-                    (item, index, ctx) -> {
-                        executionCount.incrementAndGet();
-                        return item;
-                    },
-                    MapConfig.builder().nestingType(nestingType).build());
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    var result = context.map(
+                            "empty-map",
+                            List.<String>of(),
+                            String.class,
+                            (item, index, ctx) -> {
+                                executionCount.incrementAndGet();
+                                return item;
+                            },
+                            MapConfig.builder().nestingType(nestingType).build());
 
-            assertTrue(result.allSucceeded());
-            assertEquals(0, result.size());
-            return "done";
-        });
+                    assertTrue(result.allSucceeded());
+                    assertEquals(0, result.size());
+                    return "done";
+                },
+                config);
 
         var result1 = runner.runUntilComplete("test");
         assertEquals(ExecutionStatus.SUCCEEDED, result1.getStatus());

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
@@ -1780,7 +1780,7 @@ class MapIntegrationTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"FLAT, 0", "NESTED, 0"})
+    @CsvSource({"FLAT, 2", "NESTED, 2"})
     void testMapWithEmptyItems(NestingType nestingType, int events) {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             List<String> items = List.of();
@@ -1803,7 +1803,7 @@ class MapIntegrationTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"FLAT, 0", "NESTED, 0"})
+    @CsvSource({"FLAT, 2", "NESTED, 2"})
     void testAnyOfMapWithEmptyItems(NestingType nestingType, int events) {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             List<String> items = List.of();
@@ -1822,5 +1822,37 @@ class MapIntegrationTest {
         var result = runner.runUntilComplete("test");
         assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
         assertEquals(events, result.getHistoryEvents().size());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"FLAT, 2", "NESTED, 2"})
+    void testEmptyMapReplayUsesCheckpoint(NestingType nestingType, int events) {
+        var executionCount = new AtomicInteger(0);
+
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var result = context.map(
+                    "empty-map",
+                    List.<String>of(),
+                    String.class,
+                    (item, index, ctx) -> {
+                        executionCount.incrementAndGet();
+                        return item;
+                    },
+                    MapConfig.builder().nestingType(nestingType).build());
+
+            assertTrue(result.allSucceeded());
+            assertEquals(0, result.size());
+            return "done";
+        });
+
+        var result1 = runner.runUntilComplete("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result1.getStatus());
+        var firstRunCount = executionCount.get();
+
+        // Replay from the checkpointed empty map, no re-execution, no error
+        var result2 = runner.run("test");
+        assertEquals(ExecutionStatus.SUCCEEDED, result2.getStatus());
+        assertEquals(firstRunCount, executionCount.get(), "Map functions should not re-execute on replay");
+        assertEquals(events, result2.getHistoryEvents().size());
     }
 }

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -331,6 +331,34 @@ class PluginIntegrationTest {
         assertNull(stepEnd.error(), "error should be null for successful step");
     }
 
+    @Test
+    void plugin_operationStartAndEnd_balanced_forEmptyMap() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    context.map("empty-map", List.<String>of(), String.class, (item, index, ctx) -> item);
+                    return "done";
+                },
+                config);
+
+        var result = runner.runUntilComplete("input");
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+
+        // An empty map must fire a balanced onOperationStart/onOperationEnd pair so plugins
+        // (e.g. OTel) do not leave the completed map reported as PENDING.
+        long startCount = plugin.operationStarts.stream()
+                .filter(info -> "empty-map".equals(info.name()))
+                .count();
+        long endCount = plugin.operationEnds.stream()
+                .filter(info -> "empty-map".equals(info.name()))
+                .count();
+        assertEquals(1, startCount, "empty map should fire onOperationStart exactly once");
+        assertEquals(1, endCount, "empty map should fire onOperationEnd exactly once");
+    }
+
     // ─── Operation change hook ───────────────────────────────────────────
 
     @Test

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -334,7 +334,11 @@ class PluginIntegrationTest {
     @Test
     void plugin_operationStartAndEnd_balanced_forEmptyMap() {
         var plugin = new RecordingPlugin();
-        var config = DurableConfig.builder().withPlugins(plugin).build();
+        // withCheckpointEmptyMap is a temporary flag expected to be removed in a future major version.
+        var config = DurableConfig.builder()
+                .withPlugins(plugin)
+                .withCheckpointEmptyMap(true)
+                .build();
 
         var runner = LocalDurableTestRunner.create(
                 String.class,

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
@@ -62,6 +62,8 @@ public class LocalDurableTestRunner<I, O> {
                     .withPollingStrategy(customerConfig.getPollingStrategy())
                     .withCheckpointDelay(customerConfig.getCheckpointDelay())
                     .withLoggerConfig(customerConfig.getLoggerConfig())
+                    // Temporary: remove along with the checkpointEmptyMap flag in a future major version.
+                    .withCheckpointEmptyMap(customerConfig.shouldCheckpointEmptyMap())
                     .withPlugins(customerConfig.getPluginRunner().getPlugins().toArray(new DurableExecutionPlugin[0]))
                     .build();
         } else {

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
@@ -99,6 +99,7 @@ public final class DurableConfig {
     private final PollingStrategy pollingStrategy;
     private final Duration checkpointDelay;
     private final boolean deserializeAfterSerialization;
+    private final boolean checkpointEmptyMap;
     private final PluginRunner pluginRunner;
 
     private DurableConfig(Builder builder) {
@@ -111,6 +112,7 @@ public final class DurableConfig {
         this.pollingStrategy = Objects.requireNonNullElse(builder.pollingStrategy, PollingStrategies.Presets.DEFAULT);
         this.checkpointDelay = Objects.requireNonNullElseGet(builder.checkpointDelay, () -> Duration.ofSeconds(0));
         this.deserializeAfterSerialization = builder.deserializeAfterSerialization;
+        this.checkpointEmptyMap = builder.checkpointEmptyMap;
         this.pluginRunner = builder.plugins.isEmpty() ? PluginRunner.noOp() : new PluginRunner(builder.plugins);
 
         validateConfiguration();
@@ -199,6 +201,16 @@ public final class DurableConfig {
      */
     public boolean shouldDeserializeAfterSerialization() {
         return deserializeAfterSerialization;
+    }
+
+    /**
+     * Whether an empty map operation should emit START and SUCCEED checkpoints. Defaults to not checkpointing; this
+     * default and the flag are expected to be removed in a future major version.
+     *
+     * @return true when empty maps should be checkpointed
+     */
+    public boolean shouldCheckpointEmptyMap() {
+        return checkpointEmptyMap;
     }
 
     /**
@@ -309,6 +321,7 @@ public final class DurableConfig {
         private PollingStrategy pollingStrategy;
         private Duration checkpointDelay;
         private boolean deserializeAfterSerialization = true;
+        private boolean checkpointEmptyMap = false;
         private List<DurableExecutionPlugin> plugins = new ArrayList<>();
 
         public Builder() {}
@@ -430,6 +443,19 @@ public final class DurableConfig {
          */
         public Builder withDeserializeAfterSerialization(boolean deserializeAfterSerialization) {
             this.deserializeAfterSerialization = deserializeAfterSerialization;
+            return this;
+        }
+
+        /**
+         * Controls whether an empty map operation emits START and SUCCEED checkpoints. Defaults to not checkpointing,
+         * which leaves the operation out of the durable execution history. This default and the flag are expected to be
+         * removed in a future major version.
+         *
+         * @param checkpointEmptyMap true to checkpoint empty maps
+         * @return This builder
+         */
+        public Builder withCheckpointEmptyMap(boolean checkpointEmptyMap) {
+            this.checkpointEmptyMap = checkpointEmptyMap;
             return this;
         }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
@@ -6,6 +6,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.lambda.model.ContextOptions;
 import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationAction;
@@ -37,6 +39,7 @@ import software.amazon.lambda.durable.util.ExceptionHelper;
  */
 public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
 
+    private static final Logger logger = LoggerFactory.getLogger(MapOperation.class);
     private static final int LARGE_RESULT_THRESHOLD = 256 * 1024;
 
     private final List<I> items;
@@ -101,11 +104,26 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
     @Override
     protected void start() {
         if (items.isEmpty()) {
-            // Empty map: checkpoint START + SUCCEED directly to produce a complete map operation with an empty result.
-            sendOperationUpdate(OperationUpdate.builder()
-                    .action(OperationAction.START)
-                    .subType(getSubType().getValue()));
-            handleCompletion(CompletionConfig.CompletionDecision.complete(ConcurrencyCompletionStatus.ALL_COMPLETED));
+            // TODO: Remove the checkpointEmptyMap flag and the non-checkpointing branch in a future major version,
+            // making checkpointing the default.
+            if (getContext().getDurableConfig().shouldCheckpointEmptyMap()) {
+                // Checkpoint START + SUCCEED to produce a complete map operation with an empty result.
+                sendOperationUpdate(OperationUpdate.builder()
+                        .action(OperationAction.START)
+                        .subType(getSubType().getValue()));
+                handleCompletion(
+                        CompletionConfig.CompletionDecision.complete(ConcurrencyCompletionStatus.ALL_COMPLETED));
+            } else {
+                // Default: complete without checkpointing. Fire onOperationEnd so plugin hooks stay balanced.
+                logger.warn(
+                        "Empty map operation '{}' is not checkpointed by default. This behavior is unintended and may"
+                                + " affect replay and plugin instrumentation. Enable"
+                                + " DurableConfig.withCheckpointEmptyMap(true) to checkpoint empty maps.",
+                        getName());
+                cachedResult = MapResult.empty();
+                fireOnOperationEnd(null, null, false);
+                markAlreadyCompleted();
+            }
             return;
         }
         sendOperationUpdateAsync(OperationUpdate.builder()
@@ -221,6 +239,11 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
 
     @Override
     public MapResult<O> get() {
+        // Non-checkpointed empty map: no stored operation, so skip join() and return the result set in start().
+        // Tied to the temporary checkpointEmptyMap flag; remove with it in a future major version.
+        if (items.isEmpty() && !getContext().getDurableConfig().shouldCheckpointEmptyMap()) {
+            return cachedResult;
+        }
         join();
         // cachedResult is always set upon successful completion
         return cachedResult;

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/MapOperation.java
@@ -17,6 +17,7 @@ import software.amazon.lambda.durable.config.MapConfig;
 import software.amazon.lambda.durable.context.DurableContextImpl;
 import software.amazon.lambda.durable.exception.UnrecoverableDurableExecutionException;
 import software.amazon.lambda.durable.execution.SuspendExecutionException;
+import software.amazon.lambda.durable.model.ConcurrencyCompletionStatus;
 import software.amazon.lambda.durable.model.MapResult;
 import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
@@ -100,7 +101,11 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
     @Override
     protected void start() {
         if (items.isEmpty()) {
-            markAlreadyCompleted();
+            // Empty map: checkpoint START + SUCCEED directly to produce a complete map operation with an empty result.
+            sendOperationUpdate(OperationUpdate.builder()
+                    .action(OperationAction.START)
+                    .subType(getSubType().getValue()));
+            handleCompletion(CompletionConfig.CompletionDecision.complete(ConcurrencyCompletionStatus.ALL_COMPLETED));
             return;
         }
         sendOperationUpdateAsync(OperationUpdate.builder()
@@ -113,9 +118,6 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
 
     @Override
     protected void replay(Operation existing) {
-        if (items.isEmpty()) {
-            throw terminateExecutionWithIllegalDurableOperationException("Empty Map operation is not replayable");
-        }
         switch (existing.status()) {
             case SUCCEEDED -> {
                 var result = existing.contextDetails() != null
@@ -219,9 +221,6 @@ public class MapOperation<I, O> extends ConcurrencyOperation<MapResult<O>> {
 
     @Override
     public MapResult<O> get() {
-        if (items.isEmpty()) {
-            return MapResult.empty();
-        }
         join();
         // cachedResult is always set upon successful completion
         return cachedResult;

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
@@ -105,6 +105,26 @@ class DurableConfigTest {
         assertFalse(config.shouldDeserializeAfterSerialization());
     }
 
+    // Temporary: remove along with the checkpointEmptyMap flag in a future major version.
+    @Test
+    void testBuilder_CheckpointEmptyMapDefaultsToFalse() {
+        var config =
+                DurableConfig.builder().withDurableExecutionClient(mockClient).build();
+
+        assertFalse(config.shouldCheckpointEmptyMap());
+    }
+
+    // Temporary: remove along with the checkpointEmptyMap flag in a future major version.
+    @Test
+    void testBuilder_WithCheckpointEmptyMapEnabled() {
+        var config = DurableConfig.builder()
+                .withDurableExecutionClient(mockClient)
+                .withCheckpointEmptyMap(true)
+                .build();
+
+        assertTrue(config.shouldCheckpointEmptyMap());
+    }
+
     @Test
     void testBuilder_WithAllCustomComponents() {
         var config = DurableConfig.builder()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

https://github.com/aws/aws-durable-execution-sdk-java/issues/529

### Description

Currently when a map operation gets an empty list of items, it will complete locally without producing the usual durable checkpoints. This resulted in logs or side effects re-running unintentionally, or plugin hooks not being called.

This PR handles empty maps as first-class checkpointed operations, so behaviour is consistent with non-empty maps.

### Code Changes

`MapOperation.java`
- `start()` no longer calls `markAlreadyCompleted()` on empty maps. 
  - It now sends a start checkpoint to the backend, like in the non-empty case. 
    - The sync `sendOperationUpdate()` is used to guarantee the start checkpoint is acknowledged before sending the success checkpoint.
  - And then it calls `handleCompletion()`, to mimic how non-empty maps send a success checkpoint to the backend.

- `replay()` no longer guards against empty maps.
  - The guard existed because previously empty maps did not checkpoint, causing this method to hang. But now that empty maps checkpoint, `replay()` will be able to flow through the normal SUCCEEDED path.

- `get()` no longer returns an empty result for empty maps.
  - So now the actual checkpointed result will be returned via `join()`, consistent with the normal path.

`MapIntegrationTest.java`
- Updated the empty map tests to now expect the correct number of events (previously they expected 0, because all events were skipped for empty maps).
- Added a new test to check that empty maps are correctly replayed.

`PluginIntegrationTest.java`
- Added a test to check that an empty map operation will properly fire the `onOperationStart` and `onOperationEnd` hooks.

---

**Also contains a commit for the relevant conformance suite test case. See this PR: https://github.com/aws/aws-durable-execution-sdk-java/pull/556.**

---

### Demo/Screenshots

### Checklist

- [ ] I have filled out every section of the PR template
- [ ] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? No unit tests for map operation.

#### Integration Tests

Have integration tests been written for these changes? YES

#### Examples

Has a new example been added for the change? (if applicable) N/A
