### PR TITLE
Add workflow-rooted ExecutionOtelPlugin and fix OtelPlugin status parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ sdk-integration-tests/src/test/  # SDK components working together via LocalDura
 ├── MapIntegrationTest
 ├── ParallelIntegrationTest
 ├── WaitForConditionIntegrationTest
-└── OtelPluginIntegrationTest
+└── InvocationOtelPluginIntegrationTest
 
 otel-plugin/src/test/            # OpenTelemetry plugin unit tests
 
@@ -272,7 +272,7 @@ void testAgainstRealLambda() {
 | `ParallelOperation` | Runs named child-context branches concurrently |
 | `ConcurrencyOperation` | Shared base for map/parallel concurrency limiting and completion evaluation |
 | `DurableExecutionPlugin` | Preview lifecycle hook interface |
-| `OtelPlugin` | OpenTelemetry plugin implementation in `otel-plugin` |
+| `InvocationOtelPlugin` | OpenTelemetry plugin implementation in `otel-plugin` |
 
 ### Serialization
 

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/general/OtelExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/general/OtelExample.java
@@ -9,7 +9,7 @@ import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.examples.types.GreetingRequest;
-import software.amazon.lambda.durable.otel.OtelPlugin;
+import software.amazon.lambda.durable.otel.InvocationOtelPlugin;
 
 /**
  * Example demonstrating OpenTelemetry instrumentation with the Durable Execution SDK.
@@ -39,7 +39,7 @@ public class OtelExample extends DurableHandler<GreetingRequest, String> {
 
     @Override
     protected DurableConfig createConfiguration() {
-        var otelPlugin = new OtelPlugin(
+        var otelPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create())));
 
         return DurableConfig.builder().withPlugins(otelPlugin).build();

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayExamples.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayExamples.java
@@ -10,7 +10,7 @@ import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.examples.types.GreetingRequest;
-import software.amazon.lambda.durable.otel.OtelPlugin;
+import software.amazon.lambda.durable.otel.InvocationOtelPlugin;
 
 /**
  * OTel examples for map, parallel, and nested context operations. These are local-only examples (not deployed to
@@ -22,8 +22,8 @@ public final class OtelXRayExamples {
 
     private static DurableConfig otelConfig() {
         var otlpExporter = OtlpGrpcSpanExporter.getDefault();
-        var otelPlugin =
-                new OtelPlugin(SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
+        var otelPlugin = new InvocationOtelPlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
         return DurableConfig.builder().withPlugins(otelPlugin).build();
     }
 

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayStepExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayStepExample.java
@@ -10,7 +10,7 @@ import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.examples.ExampleTemplate;
 import software.amazon.lambda.durable.examples.types.GreetingRequest;
-import software.amazon.lambda.durable.otel.OtelPlugin;
+import software.amazon.lambda.durable.otel.InvocationOtelPlugin;
 
 /**
  * OTel + X-Ray example: simple steps in a single invocation.
@@ -40,8 +40,8 @@ public class OtelXRayStepExample extends DurableHandler<GreetingRequest, String>
         // OTLP exporter sends spans to the ADOT collector (localhost:4317 by default)
         var otlpExporter = OtlpGrpcSpanExporter.getDefault();
 
-        var otelPlugin =
-                new OtelPlugin(SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
+        var otelPlugin = new InvocationOtelPlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
 
         return DurableConfig.builder().withPlugins(otelPlugin).build();
     }

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayWaitExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/otel/OtelXRayWaitExample.java
@@ -11,7 +11,7 @@ import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.examples.ExampleTemplate;
 import software.amazon.lambda.durable.examples.types.GreetingRequest;
-import software.amazon.lambda.durable.otel.OtelPlugin;
+import software.amazon.lambda.durable.otel.InvocationOtelPlugin;
 
 /**
  * OTel + X-Ray example: step → wait → step pattern that forces multiple Lambda invocations.
@@ -52,8 +52,8 @@ public class OtelXRayWaitExample extends DurableHandler<GreetingRequest, String>
         // OTLP exporter sends spans to the ADOT collector (localhost:4317 by default)
         var otlpExporter = OtlpGrpcSpanExporter.getDefault();
 
-        var otelPlugin =
-                new OtelPlugin(SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
+        var otelPlugin = new InvocationOtelPlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
 
         return DurableConfig.builder().withPlugins(otelPlugin).build();
     }

--- a/otel-plugin/README.md
+++ b/otel-plugin/README.md
@@ -41,7 +41,7 @@ You also need the OpenTelemetry SDK and an exporter:
 
 1. Add the ADOT Lambda Layer to your function
 2. Enable X-Ray Active Tracing on the function
-3. Register `OtelPlugin` in your handler's `DurableConfig`
+3. Register `InvocationOtelPlugin` in your handler's `DurableConfig`
 4. Grant X-Ray write permissions
 
 ### 1. ADOT Lambda Layer
@@ -110,7 +110,7 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
-import software.amazon.lambda.durable.otel.OtelPlugin;
+import software.amazon.lambda.durable.otel.InvocationOtelPlugin;
 
 public class MyHandler extends DurableHandler<MyInput, MyOutput> {
 
@@ -118,7 +118,7 @@ public class MyHandler extends DurableHandler<MyInput, MyOutput> {
     protected DurableConfig createConfiguration() {
         var otlpExporter = OtlpGrpcSpanExporter.getDefault();
 
-        var otelPlugin = new OtelPlugin(
+        var otelPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder()
                         .addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
 
@@ -215,13 +215,13 @@ These appear automatically in structured log output (Log4j2 JSON, Logback JSON) 
 
 ```java
 // Default: X-Ray context extraction, MDC enabled
-new OtelPlugin(tracerProviderBuilder);
+new InvocationOtelPlugin(tracerProviderBuilder);
 
 // Custom context extractor, MDC enabled
-new OtelPlugin(tracerProviderBuilder, contextExtractor);
+new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor);
 
 // Full configuration
-new OtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc);
+new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc);
 ```
 
 | Parameter | Description | Default |
@@ -262,7 +262,7 @@ For local testing, use a logging exporter to print spans to stdout:
 ```java
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 
-var otelPlugin = new OtelPlugin(
+var otelPlugin = new InvocationOtelPlugin(
         SdkTracerProvider.builder()
                 .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create())));
 ```

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
@@ -34,6 +34,7 @@ public class DeterministicIdGenerator implements IdGenerator {
     private final AtomicReference<String> extractedTraceId = new AtomicReference<>(null);
     private final AtomicReference<String> arnDerivedTraceId = new AtomicReference<>(null);
     private final ThreadLocal<String> pendingSpanOperationId = new ThreadLocal<>();
+    private final ThreadLocal<String> pendingRawSpanId = new ThreadLocal<>();
     private final AtomicReference<String> durableExecutionArn = new AtomicReference<>(null);
 
     /**
@@ -67,6 +68,17 @@ public class DeterministicIdGenerator implements IdGenerator {
     }
 
     /**
+     * Queues the next span to use the given pre-computed span ID verbatim. Unlike {@link #setNextSpanOperationId}, the
+     * supplied value is used directly rather than derived from an operation ID. Used for the Workflow root span, whose
+     * ID is derived once from the execution ARN via {@link #generateWorkflowSpanId()}.
+     *
+     * @param spanId a 16-char lowercase hex span ID
+     */
+    public void setNextSpanId(String spanId) {
+        this.pendingRawSpanId.set(spanId);
+    }
+
+    /**
      * Generates a deterministic span ID for a given operation ID without consuming the ThreadLocal state.
      *
      * @param operationId the operation ID to derive the span ID from
@@ -74,6 +86,24 @@ public class DeterministicIdGenerator implements IdGenerator {
      */
     public String generateSpanIdForOperation(String operationId) {
         return generateSpanIdFromOperation(operationId);
+    }
+
+    /**
+     * Generates the deterministic span ID for the Workflow root span from the current execution ARN, using the seed
+     * {@code "workflow:" + arn} (SHA-256, truncated to 16 hex chars). Stable across all invocations of the same
+     * execution so the Workflow span is exported once as a single logical span. Guarded to never be all-zero (an
+     * invalid OTel span ID).
+     *
+     * @return a deterministic 16-char hex span ID
+     */
+    public String generateWorkflowSpanId() {
+        var arn = durableExecutionArn.get();
+        var seed = "workflow:" + (arn != null ? arn : "");
+        var spanId = sha256(seed).substring(0, 16);
+        if (spanId.equals("0000000000000000")) {
+            spanId = "0000000000000001";
+        }
+        return spanId;
     }
 
     @Override
@@ -94,6 +124,11 @@ public class DeterministicIdGenerator implements IdGenerator {
 
     @Override
     public String generateSpanId() {
+        var raw = pendingRawSpanId.get();
+        if (raw != null) {
+            pendingRawSpanId.remove();
+            return raw;
+        }
         var operationId = pendingSpanOperationId.get();
         if (operationId != null) {
             pendingSpanOperationId.remove();

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -185,23 +185,20 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
 
     @Override
     public void onInvocationEnd(InvocationEndInfo info) {
-        // End any operation spans that are still open (operations that didn't complete in this invocation)
-        for (var entry : operationSpans.entrySet()) {
-            var span = entry.getValue();
-            span.setAttribute(DURABLE_OPERATION_STATUS, "PENDING");
-            span.end();
-        }
+        // Reset per-invocation operation state WITHOUT ending open operation spans. Matching the JS/Python
+        // ExecutionOtelPlugin, an operation span is only ended in onOperationEnd. An operation still open when the
+        // invocation suspends is left un-exported here and is re-materialized once (with its deterministic span ID,
+        // plus a link to the invocation that completes it) when onOperationEnd fires in a later invocation.
         operationSpans.clear();
         operationContexts.clear();
 
-        // End any attempt spans that are still open (e.g., crash before onUserFunctionEnd)
-        for (var entry : attemptScopes.entrySet()) {
-            entry.getValue().close();
+        // Defensively close any lingering attempt scopes so OTel context is not leaked on worker threads (normally
+        // every onUserFunctionStart is paired with onUserFunctionEnd within the invocation). The attempt spans
+        // themselves are left un-ended rather than force-ended, consistent with not ending open spans here.
+        for (var scope : attemptScopes.values()) {
+            scope.close();
         }
         attemptScopes.clear();
-        for (var entry : attemptSpans.entrySet()) {
-            entry.getValue().end();
-        }
         attemptSpans.clear();
 
         // End the invocation span every invocation.

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -48,15 +48,15 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  *       span, linked to the current Invocation span.
  * </ul>
  *
- * <p>Contrast with {@link OtelPlugin} (the invocation-rooted variant, equivalent to the reference
- * {@code InvocationOtelPlugin}): there the invocation span is the root and there is no Workflow span. Here the Workflow
- * span is the root, operations hang off the Workflow span, and each operation/attempt links to the invocation that ran
- * it. Both plugins share {@link DeterministicIdGenerator}, {@link ContextExtractor}, {@link SpanAttributes}, and
- * {@link MdcSpanEnricher}.
+ * <p>Contrast with {@link InvocationOtelPlugin} (the invocation-rooted variant, equivalent to the reference
+ * {@code InvocationInvocationOtelPlugin}): there the invocation span is the root and there is no Workflow span. Here
+ * the Workflow span is the root, operations hang off the Workflow span, and each operation/attempt links to the
+ * invocation that ran it. Both plugins share {@link DeterministicIdGenerator}, {@link ContextExtractor},
+ * {@link SpanAttributes}, and {@link MdcSpanEnricher}.
  *
- * <p>Trace ID resolution matches {@link OtelPlugin}: the X-Ray trace ID from {@code _X_AMZN_TRACE_ID} when available
- * (the backend propagates the same Root to all invocations, unifying the trace), else a deterministic trace ID derived
- * from the execution ARN.
+ * <p>Trace ID resolution matches {@link InvocationOtelPlugin}: the X-Ray trace ID from {@code _X_AMZN_TRACE_ID} when
+ * available (the backend propagates the same Root to all invocations, unifying the trace), else a deterministic trace
+ * ID derived from the execution ARN.
  *
  * <p>Status mapping (parity with the Python/JS references):
  *
@@ -154,7 +154,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         idGenerator.setDurableExecutionArn(info.durableExecutionArn());
 
         // Extract trace context from environment (X-Ray header). Only the trace ID is used — the Workflow span is a
-        // true root, so the X-Ray parent span ID is intentionally not used for parenting (unlike OtelPlugin).
+        // true root, so the X-Ray parent span ID is intentionally not used for parenting (unlike InvocationOtelPlugin).
         var extractedContext = contextExtractor.extract();
         if (extractedContext != null) {
             idGenerator.setExtractedTraceId(extractedContext.traceId());

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -163,13 +163,15 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         }
 
         // Workflow root span — deterministic span ID from the ARN, no parent. Recreated every invocation with the
-        // same ID so it is exported once as a single logical span (on the terminal invocation only).
-        idGenerator.setNextSpanId(idGenerator.generateWorkflowSpanId());
-        workflowSpan = tracer.spanBuilder(workflowSpanName)
+        // same ID so it is exported once as a single logical span (on the terminal invocation only). Its start time
+        // is the execution start time from the backend (falling back to now if unavailable).
+        var workflowSpanBuilder = tracer.spanBuilder(workflowSpanName)
                 .setSpanKind(SpanKind.INTERNAL)
                 .setNoParent()
                 .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())
-                .startSpan();
+                .setStartTimestamp(info.executionStartTime() != null ? info.executionStartTime() : Instant.now());
+        idGenerator.setNextSpanId(idGenerator.generateWorkflowSpanId());
+        workflowSpan = workflowSpanBuilder.startSpan();
 
         // Invocation span — child of the Workflow span, INTERNAL kind, random span ID (new every invocation).
         var spanBuilder = tracer.spanBuilder("invocation")

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -5,6 +5,7 @@ package software.amazon.lambda.durable.otel;
 import static software.amazon.lambda.durable.otel.SpanAttributes.*;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanContext;
@@ -15,8 +16,10 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.semconv.ServiceAttributes;
 import java.time.Instant;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
@@ -81,6 +84,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
     private static final Logger logger = LoggerFactory.getLogger(ExecutionOtelPlugin.class);
     private static final String INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
     private static final String DEFAULT_WORKFLOW_SPAN_NAME = "Workflow";
+    private static final String SERVICE_NAME = "workflow";
 
     private final SdkTracerProvider tracerProvider;
     private final Tracer tracer;
@@ -139,6 +143,12 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
             boolean enableMdc,
             String workflowSpanName) {
         this.idGenerator = new DeterministicIdGenerator();
+
+        // Set service.name so this plugin's spans group under a distinct "workflow" node in X-Ray/OTLP backends
+        // (parity with InvocationOtelPlugin, which sets "invocation"). Applies to all spans from this provider.
+        var resource = Resource.create(Attributes.of(ServiceAttributes.SERVICE_NAME, SERVICE_NAME));
+        tracerProviderBuilder.addResource(resource);
+
         this.tracerProvider = tracerProviderBuilder.setIdGenerator(idGenerator).build();
         this.tracer = tracerProvider.get(INSTRUMENTATION_NAME);
         this.contextExtractor = contextExtractor;
@@ -291,6 +301,10 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
             if (info.status() != null) {
                 span.setAttribute(DURABLE_OPERATION_STATUS, info.status());
             }
+            // Total attempts for retriable operations (STEP, WAIT_FOR_CONDITION) — emitted only at end.
+            if (info.attempt() != null) {
+                span.setAttribute(DURABLE_ATTEMPT_NUMBER, info.attempt().longValue());
+            }
             if (info.error() != null) {
                 span.setStatus(StatusCode.ERROR, info.error().getMessage());
                 span.recordException(info.error());
@@ -327,6 +341,11 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
 
             if (info.status() != null) {
                 continuationSpan.setAttribute(DURABLE_OPERATION_STATUS, info.status());
+            }
+            // Total attempts for retriable operations (STEP, WAIT_FOR_CONDITION) — emitted only at end.
+            if (info.attempt() != null) {
+                continuationSpan.setAttribute(
+                        DURABLE_ATTEMPT_NUMBER, info.attempt().longValue());
             }
             if (info.error() != null) {
                 continuationSpan.setStatus(StatusCode.ERROR, info.error().getMessage());

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -263,6 +263,9 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
                 .setAttribute(DURABLE_OPERATION_TYPE, info.type());
         addInvocationLink(spanBuilder);
 
+        if (info.startTimestamp() != null) {
+            spanBuilder.setStartTimestamp(info.startTimestamp());
+        }
         if (info.name() != null) {
             spanBuilder.setAttribute(DURABLE_OPERATION_NAME, info.name());
         }

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -292,8 +292,10 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
             }
             endSpan(span, info.endTimestamp());
         } else {
-            // Operation completed between invocations (started in a prior invocation). Recreate it with the same
-            // deterministic span ID so it stitches to the original, plus a link to the current invocation.
+            // Operation completed between invocations: its onOperationStart ran in a prior invocation, whose
+            // in-memory span was dropped un-exported at that invocation's end. Emit the operation's single span
+            // now, using its deterministic span ID (stable across the execution), plus a link to the invocation
+            // that completed it.
             operationContexts.remove(info.id());
             idGenerator.setNextSpanOperationId(info.id());
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -164,6 +164,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         // same ID so it is exported once as a single logical span (on the terminal invocation only).
         idGenerator.setNextSpanId(idGenerator.generateWorkflowSpanId());
         workflowSpan = tracer.spanBuilder(workflowSpanName)
+                .setSpanKind(SpanKind.INTERNAL)
                 .setNoParent()
                 .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())
                 .startSpan();

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -5,8 +5,8 @@ package software.amazon.lambda.durable.otel;
 import static software.amazon.lambda.durable.otel.SpanAttributes.*;
 
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
@@ -15,10 +15,8 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
-import io.opentelemetry.semconv.ServiceAttributes;
 import java.time.Instant;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
@@ -32,34 +30,43 @@ import software.amazon.lambda.durable.plugin.UserFunctionEndInfo;
 import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
 
 /**
- * OpenTelemetry plugin for the AWS Lambda Durable Execution SDK.
+ * Workflow-rooted OpenTelemetry plugin for the AWS Lambda Durable Execution SDK.
  *
- * <p>Creates spans at three levels:
- *
- * <ul>
- *   <li><b>Invocation span</b> — one per Lambda invocation
- *   <li><b>Operation span</b> — created when an operation starts, ended when it completes or when the invocation ends
- *   <li><b>Attempt span</b> — one per user function execution (step attempt, child context run)
- * </ul>
- *
- * <p>Trace ID resolution:
- *
- * <ol>
- *   <li>Uses the X-Ray trace ID from {@code _X_AMZN_TRACE_ID} when available. The durable execution backend propagates
- *       the same Root to all invocations of the same execution, naturally unifying the trace.
- *   <li>Falls back to a deterministic trace ID derived from the execution ARN (for local tests or non-Lambda
- *       environments).
- * </ol>
- *
- * <p>Requires the ADOT Lambda Layer for trace export. Configure with:
+ * <p>This is the Java port of the {@code ExecutionOtelPlugin} in the Python and JavaScript SDKs. It renders the full
+ * durable-execution hierarchy:
  *
  * <ul>
- *   <li>Lambda Layer: {@code aws-otel-java-agent} (provides the OTLP collector extension)
- *   <li>Tracing: Active (to populate {@code _X_AMZN_TRACE_ID})
+ *   <li><b>Workflow span</b> — one <em>logical</em> root span per durable execution. Its span ID is derived
+ *       deterministically from the execution ARN, so every invocation of the same execution produces the same ID. It is
+ *       ended (and therefore exported) exactly once, on the terminal invocation.
+ *   <li><b>Invocation span</b> — one per Lambda invocation, a child of the Workflow span. Created and ended every
+ *       invocation.
+ *   <li><b>Operation span</b> — parented to its parent operation span (or the Workflow span) and carrying a
+ *       <em>link</em> to the current Invocation span for correlation. Deterministic ID keyed by operation ID, so a
+ *       suspended-then-resumed operation stitches into a single logical span across invocations.
+ *   <li><b>Attempt span</b> — one per user-function execution (step attempt, child-context run), child of the operation
+ *       span, linked to the current Invocation span.
  * </ul>
  *
- * <p>Note: Do NOT set {@code AWS_LAMBDA_EXEC_WRAPPER}. The collector extension runs independently. The wrapper would
- * attach the auto-instrumentation agent which creates a competing TracerProvider.
+ * <p>Contrast with {@link OtelPlugin} (the invocation-rooted variant, equivalent to the reference
+ * {@code InvocationOtelPlugin}): there the invocation span is the root and there is no Workflow span. Here the Workflow
+ * span is the root, operations hang off the Workflow span, and each operation/attempt links to the invocation that ran
+ * it. Both plugins share {@link DeterministicIdGenerator}, {@link ContextExtractor}, {@link SpanAttributes}, and
+ * {@link MdcSpanEnricher}.
+ *
+ * <p>Trace ID resolution matches {@link OtelPlugin}: the X-Ray trace ID from {@code _X_AMZN_TRACE_ID} when available
+ * (the backend propagates the same Root to all invocations, unifying the trace), else a deterministic trace ID derived
+ * from the execution ARN.
+ *
+ * <p>Status mapping (parity with the Python/JS references):
+ *
+ * <ul>
+ *   <li>Invocation span: {@code SUCCEEDED}/{@code PENDING} → {@link StatusCode#OK}; {@code RETRYING}/{@code FAILED} →
+ *       {@link StatusCode#ERROR}.
+ *   <li>Workflow span (terminal only): {@code SUCCEEDED} → {@link StatusCode#OK}; {@code FAILED} →
+ *       {@link StatusCode#ERROR}. Non-terminal statuses never end the Workflow span, so it is not exported this
+ *       invocation.
+ * </ul>
  *
  * <p>Thread-safe: uses {@link ConcurrentHashMap} for span/scope storage since the SDK runs user code on multiple
  * threads.
@@ -67,18 +74,21 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
 @Deprecated
-public class OtelPlugin implements DurableExecutionPlugin {
+public class ExecutionOtelPlugin implements DurableExecutionPlugin {
 
-    private static final Logger logger = LoggerFactory.getLogger(OtelPlugin.class);
+    private static final Logger logger = LoggerFactory.getLogger(ExecutionOtelPlugin.class);
     private static final String INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
+    private static final String DEFAULT_WORKFLOW_SPAN_NAME = "Workflow";
 
     private final SdkTracerProvider tracerProvider;
     private final Tracer tracer;
     private final DeterministicIdGenerator idGenerator;
     private final ContextExtractor contextExtractor;
     private final boolean enableMdc;
+    private final String workflowSpanName;
 
     // Per-invocation state
+    private volatile Span workflowSpan;
     private volatile Span invocationSpan;
     private volatile String durableExecutionArn;
 
@@ -93,55 +103,45 @@ public class OtelPlugin implements DurableExecutionPlugin {
     private final ConcurrentHashMap<String, SpanContext> operationContexts = new ConcurrentHashMap<>();
 
     /**
-     * Creates an OTel plugin with default settings: X-Ray context extraction, MDC enabled.
-     *
-     * <p>Uses the provided tracer provider builder. Customers configure exporters and span processors on the builder —
-     * the plugin handles ID generation.
-     *
-     * <p>For ADOT layer usage, configure with an OTLP exporter:
-     *
-     * <pre>{@code
-     * var otlpExporter = OtlpGrpcSpanExporter.getDefault(); // sends to localhost:4317
-     * var plugin = new OtelPlugin(
-     *     SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
-     * }</pre>
+     * Creates a workflow-rooted OTel plugin with default settings: X-Ray context extraction, MDC enabled, root span
+     * named {@code "Workflow"}.
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      */
-    public OtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder) {
-        this(tracerProviderBuilder, new XRayContextExtractor(), true);
+    public ExecutionOtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder) {
+        this(tracerProviderBuilder, new XRayContextExtractor(), true, DEFAULT_WORKFLOW_SPAN_NAME);
     }
 
     /**
-     * Creates an OTel plugin with a custom context extractor, MDC enabled.
+     * Creates a workflow-rooted OTel plugin with a custom context extractor, MDC enabled, root span named
+     * {@code "Workflow"}.
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
      */
-    public OtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor) {
-        this(tracerProviderBuilder, contextExtractor, true);
+    public ExecutionOtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor) {
+        this(tracerProviderBuilder, contextExtractor, true, DEFAULT_WORKFLOW_SPAN_NAME);
     }
 
     /**
-     * Creates an OTel plugin with full configuration.
+     * Creates a workflow-rooted OTel plugin with full configuration.
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
      * @param enableMdc if true, injects traceId/spanId/traceSampled into SLF4J MDC for log correlation
+     * @param workflowSpanName the name for the Workflow root span
      */
-    public OtelPlugin(
-            SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor, boolean enableMdc) {
+    public ExecutionOtelPlugin(
+            SdkTracerProviderBuilder tracerProviderBuilder,
+            ContextExtractor contextExtractor,
+            boolean enableMdc,
+            String workflowSpanName) {
         this.idGenerator = new DeterministicIdGenerator();
-
-        // Set service.name to "invocation" — X-Ray uses this as the display name for SERVER spans,
-        // creating a separate service node in the trace map labeled "invocation".
-        var resource = Resource.create(Attributes.of(ServiceAttributes.SERVICE_NAME, "invocation"));
-        tracerProviderBuilder.addResource(resource);
-
         this.tracerProvider = tracerProviderBuilder.setIdGenerator(idGenerator).build();
         this.tracer = tracerProvider.get(INSTRUMENTATION_NAME);
         this.contextExtractor = contextExtractor;
         this.enableMdc = enableMdc;
+        this.workflowSpanName = workflowSpanName != null ? workflowSpanName : DEFAULT_WORKFLOW_SPAN_NAME;
     }
 
     // ─── Invocation hooks ────────────────────────────────────────────────
@@ -150,38 +150,28 @@ public class OtelPlugin implements DurableExecutionPlugin {
     public void onInvocationStart(InvocationInfo info) {
         this.durableExecutionArn = info.durableExecutionArn();
 
-        // Set execution ARN for deterministic span ID generation
+        // Set execution ARN for deterministic span/trace ID generation
         idGenerator.setDurableExecutionArn(info.durableExecutionArn());
 
-        // Extract trace context from environment (X-Ray header)
+        // Extract trace context from environment (X-Ray header). Only the trace ID is used — the Workflow span is a
+        // true root, so the X-Ray parent span ID is intentionally not used for parenting (unlike OtelPlugin).
         var extractedContext = contextExtractor.extract();
-
         if (extractedContext != null) {
-            // Use the X-Ray trace ID — backend propagates same Root across all invocations
             idGenerator.setExtractedTraceId(extractedContext.traceId());
         }
-        // If no extracted context, idGenerator falls back to ARN-derived trace ID
 
-        // Determine parent context for the invocation span.
-        Context parentContext;
-        if (extractedContext != null && extractedContext.parentSpanId() != null) {
-            // X-Ray header has parent — create the invocation span as a child of that segment.
-            // This connects our OTLP-exported spans to the Lambda service's X-Ray segments.
-            var parentSpanContext = SpanContext.createFromRemoteParent(
-                    extractedContext.traceId(),
-                    extractedContext.parentSpanId(),
-                    TraceFlags.getSampled(),
-                    TraceState.getDefault());
-            parentContext = Context.root().with(Span.wrap(parentSpanContext));
-        } else {
-            parentContext = Context.root();
-        }
+        // Workflow root span — deterministic span ID from the ARN, no parent. Recreated every invocation with the
+        // same ID so it is exported once as a single logical span (on the terminal invocation only).
+        idGenerator.setNextSpanId(idGenerator.generateWorkflowSpanId());
+        workflowSpan = tracer.spanBuilder(workflowSpanName)
+                .setNoParent()
+                .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())
+                .startSpan();
 
-        // Create a SERVER span to establish a separate X-Ray service node.
-        // X-Ray uses service.name for the segment display name.
+        // Invocation span — child of the Workflow span, INTERNAL kind, random span ID (new every invocation).
         var spanBuilder = tracer.spanBuilder("invocation")
-                .setSpanKind(SpanKind.SERVER)
-                .setParent(parentContext)
+                .setSpanKind(SpanKind.INTERNAL)
+                .setParent(Context.root().with(workflowSpan))
                 .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())
                 .setAttribute(DURABLE_FIRST_INVOCATION, info.isFirstInvocation());
 
@@ -194,8 +184,6 @@ public class OtelPlugin implements DurableExecutionPlugin {
 
     @Override
     public void onInvocationEnd(InvocationEndInfo info) {
-        if (invocationSpan == null) return;
-
         // End any operation spans that are still open (operations that didn't complete in this invocation)
         for (var entry : operationSpans.entrySet()) {
             var span = entry.getValue();
@@ -215,27 +203,37 @@ public class OtelPlugin implements DurableExecutionPlugin {
         }
         attemptSpans.clear();
 
-        // End invocation span
-        invocationSpan.setAttribute(
-                DURABLE_INVOCATION_STATUS, info.invocationStatus().name());
-
-        // Status mapping (parity with Python/JS references):
-        //   SUCCEEDED, PENDING  -> OK
-        //   RETRYING, FAILED    -> ERROR (records the execution error when present)
-        switch (info.invocationStatus()) {
-            case SUCCEEDED, PENDING -> invocationSpan.setStatus(StatusCode.OK);
-            case RETRYING, FAILED -> {
-                var message =
-                        info.executionError() != null ? info.executionError().getMessage() : null;
-                invocationSpan.setStatus(StatusCode.ERROR, message);
-                if (info.executionError() != null) {
-                    invocationSpan.recordException(info.executionError());
-                }
-            }
+        // End the invocation span every invocation.
+        if (invocationSpan != null) {
+            invocationSpan.setAttribute(
+                    DURABLE_INVOCATION_STATUS, info.invocationStatus().name());
+            applyInvocationStatus(invocationSpan, info);
+            invocationSpan.end();
+            invocationSpan = null;
         }
 
-        invocationSpan.end();
-        invocationSpan = null;
+        // End the Workflow span only on a terminal status, so it is exported exactly once per execution.
+        if (workflowSpan != null) {
+            if (isTerminal(info)) {
+                workflowSpan.setAttribute(
+                        DURABLE_EXECUTION_STATUS, info.invocationStatus().name());
+                switch (info.invocationStatus()) {
+                    case FAILED -> {
+                        var message = info.executionError() != null
+                                ? info.executionError().getMessage()
+                                : null;
+                        workflowSpan.setStatus(StatusCode.ERROR, message);
+                        if (info.executionError() != null) {
+                            workflowSpan.recordException(info.executionError());
+                        }
+                    }
+                    default -> workflowSpan.setStatus(StatusCode.OK); // SUCCEEDED
+                }
+                workflowSpan.end();
+            }
+            // Non-terminal (PENDING/RETRYING): leave the Workflow span un-ended (not exported this invocation).
+            workflowSpan = null;
+        }
 
         // Flush spans before Lambda freezes
         var flushResult = tracerProvider.forceFlush().join(5, java.util.concurrent.TimeUnit.SECONDS);
@@ -252,24 +250,16 @@ public class OtelPlugin implements DurableExecutionPlugin {
 
         var parentContext = resolveParentContext(info.parentId());
 
+        // Always use a deterministic span ID keyed by operation ID (regardless of replay) so a suspended-then-resumed
+        // operation stitches into a single logical span across invocations.
+        idGenerator.setNextSpanOperationId(info.id());
+
         var spanBuilder = tracer.spanBuilder(spanName(info.type(), info.subType(), info.name()))
                 .setParent(parentContext)
                 .setAttribute(DURABLE_EXECUTION_ARN, durableExecutionArn)
                 .setAttribute(DURABLE_OPERATION_ID, info.id())
                 .setAttribute(DURABLE_OPERATION_TYPE, info.type());
-
-        if (info.isReplay()) {
-            // Operation was already started in a prior invocation — use a random span ID
-            // and add a Link to the deterministic span from the original invocation for correlation.
-            var deterministicSpanId = idGenerator.generateSpanIdForOperation(info.id());
-            var traceId = idGenerator.generateTraceId();
-            var linkedSpanContext =
-                    SpanContext.create(traceId, deterministicSpanId, TraceFlags.getSampled(), TraceState.getDefault());
-            spanBuilder.addLink(linkedSpanContext);
-        } else {
-            // First execution — use deterministic span ID so continuations can link back
-            idGenerator.setNextSpanOperationId(info.id());
-        }
+        addInvocationLink(spanBuilder);
 
         if (info.name() != null) {
             spanBuilder.setAttribute(DURABLE_OPERATION_NAME, info.name());
@@ -300,30 +290,30 @@ public class OtelPlugin implements DurableExecutionPlugin {
                 span.setStatus(StatusCode.ERROR, info.error().getMessage());
                 span.recordException(info.error());
             }
-            span.end();
+            endSpan(span, info.endTimestamp());
         } else {
-            // Operation was started in a prior invocation — create a continuation span with Link
-            // to the deterministic span ID from the original invocation.
-            var deterministicSpanId = idGenerator.generateSpanIdForOperation(info.id());
-            var traceId = idGenerator.generateTraceId();
-            var linkedSpanContext =
-                    SpanContext.create(traceId, deterministicSpanId, TraceFlags.getSampled(), TraceState.getDefault());
+            // Operation completed between invocations (started in a prior invocation). Recreate it with the same
+            // deterministic span ID so it stitches to the original, plus a link to the current invocation.
+            operationContexts.remove(info.id());
+            idGenerator.setNextSpanOperationId(info.id());
 
             var parentContext = resolveParentContext(info.parentId());
 
             var spanBuilder = tracer.spanBuilder(spanName(info.type(), info.subType(), info.name()))
                     .setParent(parentContext)
-                    .addLink(linkedSpanContext)
                     .setAttribute(DURABLE_EXECUTION_ARN, durableExecutionArn)
                     .setAttribute(DURABLE_OPERATION_ID, info.id())
                     .setAttribute(DURABLE_OPERATION_TYPE, info.type());
+            addInvocationLink(spanBuilder);
 
             if (info.startTimestamp() != null) {
                 spanBuilder.setStartTimestamp(info.startTimestamp());
             }
-
             if (info.name() != null) {
                 spanBuilder.setAttribute(DURABLE_OPERATION_NAME, info.name());
+            }
+            if (info.subType() != null) {
+                spanBuilder.setAttribute(DURABLE_OPERATION_SUBTYPE, info.subType());
             }
 
             var continuationSpan = spanBuilder.startSpan();
@@ -336,7 +326,7 @@ public class OtelPlugin implements DurableExecutionPlugin {
                 continuationSpan.recordException(info.error());
             }
 
-            continuationSpan.end();
+            endSpan(continuationSpan, info.endTimestamp());
         }
     }
 
@@ -344,11 +334,9 @@ public class OtelPlugin implements DurableExecutionPlugin {
 
     @Override
     public void onUserFunctionStart(UserFunctionStartInfo info) {
-        // Skip attempt spans for CONTEXT operations — they are a scoping construct, not a
-        // retriable unit of work, so attempt number/outcome attributes don't apply.
-        // The operation span itself provides parent context for auto-instrumented calls.
+        // Skip attempt spans for CONTEXT operations — they are a scoping construct, not a retriable unit of work. Still
+        // make the operation span current so auto-instrumented calls become children.
         if ("CONTEXT".equals(info.type())) {
-            // Still set the operation span as current so auto-instrumented calls become children
             var operationSpan = operationSpans.get(info.id());
             if (operationSpan != null) {
                 var scope = operationSpan.makeCurrent();
@@ -363,12 +351,13 @@ public class OtelPlugin implements DurableExecutionPlugin {
 
         var key = attemptKey(info.id(), info.attempt());
 
-        // Use the operation span as parent for the attempt span
+        // Parent the attempt span to its operation span.
         var parentContext = resolveParentContext(info.id());
 
         var spanBuilder = tracer.spanBuilder(attemptSpanName(info.type(), info.subType(), info.name(), info.attempt()))
                 .setParent(parentContext)
                 .setStartTimestamp(info.startTimestamp() != null ? info.startTimestamp() : Instant.now());
+        addInvocationLink(spanBuilder);
 
         spanBuilder.setAttribute(DURABLE_EXECUTION_ARN, durableExecutionArn);
         spanBuilder.setAttribute(DURABLE_OPERATION_ID, info.id());
@@ -390,7 +379,6 @@ public class OtelPlugin implements DurableExecutionPlugin {
         var scope = span.makeCurrent();
         attemptScopes.put(key, scope);
 
-        // Inject trace context into MDC for log-trace correlation
         if (enableMdc) {
             MdcSpanEnricher.inject();
         }
@@ -406,7 +394,6 @@ public class OtelPlugin implements DurableExecutionPlugin {
             scope.close();
         }
 
-        // Clear MDC after user function completes
         if (enableMdc) {
             MdcSpanEnricher.clear();
         }
@@ -427,14 +414,39 @@ public class OtelPlugin implements DurableExecutionPlugin {
             span.recordException(info.error());
         }
 
-        if (info.endTimestamp() != null) {
-            span.end(info.endTimestamp());
-        } else {
-            span.end();
-        }
+        endSpan(span, info.endTimestamp());
     }
 
     // ─── Helpers ─────────────────────────────────────────────────────────
+
+    private void applyInvocationStatus(Span span, InvocationEndInfo info) {
+        switch (info.invocationStatus()) {
+            case SUCCEEDED, PENDING -> span.setStatus(StatusCode.OK);
+            case RETRYING, FAILED -> {
+                var message =
+                        info.executionError() != null ? info.executionError().getMessage() : null;
+                span.setStatus(StatusCode.ERROR, message);
+                if (info.executionError() != null) {
+                    span.recordException(info.executionError());
+                }
+            }
+        }
+    }
+
+    private static boolean isTerminal(InvocationEndInfo info) {
+        return switch (info.invocationStatus()) {
+            case SUCCEEDED, FAILED -> true;
+            case PENDING, RETRYING -> false;
+        };
+    }
+
+    /** Adds a link to the current invocation span, if one exists, for correlation. */
+    private void addInvocationLink(SpanBuilder spanBuilder) {
+        var currentInvocationSpan = invocationSpan;
+        if (currentInvocationSpan != null) {
+            spanBuilder.addLink(currentInvocationSpan.getSpanContext());
+        }
+    }
 
     private Context resolveParentContext(String parentId) {
         if (parentId != null) {
@@ -442,18 +454,26 @@ public class OtelPlugin implements DurableExecutionPlugin {
             if (parentSpanContext != null) {
                 return Context.current().with(Span.wrap(parentSpanContext));
             }
-            // Parent operation from a prior invocation — create non-recording placeholder
+            // Parent operation from a prior invocation — create a non-recording placeholder with its deterministic ID.
             var deterministicParentSpanId = idGenerator.generateSpanIdForOperation(parentId);
             var traceId = idGenerator.generateTraceId();
             var placeholderContext = SpanContext.create(
                     traceId, deterministicParentSpanId, TraceFlags.getSampled(), TraceState.getDefault());
             return Context.current().with(Span.wrap(placeholderContext));
         }
-        // Fall back to invocation span as parent
-        if (invocationSpan != null) {
-            return Context.current().with(invocationSpan);
+        // No parent operation — hang off the Workflow root span.
+        if (workflowSpan != null) {
+            return Context.current().with(workflowSpan);
         }
         return Context.current();
+    }
+
+    private static void endSpan(Span span, Instant endTimestamp) {
+        if (endTimestamp != null) {
+            span.end(endTimestamp);
+        } else {
+            span.end();
+        }
     }
 
     private static String spanName(String type, String subType, String name) {

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -61,11 +61,13 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * <p>Status mapping (parity with the Python/JS references):
  *
  * <ul>
- *   <li>Invocation span: {@code SUCCEEDED}/{@code PENDING} → {@link StatusCode#OK}; {@code RETRYING}/{@code FAILED} →
- *       {@link StatusCode#ERROR}.
+ *   <li>Invocation span: {@code SUCCEEDED}/{@code PENDING} → {@link StatusCode#OK}; {@code FAILED} →
+ *       {@link StatusCode#ERROR}; {@code RETRYING} → {@link StatusCode#UNSET}. {@code RETRYING} is left {@code UNSET}
+ *       because the plugin interface does not expose whether the invocation/workflow was STOPPED or TIMED_OUT versus
+ *       retried for a transient error, so an ERROR status cannot be asserted reliably.
  *   <li>Workflow span (terminal only): {@code SUCCEEDED} → {@link StatusCode#OK}; {@code FAILED} →
- *       {@link StatusCode#ERROR}. Non-terminal statuses never end the Workflow span, so it is not exported this
- *       invocation.
+ *       {@link StatusCode#ERROR}. Non-terminal statuses ({@code PENDING}/{@code RETRYING}) never end the Workflow span,
+ *       so it is not exported this invocation (effectively {@link StatusCode#UNSET}).
  * </ul>
  *
  * <p>Thread-safe: uses {@link ConcurrentHashMap} for span/scope storage since the SDK runs user code on multiple
@@ -418,15 +420,25 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
     // ─── Helpers ─────────────────────────────────────────────────────────
 
     private void applyInvocationStatus(Span span, InvocationEndInfo info) {
+        // Invocation span status mapping:
+        //   SUCCEEDED, PENDING -> OK
+        //   FAILED             -> ERROR (records the execution error when present)
+        //   RETRYING           -> UNSET (left unset)
+        // RETRYING is left UNSET on purpose: the plugin interface does not expose whether the invocation/workflow
+        // was STOPPED or TIMED_OUT versus retried for a transient error, so an ERROR status cannot be asserted
+        // reliably for a retrying invocation.
         switch (info.invocationStatus()) {
             case SUCCEEDED, PENDING -> span.setStatus(StatusCode.OK);
-            case RETRYING, FAILED -> {
+            case FAILED -> {
                 var message =
                         info.executionError() != null ? info.executionError().getMessage() : null;
                 span.setStatus(StatusCode.ERROR, message);
                 if (info.executionError() != null) {
                     span.recordException(info.executionError());
                 }
+            }
+            case RETRYING -> {
+                // UNSET — see note above.
             }
         }
     }

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -219,18 +219,25 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         invocationSpan.setAttribute(
                 DURABLE_INVOCATION_STATUS, info.invocationStatus().name());
 
-        // Status mapping (parity with Python/JS references):
-        //   SUCCEEDED, PENDING  -> OK
-        //   RETRYING, FAILED    -> ERROR (records the execution error when present)
+        // Invocation span status mapping:
+        //   SUCCEEDED, PENDING -> OK
+        //   FAILED             -> ERROR (records the execution error when present)
+        //   RETRYING           -> UNSET
+        // RETRYING is left UNSET on purpose: the plugin interface does not expose whether the invocation/workflow
+        // was STOPPED or TIMED_OUT versus retried for a transient error, so an ERROR status cannot be asserted
+        // reliably for a retrying invocation.
         switch (info.invocationStatus()) {
             case SUCCEEDED, PENDING -> invocationSpan.setStatus(StatusCode.OK);
-            case RETRYING, FAILED -> {
+            case FAILED -> {
                 var message =
                         info.executionError() != null ? info.executionError().getMessage() : null;
                 invocationSpan.setStatus(StatusCode.ERROR, message);
                 if (info.executionError() != null) {
                     invocationSpan.recordException(info.executionError());
                 }
+            }
+            case RETRYING -> {
+                // UNSET — see note above.
             }
         }
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -67,9 +67,9 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
 @Deprecated
-public class OtelPlugin implements DurableExecutionPlugin {
+public class InvocationOtelPlugin implements DurableExecutionPlugin {
 
-    private static final Logger logger = LoggerFactory.getLogger(OtelPlugin.class);
+    private static final Logger logger = LoggerFactory.getLogger(InvocationOtelPlugin.class);
     private static final String INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
 
     private final SdkTracerProvider tracerProvider;
@@ -102,13 +102,13 @@ public class OtelPlugin implements DurableExecutionPlugin {
      *
      * <pre>{@code
      * var otlpExporter = OtlpGrpcSpanExporter.getDefault(); // sends to localhost:4317
-     * var plugin = new OtelPlugin(
+     * var plugin = new InvocationOtelPlugin(
      *     SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(otlpExporter)));
      * }</pre>
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      */
-    public OtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder) {
+    public InvocationOtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder) {
         this(tracerProviderBuilder, new XRayContextExtractor(), true);
     }
 
@@ -118,7 +118,7 @@ public class OtelPlugin implements DurableExecutionPlugin {
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
      */
-    public OtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor) {
+    public InvocationOtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor) {
         this(tracerProviderBuilder, contextExtractor, true);
     }
 
@@ -129,7 +129,7 @@ public class OtelPlugin implements DurableExecutionPlugin {
      * @param contextExtractor extracts parent trace context from the Lambda environment
      * @param enableMdc if true, injects traceId/spanId/traceSampled into SLF4J MDC for log correlation
      */
-    public OtelPlugin(
+    public InvocationOtelPlugin(
             SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor, boolean enableMdc) {
         this.idGenerator = new DeterministicIdGenerator();
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
@@ -20,8 +20,8 @@ import org.slf4j.MDC;
  * </ul>
  *
  * <p>Usage: Call {@link #inject()} in {@code onUserFunctionStart} (after span is active) and {@link #clear()} in
- * {@code onUserFunctionEnd}. Or use the convenience plugin {@link OtelPlugin} which handles this automatically when MDC
- * enrichment is enabled.
+ * {@code onUserFunctionEnd}. Or use the convenience plugin {@link InvocationOtelPlugin} which handles this
+ * automatically when MDC enrichment is enabled.
  *
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/SpanAttributes.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/SpanAttributes.java
@@ -15,6 +15,7 @@ final class SpanAttributes {
     private SpanAttributes() {}
 
     static final AttributeKey<String> DURABLE_EXECUTION_ARN = AttributeKey.stringKey("durable.execution.arn");
+    static final AttributeKey<String> DURABLE_EXECUTION_STATUS = AttributeKey.stringKey("durable.execution.status");
     static final AttributeKey<String> DURABLE_OPERATION_ID = AttributeKey.stringKey("durable.operation.id");
     static final AttributeKey<String> DURABLE_OPERATION_TYPE = AttributeKey.stringKey("durable.operation.type");
     static final AttributeKey<String> DURABLE_OPERATION_NAME = AttributeKey.stringKey("durable.operation.name");

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -125,7 +125,7 @@ class ExecutionOtelPluginTest {
     }
 
     @Test
-    void retryingInvocation_invocationSpanError_workflowNotExported() {
+    void retryingInvocation_invocationSpanUnset_workflowNotExported() {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
         plugin.onInvocationEnd(new InvocationEndInfo(
                 "req-1", ARN, true, InvocationStatus.RETRYING, new RuntimeException("transient")));
@@ -134,7 +134,10 @@ class ExecutionOtelPluginTest {
         assertEquals(1, spans.size(), "RETRYING is non-terminal — Workflow span not exported");
         var invocationSpan = spans.get(0);
         assertEquals("invocation", invocationSpan.getName());
-        assertEquals(StatusCode.ERROR, invocationSpan.getStatus().getStatusCode());
+        assertEquals(
+                StatusCode.UNSET,
+                invocationSpan.getStatus().getStatusCode(),
+                "RETRYING invocation span is UNSET (interface cannot distinguish STOPPED/TIMED_OUT)");
     }
 
     // ─── Operation topology: parented to Workflow, linked to invocation ──

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -262,20 +262,48 @@ class ExecutionOtelPluginTest {
     }
 
     @Test
-    void operationNotCompleted_endedPendingAtInvocationEnd() {
+    void operationNotCompleted_notEndedAtInvocationEnd() {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
         plugin.onOperationStart(new OperationInfo("op-1", "my-wait", "WAIT", "Wait", null, Instant.now(), null, false));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        // invocation span + PENDING operation span (Workflow not exported — non-terminal)
-        assertEquals(2, spans.size());
-        var operationSpan = spanByName(spans, "my-wait");
-        assertEquals(
-                "PENDING",
-                operationSpan
-                        .getAttributes()
-                        .get(io.opentelemetry.api.common.AttributeKey.stringKey("durable.operation.status")));
+        // Only the invocation span is exported. The still-open operation span is NOT force-ended (no PENDING
+        // span here), and the Workflow span is not exported on a non-terminal invocation.
+        assertEquals(1, spans.size());
+        assertEquals("invocation", spans.get(0).getName());
+        assertTrue(
+                spans.stream().noneMatch(s -> s.getName().equals("my-wait")),
+                "An operation still open at invocation end must not be ended/exported in onInvocationEnd");
+    }
+
+    @Test
+    void operationOpenedThenCompletedNextInvocation_exportedOnceOnOperationEnd() {
+        // Invocation 1: operation opens but does not complete.
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onOperationStart(new OperationInfo("op-1", "my-wait", "WAIT", "Wait", null, Instant.now(), null, false));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
+        assertTrue(
+                spanExporter.getFinishedSpanItems().stream()
+                        .noneMatch(s -> s.getName().equals("my-wait")),
+                "Operation span must not be exported by the suspending invocation");
+        spanExporter.reset();
+
+        // Invocation 2: the operation completes → materialized once via onOperationEnd, linked to this invocation.
+        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "my-wait", "WAIT", "Wait", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        var waitSpans =
+                spans.stream().filter(s -> s.getName().equals("my-wait")).toList();
+        assertEquals(1, waitSpans.size(), "The operation must be exported exactly once, when it completes");
+        var invocationSpan = spanByName(spans, "invocation");
+        assertTrue(
+                waitSpans.get(0).getLinks().stream()
+                        .anyMatch(l -> l.getSpanContext().getSpanId().equals(invocationSpan.getSpanId())),
+                "Completed operation span should link to the invocation that completed it");
     }
 
     // ─── Cross-invocation stitching ──────────────────────────────────────

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -156,6 +156,23 @@ class ExecutionOtelPluginTest {
     // ─── Operation topology: parented to Workflow, linked to invocation ──
 
     @Test
+    void operationSpan_startsAtOperationStartTimestamp() {
+        var opStart = Instant.parse("2026-02-01T10:00:00Z");
+        var opEnd = Instant.parse("2026-02-01T10:00:03Z");
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
+        plugin.onOperationStart(new OperationInfo("op-1", "step-a", "STEP", "Step", null, opStart, null, false));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "step-a", "STEP", "Step", null, opStart, opEnd, "SUCCEEDED", null, false, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var operationSpan = spanByName(spanExporter.getFinishedSpanItems(), "step-a");
+        assertEquals(
+                opStart.toEpochMilli(),
+                operationSpan.getStartEpochNanos() / 1_000_000,
+                "Operation span should start at OperationInfo.startTimestamp()");
+    }
+
+    @Test
     void operationSpan_parentedToWorkflow_linkedToInvocation() {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onOperationStart(new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -49,6 +49,17 @@ class ExecutionOtelPluginTest {
     }
 
     @Test
+    void workflowSpan_hasInternalKind() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        assertEquals(
+                SpanKind.INTERNAL,
+                spanByName(spanExporter.getFinishedSpanItems(), "Workflow").getKind(),
+                "Workflow span must be INTERNAL kind");
+    }
+
+    @Test
     void workflowSpan_isRoot_invocationSpanIsChild() {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -49,6 +49,20 @@ class ExecutionOtelPluginTest {
     }
 
     @Test
+    void spans_carryWorkflowServiceName() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "Workflow");
+        assertEquals(
+                "workflow",
+                workflowSpan
+                        .getResource()
+                        .getAttribute(io.opentelemetry.api.common.AttributeKey.stringKey("service.name")),
+                "Spans should carry service.name=workflow");
+    }
+
+    @Test
     void workflowSpan_startsAtExecutionStartTime() {
         var start = Instant.parse("2026-01-15T08:00:00Z");
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, start));
@@ -154,6 +168,40 @@ class ExecutionOtelPluginTest {
     }
 
     // ─── Operation topology: parented to Workflow, linked to invocation ──
+
+    @Test
+    void operationSpan_carriesAttemptNumberAtEnd() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
+        plugin.onOperationStart(new OperationInfo("op-1", "flaky", "STEP", "Step", null, Instant.now(), null, false));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "flaky", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", 3, false, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var operationSpan = spanByName(spanExporter.getFinishedSpanItems(), "flaky");
+        assertEquals(
+                3L,
+                operationSpan
+                        .getAttributes()
+                        .get(io.opentelemetry.api.common.AttributeKey.longKey("durable.attempt.number")),
+                "Operation span should carry total attempt count at end");
+    }
+
+    @Test
+    void continuationOperationSpan_carriesAttemptNumber() {
+        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false, Instant.now()));
+        // No matching onOperationStart in this invocation — continuation branch.
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "flaky", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", 2, false, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
+
+        var operationSpan = spanByName(spanExporter.getFinishedSpanItems(), "flaky");
+        assertEquals(
+                2L,
+                operationSpan
+                        .getAttributes()
+                        .get(io.opentelemetry.api.common.AttributeKey.longKey("durable.attempt.number")),
+                "Continuation operation span should also carry the total attempt count");
+    }
 
     @Test
     void operationSpan_startsAtOperationStartTimestamp() {

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -49,6 +49,19 @@ class ExecutionOtelPluginTest {
     }
 
     @Test
+    void workflowSpan_startsAtExecutionStartTime() {
+        var start = Instant.parse("2026-01-15T08:00:00Z");
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, start));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "Workflow");
+        assertEquals(
+                start.toEpochMilli(),
+                workflowSpan.getStartEpochNanos() / 1_000_000,
+                "Workflow span should start at the execution start time from InvocationInfo");
+    }
+
+    @Test
     void workflowSpan_hasInternalKind() {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -1,0 +1,389 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.otel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.plugin.*;
+
+class ExecutionOtelPluginTest {
+
+    private static final String ARN = "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1";
+
+    private InMemorySpanExporter spanExporter;
+    private ExecutionOtelPlugin plugin;
+
+    @BeforeEach
+    void setUp() {
+        spanExporter = InMemorySpanExporter.create();
+        plugin = new ExecutionOtelPlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
+                () -> null,
+                false,
+                "Workflow");
+    }
+
+    // ─── Workflow root span lifecycle ────────────────────────────────────
+
+    @Test
+    void terminalInvocation_exportsWorkflowAndInvocationSpans() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        assertEquals(2, spans.size(), "Terminal invocation should export the Workflow span and the invocation span");
+
+        var workflowSpan = spanByName(spans, "Workflow");
+        var invocationSpan = spanByName(spans, "invocation");
+
+        assertEquals(StatusCode.OK, workflowSpan.getStatus().getStatusCode());
+        assertEquals(StatusCode.OK, invocationSpan.getStatus().getStatusCode());
+    }
+
+    @Test
+    void workflowSpan_isRoot_invocationSpanIsChild() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        var workflowSpan = spanByName(spans, "Workflow");
+        var invocationSpan = spanByName(spans, "invocation");
+
+        assertFalse(
+                invocationSpan.getParentSpanContext().getSpanId().equals("0000000000000000"),
+                "Invocation span must have a parent");
+        assertEquals(
+                workflowSpan.getSpanId(),
+                invocationSpan.getParentSpanId(),
+                "Invocation span must be a child of the Workflow root span");
+        assertEquals(SpanKind.INTERNAL, invocationSpan.getKind());
+    }
+
+    @Test
+    void nonTerminalInvocation_doesNotExportWorkflowSpan() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        // Only the invocation span is exported; the Workflow span is not ended on non-terminal status.
+        assertEquals(1, spans.size());
+        assertEquals("invocation", spans.get(0).getName());
+        assertEquals(StatusCode.OK, spans.get(0).getStatus().getStatusCode(), "PENDING invocation span maps to OK");
+    }
+
+    @Test
+    void workflowSpan_exportedOnceAcrossInvocations_sameSpanId() {
+        // Invocation 1: non-terminal → no Workflow span exported
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
+        assertTrue(
+                spanExporter.getFinishedSpanItems().stream()
+                        .noneMatch(s -> s.getName().equals("Workflow")),
+                "Workflow span must not be exported on a non-terminal invocation");
+        spanExporter.reset();
+
+        // Invocation 2: terminal → Workflow span exported with the deterministic ID
+        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
+
+        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "Workflow");
+        assertEquals(StatusCode.OK, workflowSpan.getStatus().getStatusCode());
+        assertTrue(workflowSpan.getSpanId().matches("[0-9a-f]{16}"));
+    }
+
+    // ─── Status mapping ──────────────────────────────────────────────────
+
+    @Test
+    void failedInvocation_setsErrorOnBothWorkflowAndInvocationSpans() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationEnd(
+                new InvocationEndInfo("req-1", ARN, true, InvocationStatus.FAILED, new RuntimeException("boom")));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        assertEquals(StatusCode.ERROR, spanByName(spans, "Workflow").getStatus().getStatusCode());
+        assertEquals(
+                StatusCode.ERROR, spanByName(spans, "invocation").getStatus().getStatusCode());
+    }
+
+    @Test
+    void retryingInvocation_invocationSpanError_workflowNotExported() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationEnd(new InvocationEndInfo(
+                "req-1", ARN, true, InvocationStatus.RETRYING, new RuntimeException("transient")));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        assertEquals(1, spans.size(), "RETRYING is non-terminal — Workflow span not exported");
+        var invocationSpan = spans.get(0);
+        assertEquals("invocation", invocationSpan.getName());
+        assertEquals(StatusCode.ERROR, invocationSpan.getStatus().getStatusCode());
+    }
+
+    // ─── Operation topology: parented to Workflow, linked to invocation ──
+
+    @Test
+    void operationSpan_parentedToWorkflow_linkedToInvocation() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onOperationStart(new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        var workflowSpan = spanByName(spans, "Workflow");
+        var invocationSpan = spanByName(spans, "invocation");
+        var operationSpan = spanByName(spans, "step-a");
+
+        assertEquals(
+                workflowSpan.getSpanId(),
+                operationSpan.getParentSpanId(),
+                "Operation span must be parented to the Workflow span, not the invocation span");
+        assertTrue(
+                operationSpan.getLinks().stream()
+                        .anyMatch(l -> l.getSpanContext().getSpanId().equals(invocationSpan.getSpanId())),
+                "Operation span must carry a link to the invocation span");
+    }
+
+    @Test
+    void attemptSpan_childOfOperation_linkedToInvocation() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onOperationStart(new OperationInfo("op-1", "compute", "STEP", "Step", null, Instant.now(), null, false));
+        plugin.onUserFunctionStart(
+                new UserFunctionStartInfo("op-1", "compute", "STEP", "Step", null, Instant.now(), false, 1));
+        plugin.onUserFunctionEnd(new UserFunctionEndInfo(
+                "op-1", "compute", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "compute", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        var operationSpan = spanByName(spans, "compute");
+        var invocationSpan = spanByName(spans, "invocation");
+        var attemptSpan = spans.stream()
+                .filter(s -> s.getName().contains("attempt"))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals("compute attempt 1", attemptSpan.getName());
+        assertEquals(
+                operationSpan.getSpanId(),
+                attemptSpan.getParentSpanId(),
+                "Attempt span must be a child of its operation span");
+        assertTrue(
+                attemptSpan.getLinks().stream()
+                        .anyMatch(l -> l.getSpanContext().getSpanId().equals(invocationSpan.getSpanId())),
+                "Attempt span must carry a link to the invocation span");
+    }
+
+    @Test
+    void childOperation_parentedToParentOperationSpan() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onOperationStart(new OperationInfo(
+                "op-parent", "my-context", "CONTEXT", "RunInChildContext", null, Instant.now(), null, false));
+        plugin.onOperationStart(
+                new OperationInfo("op-child", "inner-step", "STEP", "Step", "op-parent", Instant.now(), null, false));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-child",
+                "inner-step",
+                "STEP",
+                "Step",
+                "op-parent",
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                false,
+                null));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-parent",
+                "my-context",
+                "CONTEXT",
+                "RunInChildContext",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                false,
+                null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        var parentSpan = spanByName(spans, "my-context");
+        var childSpan = spanByName(spans, "inner-step");
+        assertEquals(
+                parentSpan.getSpanId(),
+                childSpan.getParentSpanId(),
+                "Child operation should be parented to its parent operation span");
+    }
+
+    // ─── Failure propagation ─────────────────────────────────────────────
+
+    @Test
+    void userFunctionFailure_setsErrorOnAttemptSpan() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onUserFunctionStart(
+                new UserFunctionStartInfo("op-1", "failing", "STEP", "Step", null, Instant.now(), false, 1));
+        plugin.onUserFunctionEnd(new UserFunctionEndInfo(
+                "op-1",
+                "failing",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                false,
+                new RuntimeException("step failed")));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.FAILED, null));
+
+        var attemptSpan = spanExporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().contains("attempt"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(StatusCode.ERROR, attemptSpan.getStatus().getStatusCode());
+    }
+
+    @Test
+    void operationNotCompleted_endedPendingAtInvocationEnd() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onOperationStart(new OperationInfo("op-1", "my-wait", "WAIT", "Wait", null, Instant.now(), null, false));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        // invocation span + PENDING operation span (Workflow not exported — non-terminal)
+        assertEquals(2, spans.size());
+        var operationSpan = spanByName(spans, "my-wait");
+        assertEquals(
+                "PENDING",
+                operationSpan
+                        .getAttributes()
+                        .get(io.opentelemetry.api.common.AttributeKey.stringKey("durable.operation.status")));
+    }
+
+    // ─── Cross-invocation stitching ──────────────────────────────────────
+
+    @Test
+    void allSpansShareTraceId_acrossInvocations() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onOperationStart(new OperationInfo("op-1", "step-1", "STEP", "Step", null, Instant.now(), null, false));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "step-1", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
+        var firstTraceId = spanExporter.getFinishedSpanItems().get(0).getTraceId();
+        spanExporter.reset();
+
+        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
+        var secondSpans = spanExporter.getFinishedSpanItems();
+
+        assertTrue(
+                secondSpans.stream().allMatch(s -> s.getTraceId().equals(firstTraceId)),
+                "All spans of one execution must share the same trace ID");
+    }
+
+    @Test
+    void operationEnd_withoutStart_createsContinuationSpanWithLink() {
+        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false));
+        // Operation completed between invocations — no matching onOperationStart in this invocation.
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-wait-1", "my-wait", "WAIT", "Wait", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        var continuationSpan = spanByName(spans, "my-wait");
+        var invocationSpan = spanByName(spans, "invocation");
+        assertFalse(continuationSpan.getLinks().isEmpty(), "Continuation span should have a link");
+        assertTrue(
+                continuationSpan.getLinks().stream()
+                        .anyMatch(l -> l.getSpanContext().getSpanId().equals(invocationSpan.getSpanId())),
+                "Continuation span should link to the current invocation span");
+    }
+
+    @Test
+    void deterministicWorkflowSpanId_stableAcrossInvocations() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+        var firstWorkflowSpanId =
+                spanByName(spanExporter.getFinishedSpanItems(), "Workflow").getSpanId();
+        spanExporter.reset();
+
+        // A second (independent) plugin for the same execution ARN must derive the same Workflow span ID.
+        var exporter2 = InMemorySpanExporter.create();
+        var plugin2 = new ExecutionOtelPlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter2)),
+                () -> null,
+                false,
+                "Workflow");
+        plugin2.onInvocationStart(new InvocationInfo("req-9", ARN, true));
+        plugin2.onInvocationEnd(new InvocationEndInfo("req-9", ARN, true, InvocationStatus.SUCCEEDED, null));
+        var secondWorkflowSpanId =
+                spanByName(exporter2.getFinishedSpanItems(), "Workflow").getSpanId();
+
+        assertEquals(
+                firstWorkflowSpanId,
+                secondWorkflowSpanId,
+                "Workflow span ID must be deterministic for a given execution ARN");
+    }
+
+    // ─── Sampling ────────────────────────────────────────────────────────
+
+    @Test
+    void sampling_disabled_producesNoSpans() {
+        var exporter = InMemorySpanExporter.create();
+        var sampledPlugin = new ExecutionOtelPlugin(
+                SdkTracerProvider.builder()
+                        .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOff())
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter)),
+                () -> null,
+                false,
+                "Workflow");
+        sampledPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        sampledPlugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+        assertTrue(exporter.getFinishedSpanItems().isEmpty(), "No spans should be exported with 0% sampling");
+    }
+
+    // ─── X-Ray trace ID ──────────────────────────────────────────────────
+
+    @Test
+    void xrayExtraction_allSpansShareExtractedTraceId() {
+        var xrayTraceId = "aabbccddee112233445566778899aabb";
+        var exporter = InMemorySpanExporter.create();
+        var xrayPlugin = new ExecutionOtelPlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
+                () -> new ExtractedContext(xrayTraceId, null),
+                false,
+                "Workflow");
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        xrayPlugin.onOperationStart(
+                new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));
+        xrayPlugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", false, null));
+        xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = exporter.getFinishedSpanItems();
+        assertTrue(spans.size() >= 3, "Workflow + invocation + operation spans expected");
+        assertTrue(
+                spans.stream().allMatch(s -> s.getTraceId().equals(xrayTraceId)),
+                "All spans must share the extracted X-Ray trace ID");
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────
+
+    private static io.opentelemetry.sdk.trace.data.SpanData spanByName(
+            java.util.List<io.opentelemetry.sdk.trace.data.SpanData> spans, String name) {
+        return spans.stream()
+                .filter(s -> s.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No span named '" + name + "' in "
+                        + spans.stream()
+                                .map(io.opentelemetry.sdk.trace.data.SpanData::getName)
+                                .toList()));
+    }
+}

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -35,7 +35,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void terminalInvocation_exportsWorkflowAndInvocationSpans() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -50,7 +50,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void workflowSpan_hasInternalKind() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         assertEquals(
@@ -61,7 +61,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void workflowSpan_isRoot_invocationSpanIsChild() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -80,7 +80,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void nonTerminalInvocation_doesNotExportWorkflowSpan() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -93,7 +93,7 @@ class ExecutionOtelPluginTest {
     @Test
     void workflowSpan_exportedOnceAcrossInvocations_sameSpanId() {
         // Invocation 1: non-terminal → no Workflow span exported
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
         assertTrue(
                 spanExporter.getFinishedSpanItems().stream()
@@ -102,7 +102,7 @@ class ExecutionOtelPluginTest {
         spanExporter.reset();
 
         // Invocation 2: terminal → Workflow span exported with the deterministic ID
-        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false));
+        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
 
         var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "Workflow");
@@ -114,7 +114,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void failedInvocation_setsErrorOnBothWorkflowAndInvocationSpans() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(
                 new InvocationEndInfo("req-1", ARN, true, InvocationStatus.FAILED, new RuntimeException("boom")));
 
@@ -126,7 +126,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void retryingInvocation_invocationSpanUnset_workflowNotExported() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo(
                 "req-1", ARN, true, InvocationStatus.RETRYING, new RuntimeException("transient")));
 
@@ -144,7 +144,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void operationSpan_parentedToWorkflow_linkedToInvocation() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onOperationStart(new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
@@ -167,7 +167,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void attemptSpan_childOfOperation_linkedToInvocation() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onOperationStart(new OperationInfo("op-1", "compute", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "compute", "STEP", "Step", null, Instant.now(), false, 1));
@@ -198,7 +198,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void childOperation_parentedToParentOperationSpan() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onOperationStart(new OperationInfo(
                 "op-parent", "my-context", "CONTEXT", "RunInChildContext", null, Instant.now(), null, false));
         plugin.onOperationStart(
@@ -242,7 +242,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void userFunctionFailure_setsErrorOnAttemptSpan() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "failing", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
@@ -268,7 +268,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void operationNotCompleted_notEndedAtInvocationEnd() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onOperationStart(new OperationInfo("op-1", "my-wait", "WAIT", "Wait", null, Instant.now(), null, false));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
 
@@ -285,7 +285,7 @@ class ExecutionOtelPluginTest {
     @Test
     void operationOpenedThenCompletedNextInvocation_exportedOnceOnOperationEnd() {
         // Invocation 1: operation opens but does not complete.
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onOperationStart(new OperationInfo("op-1", "my-wait", "WAIT", "Wait", null, Instant.now(), null, false));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
         assertTrue(
@@ -295,7 +295,7 @@ class ExecutionOtelPluginTest {
         spanExporter.reset();
 
         // Invocation 2: the operation completes → materialized once via onOperationEnd, linked to this invocation.
-        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false));
+        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false, Instant.now()));
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-1", "my-wait", "WAIT", "Wait", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
@@ -315,7 +315,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void allSpansShareTraceId_acrossInvocations() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onOperationStart(new OperationInfo("op-1", "step-1", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-1", "step-1", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
@@ -323,7 +323,7 @@ class ExecutionOtelPluginTest {
         var firstTraceId = spanExporter.getFinishedSpanItems().get(0).getTraceId();
         spanExporter.reset();
 
-        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false));
+        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
         var secondSpans = spanExporter.getFinishedSpanItems();
 
@@ -334,7 +334,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void operationEnd_withoutStart_createsContinuationSpanWithLink() {
-        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false));
+        plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false, Instant.now()));
         // Operation completed between invocations — no matching onOperationStart in this invocation.
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-wait-1",
@@ -362,7 +362,7 @@ class ExecutionOtelPluginTest {
 
     @Test
     void deterministicWorkflowSpanId_stableAcrossInvocations() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
         var firstWorkflowSpanId =
                 spanByName(spanExporter.getFinishedSpanItems(), "Workflow").getSpanId();
@@ -375,7 +375,7 @@ class ExecutionOtelPluginTest {
                 () -> null,
                 false,
                 "Workflow");
-        plugin2.onInvocationStart(new InvocationInfo("req-9", ARN, true));
+        plugin2.onInvocationStart(new InvocationInfo("req-9", ARN, true, Instant.now()));
         plugin2.onInvocationEnd(new InvocationEndInfo("req-9", ARN, true, InvocationStatus.SUCCEEDED, null));
         var secondWorkflowSpanId =
                 spanByName(exporter2.getFinishedSpanItems(), "Workflow").getSpanId();
@@ -398,7 +398,7 @@ class ExecutionOtelPluginTest {
                 () -> null,
                 false,
                 "Workflow");
-        sampledPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        sampledPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         sampledPlugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
         assertTrue(exporter.getFinishedSpanItems().isEmpty(), "No spans should be exported with 0% sampling");
     }
@@ -414,7 +414,7 @@ class ExecutionOtelPluginTest {
                 () -> new ExtractedContext(xrayTraceId, null),
                 false,
                 "Workflow");
-        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true));
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));
         xrayPlugin.onOperationEnd(new OperationEndInfo(

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginIntegrationTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginIntegrationTest.java
@@ -27,7 +27,7 @@ import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
  * Integration tests verifying the OTel plugin produces correct spans when running with the real SDK execution engine
  * (LocalDurableTestRunner).
  */
-class OtelPluginIntegrationTest {
+class InvocationOtelPluginIntegrationTest {
 
     private InMemorySpanExporter spanExporter;
     private DurableConfig otelConfig;
@@ -36,7 +36,7 @@ class OtelPluginIntegrationTest {
     void setUp() {
         spanExporter = InMemorySpanExporter.create();
 
-        var plugin = new OtelPlugin(
+        var plugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> null,
                 false);
@@ -307,7 +307,7 @@ class OtelPluginIntegrationTest {
     void sampling_off_producesNoSpans() {
         var sampledExporter = InMemorySpanExporter.create();
 
-        var noSamplePlugin = new OtelPlugin(
+        var noSamplePlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder()
                         .setSampler(Sampler.alwaysOff())
                         .addSpanProcessor(SimpleSpanProcessor.create(sampledExporter)),

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -120,6 +120,20 @@ class InvocationOtelPluginTest {
     }
 
     @Test
+    void invocationEnd_withRetrying_leavesStatusUnset() {
+        plugin.onInvocationStart(new InvocationInfo("req-123", "arn:exec1", true));
+        plugin.onInvocationEnd(new InvocationEndInfo(
+                "req-123", "arn:exec1", true, InvocationStatus.RETRYING, new RuntimeException("transient")));
+
+        var spans = spanExporter.getFinishedSpanItems();
+        assertEquals(1, spans.size());
+        assertEquals(
+                StatusCode.UNSET,
+                spans.get(0).getStatus().getStatusCode(),
+                "RETRYING invocation span is UNSET (interface cannot distinguish STOPPED/TIMED_OUT)");
+    }
+
+    @Test
     void operationStart_createsSpan_operationEnd_endsIt() {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
 

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -34,7 +34,7 @@ class InvocationOtelPluginTest {
     @Test
     void invocationStart_and_end_createsSpan() {
         plugin.onInvocationStart(new InvocationInfo(
-                "req-123", "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1", true));
+                "req-123", "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1", true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo(
                 "req-123",
                 "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1",
@@ -52,7 +52,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void invocationSpan_hasInternalKind() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var span = spanExporter.getFinishedSpanItems().get(0);
@@ -61,7 +61,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void operationSpanName_usesOperationName_withoutPrefix() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         plugin.onOperationStart(
                 new OperationInfo("op-1", "create-greeting", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onOperationEnd(new OperationEndInfo(
@@ -90,7 +90,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void attemptSpanName_usesOperationNameWithAttemptNumber() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "process-order", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
@@ -109,7 +109,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void operationEnd_withAttempt_stampsAttemptNumberOnOperationSpan() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         plugin.onOperationStart(new OperationInfo("op-1", "flaky", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onOperationEnd(new OperationEndInfo(
@@ -128,7 +128,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void attemptSpan_carriesOperationSubtype() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "process-order", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
@@ -147,7 +147,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void operationEnd_withoutMatchingStart_stampsAttemptNumberOnContinuationSpan() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         // No onOperationStart in this invocation → onOperationEnd takes the continuation-span branch.
         plugin.onOperationEnd(new OperationEndInfo(
@@ -170,7 +170,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void invocationEnd_withFailure_setsErrorStatus() {
-        plugin.onInvocationStart(new InvocationInfo("req-123", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-123", "arn:exec1", true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo(
                 "req-123", "arn:exec1", true, InvocationStatus.FAILED, new RuntimeException("boom")));
 
@@ -181,7 +181,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void invocationEnd_withRetrying_leavesStatusUnset() {
-        plugin.onInvocationStart(new InvocationInfo("req-123", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-123", "arn:exec1", true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo(
                 "req-123", "arn:exec1", true, InvocationStatus.RETRYING, new RuntimeException("transient")));
 
@@ -195,7 +195,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void operationStart_createsSpan_operationEnd_endsIt() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         var start = Instant.parse("2026-06-01T10:00:00Z");
         var end = Instant.parse("2026-06-01T10:00:05Z");
@@ -221,7 +221,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void userFunctionStart_and_end_createsAttemptSpan() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "compute", "STEP", "Step", null, Instant.now(), false, 1));
@@ -244,7 +244,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void userFunctionEnd_withFailure_setsErrorOnAttemptSpan() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "failing", "STEP", "Step", null, Instant.now(), false, 1));
@@ -274,7 +274,7 @@ class InvocationOtelPluginTest {
     @Test
     void fullLifecycle_producesCorrectSpanHierarchy() {
         var arn = "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1";
-        plugin.onInvocationStart(new InvocationInfo("req-1", arn, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", arn, true, Instant.now()));
 
         // Step 1: operation starts, user function runs, operation completes
         plugin.onOperationStart(new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));
@@ -309,14 +309,14 @@ class InvocationOtelPluginTest {
     void deterministicIds_sameExecutionProducesSameTraceId() {
         var arn = "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1";
 
-        plugin.onInvocationStart(new InvocationInfo("req-1", arn, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", arn, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.PENDING, null));
 
         var firstTraceId = spanExporter.getFinishedSpanItems().get(0).getTraceId();
         spanExporter.reset();
 
         // Second invocation of same execution
-        plugin.onInvocationStart(new InvocationInfo("req-2", arn, false));
+        plugin.onInvocationStart(new InvocationInfo("req-2", arn, false, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", arn, false, InvocationStatus.SUCCEEDED, null));
 
         var secondTraceId = spanExporter.getFinishedSpanItems().get(0).getTraceId();
@@ -326,7 +326,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void operationNotCompleted_spanEndedAtInvocationEnd() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         // Operation starts but never completes (e.g., wait operation, invocation suspends)
         plugin.onOperationStart(new OperationInfo("op-1", "my-wait", "WAIT", "Wait", null, Instant.now(), null, false));
@@ -355,7 +355,7 @@ class InvocationOtelPluginTest {
                 () -> null,
                 false);
 
-        sampledPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        sampledPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         sampledPlugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "step", "STEP", "Step", null, Instant.now(), false, 1));
         sampledPlugin.onUserFunctionEnd(new UserFunctionEndInfo(
@@ -381,7 +381,7 @@ class InvocationOtelPluginTest {
                 () -> extractedContext,
                 false);
 
-        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -400,7 +400,7 @@ class InvocationOtelPluginTest {
                 () -> extractedContext,
                 false);
 
-        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));
         xrayPlugin.onUserFunctionStart(
@@ -430,7 +430,7 @@ class InvocationOtelPluginTest {
                 () -> extractedContext,
                 false);
 
-        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -455,7 +455,7 @@ class InvocationOtelPluginTest {
                 () -> extractedContext,
                 false);
 
-        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -486,7 +486,7 @@ class InvocationOtelPluginTest {
                 false);
 
         // First invocation
-        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-1", "step-1", "STEP", "Step", null, Instant.now(), null, false));
         xrayPlugin.onOperationEnd(new OperationEndInfo(
@@ -494,7 +494,7 @@ class InvocationOtelPluginTest {
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.PENDING, null));
 
         // Second invocation (same execution, same X-Ray Root from backend)
-        xrayPlugin.onInvocationStart(new InvocationInfo("req-2", "arn:exec1", false));
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-2", "arn:exec1", false, Instant.now()));
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-2", "step-2", "STEP", "Step", null, Instant.now(), null, false));
         xrayPlugin.onOperationEnd(new OperationEndInfo(
@@ -520,7 +520,7 @@ class InvocationOtelPluginTest {
                 false);
 
         var arn = "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1";
-        noXrayPlugin.onInvocationStart(new InvocationInfo("req-1", arn, true));
+        noXrayPlugin.onInvocationStart(new InvocationInfo("req-1", arn, true, Instant.now()));
         noXrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -550,7 +550,7 @@ class InvocationOtelPluginTest {
                 () -> extractedContext,
                 false);
 
-        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -561,7 +561,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void operationEnd_withoutMatchingStart_createsContinuationSpanWithLink() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         // onOperationEnd without a prior onOperationStart — operation completed between invocations
         plugin.onOperationEnd(new OperationEndInfo(
@@ -592,7 +592,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void operationEnd_withoutMatchingStart_usesOperationStartTimestamp() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         var operationStart = Instant.parse("2026-01-15T08:30:00Z");
         var operationEnd = Instant.parse("2026-01-15T09:00:00Z");
@@ -626,7 +626,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void operationEnd_withoutMatchingStart_withError_setsErrorStatus() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-cb-1",
@@ -655,7 +655,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void contextOperation_doesNotCreateAttemptSpan() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         // Create operation span first so the CONTEXT user function has a parent
         plugin.onOperationStart(new OperationInfo(
@@ -690,7 +690,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void attemptSpan_endedAtInvocationEnd_whenUserFunctionEndNotCalled() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         // Start attempt but never call onUserFunctionEnd (simulates crash before end hook)
         plugin.onUserFunctionStart(
@@ -711,7 +711,7 @@ class InvocationOtelPluginTest {
 
     @Test
     void childOperation_parentedToParentOperationSpan() {
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         // Parent context operation
         plugin.onOperationStart(new OperationInfo(
@@ -772,7 +772,7 @@ class InvocationOtelPluginTest {
         var arn = "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1";
 
         // Invocation 1: step completes, wait starts
-        plugin.onInvocationStart(new InvocationInfo("req-1", arn, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", arn, true, Instant.now()));
         plugin.onOperationStart(new OperationInfo("op-1", "step-A", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "step-A", "STEP", "Step", null, Instant.now(), false, 1));
@@ -790,7 +790,7 @@ class InvocationOtelPluginTest {
         spanExporter.reset();
 
         // Invocation 2: wait completed between invocations, new step runs
-        plugin.onInvocationStart(new InvocationInfo("req-2", arn, false));
+        plugin.onInvocationStart(new InvocationInfo("req-2", arn, false, Instant.now()));
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-2", "pause", "WAIT", "Wait", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
         plugin.onOperationStart(new OperationInfo("op-3", "step-B", "STEP", "Step", null, Instant.now(), null, false));
@@ -825,7 +825,7 @@ class InvocationOtelPluginTest {
         var arn = "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1";
 
         // Invocation 1: step starts, attempt 1 fails, invocation suspended during retry poll
-        plugin.onInvocationStart(new InvocationInfo("req-1", arn, true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", arn, true, Instant.now()));
         plugin.onOperationStart(
                 new OperationInfo("op-1", "process-payment", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onUserFunctionStart(
@@ -867,7 +867,7 @@ class InvocationOtelPluginTest {
         spanExporter.reset();
 
         // Invocation 2: step is replayed (continuation), attempt 2 executes and succeeds
-        plugin.onInvocationStart(new InvocationInfo("req-2", arn, false));
+        plugin.onInvocationStart(new InvocationInfo("req-2", arn, false, Instant.now()));
         // isReplay=true: this operation already exists in the execution state
         plugin.onOperationStart(
                 new OperationInfo("op-1", "process-payment", "STEP", "Step", null, Instant.now(), null, true));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -15,16 +15,16 @@ import org.junit.jupiter.api.Test;
 import software.amazon.lambda.durable.execution.SuspendExecutionException;
 import software.amazon.lambda.durable.plugin.*;
 
-class OtelPluginTest {
+class InvocationOtelPluginTest {
 
     private InMemorySpanExporter spanExporter;
-    private OtelPlugin plugin;
+    private InvocationOtelPlugin plugin;
 
     @BeforeEach
     void setUp() {
         spanExporter = InMemorySpanExporter.create();
 
-        plugin = new OtelPlugin(
+        plugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> null,
                 false);
@@ -274,7 +274,7 @@ class OtelPluginTest {
     @Test
     void sampling_disabled_producesNoSpans() {
         spanExporter = InMemorySpanExporter.create();
-        var sampledPlugin = new OtelPlugin(
+        var sampledPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder()
                         .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOff())
                         .addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
@@ -302,7 +302,7 @@ class OtelPluginTest {
         var extractedContext = new ExtractedContext(xrayTraceId, null);
 
         spanExporter = InMemorySpanExporter.create();
-        var xrayPlugin = new OtelPlugin(
+        var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> extractedContext,
                 false);
@@ -321,7 +321,7 @@ class OtelPluginTest {
         var extractedContext = new ExtractedContext(xrayTraceId, null);
 
         spanExporter = InMemorySpanExporter.create();
-        var xrayPlugin = new OtelPlugin(
+        var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> extractedContext,
                 false);
@@ -351,7 +351,7 @@ class OtelPluginTest {
         var extractedContext = new ExtractedContext(xrayTraceId, parentSpanId);
 
         spanExporter = InMemorySpanExporter.create();
-        var xrayPlugin = new OtelPlugin(
+        var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> extractedContext,
                 false);
@@ -376,7 +376,7 @@ class OtelPluginTest {
         var extractedContext = new ExtractedContext(xrayTraceId, null);
 
         spanExporter = InMemorySpanExporter.create();
-        var xrayPlugin = new OtelPlugin(
+        var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> extractedContext,
                 false);
@@ -406,7 +406,7 @@ class OtelPluginTest {
         var extractedContext = new ExtractedContext(xrayTraceId, "53995c3f42cd8ad8");
 
         spanExporter = InMemorySpanExporter.create();
-        var xrayPlugin = new OtelPlugin(
+        var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> extractedContext,
                 false);
@@ -440,7 +440,7 @@ class OtelPluginTest {
     @Test
     void xrayExtraction_nullExtractor_fallsBackToArnDerived() {
         spanExporter = InMemorySpanExporter.create();
-        var noXrayPlugin = new OtelPlugin(
+        var noXrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> null,
                 false);
@@ -471,7 +471,7 @@ class OtelPluginTest {
         // Now feed it through the plugin
         var extractedContext = new ExtractedContext(convertedId, null);
         spanExporter = InMemorySpanExporter.create();
-        var xrayPlugin = new OtelPlugin(
+        var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> extractedContext,
                 false);

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
@@ -46,7 +46,7 @@ class MdcSpanEnricherTest {
     void plugin_withMdcEnabled_setsFieldsInMdc() {
         var spanExporter = InMemorySpanExporter.create();
 
-        var plugin = new OtelPlugin(
+        var plugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> null,
                 true);

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
@@ -51,7 +51,7 @@ class MdcSpanEnricherTest {
                 () -> null,
                 true);
 
-        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec-mdc-test", true));
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec-mdc-test", true, Instant.now()));
 
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "step", "STEP", "Step", null, Instant.now(), false, 1));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/OtelPluginTest.java
@@ -46,7 +46,7 @@ class OtelPluginTest {
 
         var span = spans.get(0);
         assertEquals("invocation", span.getName());
-        assertEquals(StatusCode.UNSET, span.getStatus().getStatusCode());
+        assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
     }
 
     @Test

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/DurableExecutor.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/DurableExecutor.java
@@ -66,7 +66,12 @@ public class DurableExecutor {
 
                         // onInvocationStart runs on the user thread so plugins can
                         // inject ThreadLocal objects, update MDC, etc.
-                        pluginRunner.onInvocationStart(new InvocationInfo(requestId, executionArn, isFirstInvocation));
+                        // executionStartTime comes from the initial EXECUTION operation in the first backend event.
+                        pluginRunner.onInvocationStart(new InvocationInfo(
+                                requestId,
+                                executionArn,
+                                isFirstInvocation,
+                                executionManager.getExecutionOperation().startTimestamp()));
 
                         var userInput = extractUserInput(
                                 executionManager.getExecutionOperation(), config.getSerDes(), inputType);

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
@@ -2,13 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.plugin;
 
+import java.time.Instant;
+
 /**
  * Invocation-level information available to plugin hooks.
  *
  * @param requestId the Lambda request ID for this invocation
  * @param durableExecutionArn the durable execution ARN
  * @param isFirstInvocation true if this is the first invocation of the execution (not a replay invocation)
+ * @param executionStartTime the start timestamp of the durable execution, taken from the initial EXECUTION operation in
+ *     the first event delivered by the backend. Stable across all invocations of the same execution.
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
 @Deprecated
-public record InvocationInfo(String requestId, String durableExecutionArn, boolean isFirstInvocation) {}
+public record InvocationInfo(
+        String requestId, String durableExecutionArn, boolean isFirstInvocation, Instant executionStartTime) {}

--- a/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DurableConfigTest.java
@@ -546,7 +546,8 @@ class DurableConfigTest {
                 .build();
 
         config.getPluginRunner()
-                .onInvocationStart(new software.amazon.lambda.durable.plugin.InvocationInfo("req-1", "arn:test", true));
+                .onInvocationStart(new software.amazon.lambda.durable.plugin.InvocationInfo(
+                        "req-1", "arn:test", true, java.time.Instant.now()));
 
         assertEquals(List.of("p1:onInvocationStart", "p2:onInvocationStart"), calls);
     }
@@ -565,7 +566,8 @@ class DurableConfigTest {
                 .build();
 
         config.getPluginRunner()
-                .onInvocationStart(new software.amazon.lambda.durable.plugin.InvocationInfo("req-1", "arn:test", true));
+                .onInvocationStart(new software.amazon.lambda.durable.plugin.InvocationInfo(
+                        "req-1", "arn:test", true, java.time.Instant.now()));
 
         assertEquals(List.of("p2:onInvocationStart", "p3:onInvocationStart"), calls);
     }

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
@@ -136,7 +136,8 @@ class PluginRunnerTest {
     // ─── Helper methods ──────────────────────────────────────────────────
 
     private static InvocationInfo invocationInfo() {
-        return new InvocationInfo("req-123", "arn:aws:lambda:us-east-1:123456789012:function:test", false);
+        return new InvocationInfo(
+                "req-123", "arn:aws:lambda:us-east-1:123456789012:function:test", false, Instant.now());
     }
 
     private static InvocationEndInfo invocationEndInfo() {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

Port the Workflow-rooted ExecutionOtelPlugin from the Python/JS SDKs into the otel-plugin module, alongside the existing invocation-rooted OtelPlugin:

- ExecutionOtelPlugin: deterministic Workflow root span (exported once per execution, terminal-only), invocation span as its child, operations parented to the Workflow span and linked to the invocation span; deterministic span IDs stitch suspended/resumed operations into a single logical span. Had to add SDK changes to support the workflow span by adding an executionStartTime parameter to InvocationInfo.
- OtelPlugin parity fix: invocation-span status now maps SUCCEEDED/PENDING -> OK and RETRYING/FAILED -> ERROR (was FAILED-only).
- DeterministicIdGenerator: add setNextSpanId(raw) and generateWorkflowSpanId().
- SpanAttributes: add durable.execution.status for the Workflow span.
- Tests: new ExecutionOtelPluginTest

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? yes

#### Integration Tests

Have integration tests been written for these changes? they are being worked on in a separate PR

#### Examples

Has a new example been added for the change? (if applicable)
