### PR TITLE
feat(otel): add workflow span and link operations/attempts

### DIFF
--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
@@ -69,7 +69,7 @@ public class DeterministicIdGenerator implements IdGenerator {
 
     /**
      * Queues the next span to use the given pre-computed span ID verbatim. Unlike {@link #setNextSpanOperationId}, the
-     * supplied value is used directly rather than derived from an operation ID. Used for the workflow root span, whose
+     * supplied value is used directly rather than derived from an operation ID. Used for the Workflow root span, whose
      * ID is derived once from the execution ARN via {@link #generateWorkflowSpanId()}.
      *
      * @param spanId a 16-char lowercase hex span ID
@@ -89,9 +89,9 @@ public class DeterministicIdGenerator implements IdGenerator {
     }
 
     /**
-     * Generates the deterministic span ID for the workflow root span from the current execution ARN, using the seed
+     * Generates the deterministic span ID for the Workflow root span from the current execution ARN, using the seed
      * {@code "workflow:" + arn} (SHA-256, truncated to 16 hex chars). Stable across all invocations of the same
-     * execution so the workflow span is exported once as a single logical span. Guarded to never be all-zero (an
+     * execution so the Workflow span is exported once as a single logical span. Guarded to never be all-zero (an
      * invalid OTel span ID).
      *
      * @return a deterministic 16-char hex span ID

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
@@ -69,7 +69,7 @@ public class DeterministicIdGenerator implements IdGenerator {
 
     /**
      * Queues the next span to use the given pre-computed span ID verbatim. Unlike {@link #setNextSpanOperationId}, the
-     * supplied value is used directly rather than derived from an operation ID. Used for the Workflow root span, whose
+     * supplied value is used directly rather than derived from an operation ID. Used for the workflow root span, whose
      * ID is derived once from the execution ARN via {@link #generateWorkflowSpanId()}.
      *
      * @param spanId a 16-char lowercase hex span ID
@@ -89,9 +89,9 @@ public class DeterministicIdGenerator implements IdGenerator {
     }
 
     /**
-     * Generates the deterministic span ID for the Workflow root span from the current execution ARN, using the seed
+     * Generates the deterministic span ID for the workflow root span from the current execution ARN, using the seed
      * {@code "workflow:" + arn} (SHA-256, truncated to 16 hex chars). Stable across all invocations of the same
-     * execution so the Workflow span is exported once as a single logical span. Guarded to never be all-zero (an
+     * execution so the workflow span is exported once as a single logical span. Guarded to never be all-zero (an
      * invalid OTel span ID).
      *
      * @return a deterministic 16-char hex span ID

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -83,7 +83,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
 
     private static final Logger logger = LoggerFactory.getLogger(ExecutionOtelPlugin.class);
     private static final String INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
-    private static final String DEFAULT_WORKFLOW_SPAN_NAME = "Workflow";
+    private static final String DEFAULT_WORKFLOW_SPAN_NAME = "workflow";
     private static final String SERVICE_NAME = "workflow";
 
     private final SdkTracerProvider tracerProvider;
@@ -110,7 +110,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
 
     /**
      * Creates a workflow-rooted OTel plugin with default settings: X-Ray context extraction, MDC enabled, root span
-     * named {@code "Workflow"}.
+     * named {@code "workflow"}.
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      */
@@ -120,7 +120,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
 
     /**
      * Creates a workflow-rooted OTel plugin with a custom context extractor, MDC enabled, root span named
-     * {@code "Workflow"}.
+     * {@code "workflow"}.
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -33,18 +33,18 @@ import software.amazon.lambda.durable.plugin.UserFunctionEndInfo;
 import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
 
 /**
- * workflow-rooted OpenTelemetry plugin for the AWS Lambda Durable Execution SDK.
+ * Workflow-rooted OpenTelemetry plugin for the AWS Lambda Durable Execution SDK.
  *
  * <p>This is the Java port of the {@code ExecutionOtelPlugin} in the Python and JavaScript SDKs. It renders the full
  * durable-execution hierarchy:
  *
  * <ul>
- *   <li><b>workflow span</b> — one <em>logical</em> root span per durable execution. Its span ID is derived
+ *   <li><b>Workflow span</b> — one <em>logical</em> root span per durable execution. Its span ID is derived
  *       deterministically from the execution ARN, so every invocation of the same execution produces the same ID. It is
  *       ended (and therefore exported) exactly once, on the terminal invocation.
- *   <li><b>Invocation span</b> — one per Lambda invocation, a child of the workflow span. Created and ended every
+ *   <li><b>Invocation span</b> — one per Lambda invocation, a child of the Workflow span. Created and ended every
  *       invocation.
- *   <li><b>Operation span</b> — parented to its parent operation span (or the workflow span) and carrying a
+ *   <li><b>Operation span</b> — parented to its parent operation span (or the Workflow span) and carrying a
  *       <em>link</em> to the current Invocation span for correlation. Deterministic ID keyed by operation ID, so a
  *       suspended-then-resumed operation stitches into a single logical span across invocations.
  *   <li><b>Attempt span</b> — one per user-function execution (step attempt, child-context run), child of the operation
@@ -52,8 +52,8 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * </ul>
  *
  * <p>Contrast with {@link InvocationOtelPlugin} (the invocation-rooted variant, equivalent to the reference
- * {@code InvocationOtelPlugin}): there the invocation span is the root and there is no workflow span. Here the workflow
- * span is the root, operations hang off the workflow span, and each operation/attempt links to the invocation that ran
+ * {@code InvocationOtelPlugin}): there the invocation span is the root and there is no Workflow span. Here the workflow
+ * span is the root, operations hang off the Workflow span, and each operation/attempt links to the invocation that ran
  * it. Both plugins share {@link DeterministicIdGenerator}, {@link ContextExtractor}, {@link SpanAttributes}, and
  * {@link MdcSpanEnricher}.
  *
@@ -66,10 +66,10 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * <ul>
  *   <li>Invocation span: {@code SUCCEEDED}/{@code PENDING} → {@link StatusCode#OK}; {@code FAILED} →
  *       {@link StatusCode#ERROR}; {@code RETRYING} → {@link StatusCode#UNSET}. {@code RETRYING} is left {@code UNSET}
- *       because the plugin interface does not expose whether the invocation/workflow was STOPPED or TIMED_OUT versus
+ *       because the plugin interface does not expose whether the invocation/Workflow was STOPPED or TIMED_OUT versus
  *       retried for a transient error, so an ERROR status cannot be asserted reliably.
- *   <li>workflow span (terminal only): {@code SUCCEEDED} → {@link StatusCode#OK}; {@code FAILED} →
- *       {@link StatusCode#ERROR}. Non-terminal statuses ({@code PENDING}/{@code RETRYING}) never end the workflow span,
+ *   <li>Workflow span (terminal only): {@code SUCCEEDED} → {@link StatusCode#OK}; {@code FAILED} →
+ *       {@link StatusCode#ERROR}. Non-terminal statuses ({@code PENDING}/{@code RETRYING}) never end the Workflow span,
  *       so it is not exported this invocation (effectively {@link StatusCode#UNSET}).
  * </ul>
  *
@@ -83,7 +83,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
 
     private static final Logger logger = LoggerFactory.getLogger(ExecutionOtelPlugin.class);
     private static final String INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
-    private static final String DEFAULT_WORKFLOW_SPAN_NAME = "workflow";
+    private static final String DEFAULT_WORKFLOW_SPAN_NAME = "Workflow";
     private static final String SERVICE_NAME = "workflow";
 
     private final SdkTracerProvider tracerProvider;
@@ -109,8 +109,8 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
     private final ConcurrentHashMap<String, SpanContext> operationContexts = new ConcurrentHashMap<>();
 
     /**
-     * Creates a workflow-rooted OTel plugin with default settings: X-Ray context extraction, MDC enabled, root span
-     * named {@code "workflow"}.
+     * Creates a Workflow-rooted OTel plugin with default settings: X-Ray context extraction, MDC enabled, root span
+     * named {@code "Workflow"}.
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      */
@@ -119,8 +119,8 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
     }
 
     /**
-     * Creates a workflow-rooted OTel plugin with a custom context extractor, MDC enabled, root span named
-     * {@code "workflow"}.
+     * Creates a Workflow-rooted OTel plugin with a custom context extractor, MDC enabled, root span named
+     * {@code "Workflow"}.
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
@@ -130,12 +130,12 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
     }
 
     /**
-     * Creates a workflow-rooted OTel plugin with full configuration.
+     * Creates a Workflow-rooted OTel plugin with full configuration.
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
      * @param enableMdc if true, injects traceId/spanId/traceSampled into SLF4J MDC for log correlation
-     * @param workflowSpanName the name for the workflow root span
+     * @param workflowSpanName the name for the Workflow root span
      */
     public ExecutionOtelPlugin(
             SdkTracerProviderBuilder tracerProviderBuilder,
@@ -165,14 +165,14 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         // Set execution ARN for deterministic span/trace ID generation
         idGenerator.setDurableExecutionArn(info.durableExecutionArn());
 
-        // Extract trace context from environment (X-Ray header). Only the trace ID is used — the workflow span is a
+        // Extract trace context from environment (X-Ray header). Only the trace ID is used — the Workflow span is a
         // true root, so the X-Ray parent span ID is intentionally not used for parenting (unlike InvocationOtelPlugin).
         var extractedContext = contextExtractor.extract();
         if (extractedContext != null) {
             idGenerator.setExtractedTraceId(extractedContext.traceId());
         }
 
-        // workflow root span — deterministic span ID from the ARN, no parent. Recreated every invocation with the
+        // Workflow root span — deterministic span ID from the ARN, no parent. Recreated every invocation with the
         // same ID so it is exported once as a single logical span (on the terminal invocation only). Its start time
         // is the execution start time from the backend (falling back to now if unavailable).
         var workflowSpanBuilder = tracer.spanBuilder(workflowSpanName)
@@ -183,8 +183,8 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         idGenerator.setNextSpanId(idGenerator.generateWorkflowSpanId());
         workflowSpan = workflowSpanBuilder.startSpan();
 
-        // Invocation span — child of the workflow span, INTERNAL kind, random span ID (new every invocation).
-        var spanBuilder = tracer.spanBuilder("invocation")
+        // Invocation span — child of the Workflow span, INTERNAL kind, random span ID (new every invocation).
+        var spanBuilder = tracer.spanBuilder("Invocation")
                 .setSpanKind(SpanKind.INTERNAL)
                 .setParent(Context.root().with(workflowSpan))
                 .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())
@@ -224,7 +224,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
             invocationSpan = null;
         }
 
-        // End the workflow span only on a terminal status, so it is exported exactly once per execution.
+        // End the Workflow span only on a terminal status, so it is exported exactly once per execution.
         if (workflowSpan != null) {
             if (isTerminal(info)) {
                 workflowSpan.setAttribute(
@@ -243,7 +243,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
                 }
                 workflowSpan.end();
             }
-            // Non-terminal (PENDING/RETRYING): leave the workflow span un-ended (not exported this invocation).
+            // Non-terminal (PENDING/RETRYING): leave the Workflow span un-ended (not exported this invocation).
             workflowSpan = null;
         }
 
@@ -497,7 +497,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
                     traceId, deterministicParentSpanId, TraceFlags.getSampled(), TraceState.getDefault());
             return Context.current().with(Span.wrap(placeholderContext));
         }
-        // No parent operation — hang off the workflow root span.
+        // No parent operation — hang off the Workflow root span.
         if (workflowSpan != null) {
             return Context.current().with(workflowSpan);
         }

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -33,18 +33,18 @@ import software.amazon.lambda.durable.plugin.UserFunctionEndInfo;
 import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
 
 /**
- * Workflow-rooted OpenTelemetry plugin for the AWS Lambda Durable Execution SDK.
+ * workflow-rooted OpenTelemetry plugin for the AWS Lambda Durable Execution SDK.
  *
  * <p>This is the Java port of the {@code ExecutionOtelPlugin} in the Python and JavaScript SDKs. It renders the full
  * durable-execution hierarchy:
  *
  * <ul>
- *   <li><b>Workflow span</b> — one <em>logical</em> root span per durable execution. Its span ID is derived
+ *   <li><b>workflow span</b> — one <em>logical</em> root span per durable execution. Its span ID is derived
  *       deterministically from the execution ARN, so every invocation of the same execution produces the same ID. It is
  *       ended (and therefore exported) exactly once, on the terminal invocation.
- *   <li><b>Invocation span</b> — one per Lambda invocation, a child of the Workflow span. Created and ended every
+ *   <li><b>Invocation span</b> — one per Lambda invocation, a child of the workflow span. Created and ended every
  *       invocation.
- *   <li><b>Operation span</b> — parented to its parent operation span (or the Workflow span) and carrying a
+ *   <li><b>Operation span</b> — parented to its parent operation span (or the workflow span) and carrying a
  *       <em>link</em> to the current Invocation span for correlation. Deterministic ID keyed by operation ID, so a
  *       suspended-then-resumed operation stitches into a single logical span across invocations.
  *   <li><b>Attempt span</b> — one per user-function execution (step attempt, child-context run), child of the operation
@@ -52,10 +52,10 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * </ul>
  *
  * <p>Contrast with {@link InvocationOtelPlugin} (the invocation-rooted variant, equivalent to the reference
- * {@code InvocationInvocationOtelPlugin}): there the invocation span is the root and there is no Workflow span. Here
- * the Workflow span is the root, operations hang off the Workflow span, and each operation/attempt links to the
- * invocation that ran it. Both plugins share {@link DeterministicIdGenerator}, {@link ContextExtractor},
- * {@link SpanAttributes}, and {@link MdcSpanEnricher}.
+ * {@code InvocationOtelPlugin}): there the invocation span is the root and there is no workflow span. Here the workflow
+ * span is the root, operations hang off the workflow span, and each operation/attempt links to the invocation that ran
+ * it. Both plugins share {@link DeterministicIdGenerator}, {@link ContextExtractor}, {@link SpanAttributes}, and
+ * {@link MdcSpanEnricher}.
  *
  * <p>Trace ID resolution matches {@link InvocationOtelPlugin}: the X-Ray trace ID from {@code _X_AMZN_TRACE_ID} when
  * available (the backend propagates the same Root to all invocations, unifying the trace), else a deterministic trace
@@ -68,8 +68,8 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  *       {@link StatusCode#ERROR}; {@code RETRYING} → {@link StatusCode#UNSET}. {@code RETRYING} is left {@code UNSET}
  *       because the plugin interface does not expose whether the invocation/workflow was STOPPED or TIMED_OUT versus
  *       retried for a transient error, so an ERROR status cannot be asserted reliably.
- *   <li>Workflow span (terminal only): {@code SUCCEEDED} → {@link StatusCode#OK}; {@code FAILED} →
- *       {@link StatusCode#ERROR}. Non-terminal statuses ({@code PENDING}/{@code RETRYING}) never end the Workflow span,
+ *   <li>workflow span (terminal only): {@code SUCCEEDED} → {@link StatusCode#OK}; {@code FAILED} →
+ *       {@link StatusCode#ERROR}. Non-terminal statuses ({@code PENDING}/{@code RETRYING}) never end the workflow span,
  *       so it is not exported this invocation (effectively {@link StatusCode#UNSET}).
  * </ul>
  *
@@ -135,7 +135,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
      * @param enableMdc if true, injects traceId/spanId/traceSampled into SLF4J MDC for log correlation
-     * @param workflowSpanName the name for the Workflow root span
+     * @param workflowSpanName the name for the workflow root span
      */
     public ExecutionOtelPlugin(
             SdkTracerProviderBuilder tracerProviderBuilder,
@@ -165,14 +165,14 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         // Set execution ARN for deterministic span/trace ID generation
         idGenerator.setDurableExecutionArn(info.durableExecutionArn());
 
-        // Extract trace context from environment (X-Ray header). Only the trace ID is used — the Workflow span is a
+        // Extract trace context from environment (X-Ray header). Only the trace ID is used — the workflow span is a
         // true root, so the X-Ray parent span ID is intentionally not used for parenting (unlike InvocationOtelPlugin).
         var extractedContext = contextExtractor.extract();
         if (extractedContext != null) {
             idGenerator.setExtractedTraceId(extractedContext.traceId());
         }
 
-        // Workflow root span — deterministic span ID from the ARN, no parent. Recreated every invocation with the
+        // workflow root span — deterministic span ID from the ARN, no parent. Recreated every invocation with the
         // same ID so it is exported once as a single logical span (on the terminal invocation only). Its start time
         // is the execution start time from the backend (falling back to now if unavailable).
         var workflowSpanBuilder = tracer.spanBuilder(workflowSpanName)
@@ -183,7 +183,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         idGenerator.setNextSpanId(idGenerator.generateWorkflowSpanId());
         workflowSpan = workflowSpanBuilder.startSpan();
 
-        // Invocation span — child of the Workflow span, INTERNAL kind, random span ID (new every invocation).
+        // Invocation span — child of the workflow span, INTERNAL kind, random span ID (new every invocation).
         var spanBuilder = tracer.spanBuilder("invocation")
                 .setSpanKind(SpanKind.INTERNAL)
                 .setParent(Context.root().with(workflowSpan))
@@ -224,7 +224,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
             invocationSpan = null;
         }
 
-        // End the Workflow span only on a terminal status, so it is exported exactly once per execution.
+        // End the workflow span only on a terminal status, so it is exported exactly once per execution.
         if (workflowSpan != null) {
             if (isTerminal(info)) {
                 workflowSpan.setAttribute(
@@ -243,7 +243,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
                 }
                 workflowSpan.end();
             }
-            // Non-terminal (PENDING/RETRYING): leave the Workflow span un-ended (not exported this invocation).
+            // Non-terminal (PENDING/RETRYING): leave the workflow span un-ended (not exported this invocation).
             workflowSpan = null;
         }
 
@@ -497,7 +497,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
                     traceId, deterministicParentSpanId, TraceFlags.getSampled(), TraceState.getDefault());
             return Context.current().with(Span.wrap(placeholderContext));
         }
-        // No parent operation — hang off the Workflow root span.
+        // No parent operation — hang off the workflow root span.
         if (workflowSpan != null) {
             return Context.current().with(workflowSpan);
         }

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -38,7 +38,7 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * <p>Creates spans at these levels:
  *
  * <ul>
- *   <li><b>Workflow span</b> — one logical span per durable execution (deterministic ID from the ARN, exported once on
+ *   <li><b>workflow span</b> — one logical span per durable execution (deterministic ID from the ARN, exported once on
  *       the terminal invocation). Operation and attempt spans carry a <em>link</em> to it for execution-level
  *       correlation; they remain parented to the per-invocation span (this plugin is invocation-rooted).
  *   <li><b>Invocation span</b> — one per Lambda invocation
@@ -130,7 +130,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
     }
 
     /**
-     * Creates an OTel plugin with the given context extractor and MDC setting, using the default Workflow span name.
+     * Creates an OTel plugin with the given context extractor and MDC setting, using the default workflow span name.
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
@@ -147,7 +147,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
      * @param enableMdc if true, injects traceId/spanId/traceSampled into SLF4J MDC for log correlation
-     * @param workflowSpanName the name for the Workflow span
+     * @param workflowSpanName the name for the workflow span
      */
     public InvocationOtelPlugin(
             SdkTracerProviderBuilder tracerProviderBuilder,
@@ -185,7 +185,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         }
         // If no extracted context, idGenerator falls back to ARN-derived trace ID
 
-        // Workflow root span — one logical span per durable execution, created unconditionally (independent of the
+        // workflow root span — one logical span per durable execution, created unconditionally (independent of the
         // X-Ray parent below). Deterministic span ID from the ARN so it is the same across invocations; exported once,
         // on the terminal invocation. Operation and attempt spans link to it for execution-level correlation while
         // remaining parented to the per-invocation span (this plugin stays invocation-rooted).
@@ -278,7 +278,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         invocationSpan.end();
         invocationSpan = null;
 
-        // End the Workflow span only on a terminal status, so it is exported exactly once per execution
+        // End the workflow span only on a terminal status, so it is exported exactly once per execution
         // (SUCCEEDED -> OK, FAILED -> ERROR; non-terminal statuses leave it un-ended / not exported this invocation).
         if (workflowSpan != null) {
             if (isTerminal(info)) {
@@ -335,7 +335,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
             idGenerator.setNextSpanOperationId(info.id());
         }
 
-        // Link to the Workflow span for execution-level correlation (operation stays parented to the invocation span).
+        // Link to the workflow span for execution-level correlation (operation stays parented to the invocation span).
         addWorkflowLink(spanBuilder);
 
         if (info.name() != null) {
@@ -539,7 +539,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         return Context.current();
     }
 
-    /** Adds a link to the Workflow span, if one exists, for execution-level correlation. */
+    /** Adds a link to the workflow span, if one exists, for execution-level correlation. */
     private void addWorkflowLink(SpanBuilder spanBuilder) {
         var currentWorkflowSpan = workflowSpan;
         if (currentWorkflowSpan != null) {

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -7,6 +7,7 @@ import static software.amazon.lambda.durable.otel.SpanAttributes.*;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
@@ -34,9 +35,12 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
 /**
  * OpenTelemetry plugin for the AWS Lambda Durable Execution SDK.
  *
- * <p>Creates spans at three levels:
+ * <p>Creates spans at these levels:
  *
  * <ul>
+ *   <li><b>Workflow span</b> — one logical span per durable execution (deterministic ID from the ARN, exported once on
+ *       the terminal invocation). Operation and attempt spans carry a <em>link</em> to it for execution-level
+ *       correlation; they remain parented to the per-invocation span (this plugin is invocation-rooted).
  *   <li><b>Invocation span</b> — one per Lambda invocation
  *   <li><b>Operation span</b> — created when an operation starts, ended when it completes or when the invocation ends
  *   <li><b>Attempt span</b> — one per user function execution (step attempt, child context run)
@@ -71,6 +75,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
 
     private static final Logger logger = LoggerFactory.getLogger(InvocationOtelPlugin.class);
     private static final String INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
+    private static final String WORKFLOW_SPAN_NAME = "Workflow";
 
     private final SdkTracerProvider tracerProvider;
     private final Tracer tracer;
@@ -79,6 +84,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
     private final boolean enableMdc;
 
     // Per-invocation state
+    private volatile Span workflowSpan;
     private volatile Span invocationSpan;
     private volatile String durableExecutionArn;
 
@@ -161,6 +167,18 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         }
         // If no extracted context, idGenerator falls back to ARN-derived trace ID
 
+        // Workflow root span — one logical span per durable execution, created unconditionally (independent of the
+        // X-Ray parent below). Deterministic span ID from the ARN so it is the same across invocations; exported once,
+        // on the terminal invocation. Operation and attempt spans link to it for execution-level correlation while
+        // remaining parented to the per-invocation span (this plugin stays invocation-rooted).
+        var workflowSpanBuilder = tracer.spanBuilder(WORKFLOW_SPAN_NAME)
+                .setSpanKind(SpanKind.INTERNAL)
+                .setNoParent()
+                .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())
+                .setStartTimestamp(info.executionStartTime() != null ? info.executionStartTime() : Instant.now());
+        idGenerator.setNextSpanId(idGenerator.generateWorkflowSpanId());
+        workflowSpan = workflowSpanBuilder.startSpan();
+
         // Determine parent context for the invocation span.
         Context parentContext;
         if (extractedContext != null && extractedContext.parentSpanId() != null) {
@@ -242,6 +260,29 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         invocationSpan.end();
         invocationSpan = null;
 
+        // End the Workflow span only on a terminal status, so it is exported exactly once per execution
+        // (SUCCEEDED -> OK, FAILED -> ERROR; non-terminal statuses leave it un-ended / not exported this invocation).
+        if (workflowSpan != null) {
+            if (isTerminal(info)) {
+                workflowSpan.setAttribute(
+                        DURABLE_EXECUTION_STATUS, info.invocationStatus().name());
+                switch (info.invocationStatus()) {
+                    case FAILED -> {
+                        var message = info.executionError() != null
+                                ? info.executionError().getMessage()
+                                : null;
+                        workflowSpan.setStatus(StatusCode.ERROR, message);
+                        if (info.executionError() != null) {
+                            workflowSpan.recordException(info.executionError());
+                        }
+                    }
+                    default -> workflowSpan.setStatus(StatusCode.OK); // SUCCEEDED
+                }
+                workflowSpan.end();
+            }
+            workflowSpan = null;
+        }
+
         // Flush spans before Lambda freezes
         var flushResult = tracerProvider.forceFlush().join(5, java.util.concurrent.TimeUnit.SECONDS);
         if (!flushResult.isSuccess()) {
@@ -275,6 +316,9 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
             // First execution — use deterministic span ID so continuations can link back
             idGenerator.setNextSpanOperationId(info.id());
         }
+
+        // Link to the Workflow span for execution-level correlation (operation stays parented to the invocation span).
+        addWorkflowLink(spanBuilder);
 
         if (info.name() != null) {
             spanBuilder.setAttribute(DURABLE_OPERATION_NAME, info.name());
@@ -326,6 +370,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
                     .setAttribute(DURABLE_EXECUTION_ARN, durableExecutionArn)
                     .setAttribute(DURABLE_OPERATION_ID, info.id())
                     .setAttribute(DURABLE_OPERATION_TYPE, info.type());
+            addWorkflowLink(spanBuilder);
 
             if (info.startTimestamp() != null) {
                 spanBuilder.setStartTimestamp(info.startTimestamp());
@@ -385,6 +430,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         var spanBuilder = tracer.spanBuilder(attemptSpanName(info.type(), info.subType(), info.name(), info.attempt()))
                 .setParent(parentContext)
                 .setStartTimestamp(info.startTimestamp() != null ? info.startTimestamp() : Instant.now());
+        addWorkflowLink(spanBuilder);
 
         spanBuilder.setAttribute(DURABLE_EXECUTION_ARN, durableExecutionArn);
         spanBuilder.setAttribute(DURABLE_OPERATION_ID, info.id());
@@ -473,6 +519,21 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
             return Context.current().with(invocationSpan);
         }
         return Context.current();
+    }
+
+    /** Adds a link to the Workflow span, if one exists, for execution-level correlation. */
+    private void addWorkflowLink(SpanBuilder spanBuilder) {
+        var currentWorkflowSpan = workflowSpan;
+        if (currentWorkflowSpan != null) {
+            spanBuilder.addLink(currentWorkflowSpan.getSpanContext());
+        }
+    }
+
+    private static boolean isTerminal(InvocationEndInfo info) {
+        return switch (info.invocationStatus()) {
+            case SUCCEEDED, FAILED -> true;
+            case PENDING, RETRYING -> false;
+        };
     }
 
     private static String spanName(String type, String subType, String name) {

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -38,7 +38,7 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * <p>Creates spans at these levels:
  *
  * <ul>
- *   <li><b>workflow span</b> — one logical span per durable execution (deterministic ID from the ARN, exported once on
+ *   <li><b>Workflow span</b> — one logical span per durable execution (deterministic ID from the ARN, exported once on
  *       the terminal invocation). Operation and attempt spans carry a <em>link</em> to it for execution-level
  *       correlation; they remain parented to the per-invocation span (this plugin is invocation-rooted).
  *   <li><b>Invocation span</b> — one per Lambda invocation
@@ -75,7 +75,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
 
     private static final Logger logger = LoggerFactory.getLogger(InvocationOtelPlugin.class);
     private static final String INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
-    private static final String DEFAULT_WORKFLOW_SPAN_NAME = "workflow";
+    private static final String DEFAULT_WORKFLOW_SPAN_NAME = "Workflow";
 
     private final SdkTracerProvider tracerProvider;
     private final Tracer tracer;
@@ -130,7 +130,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
     }
 
     /**
-     * Creates an OTel plugin with the given context extractor and MDC setting, using the default workflow span name.
+     * Creates an OTel plugin with the given context extractor and MDC setting, using the default Workflow span name.
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
@@ -147,7 +147,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
      * @param enableMdc if true, injects traceId/spanId/traceSampled into SLF4J MDC for log correlation
-     * @param workflowSpanName the name for the workflow span
+     * @param workflowSpanName the name for the Workflow span
      */
     public InvocationOtelPlugin(
             SdkTracerProviderBuilder tracerProviderBuilder,
@@ -185,7 +185,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         }
         // If no extracted context, idGenerator falls back to ARN-derived trace ID
 
-        // workflow root span — one logical span per durable execution, created unconditionally (independent of the
+        // Workflow root span — one logical span per durable execution, created unconditionally (independent of the
         // X-Ray parent below). Deterministic span ID from the ARN so it is the same across invocations; exported once,
         // on the terminal invocation. Operation and attempt spans link to it for execution-level correlation while
         // remaining parented to the per-invocation span (this plugin stays invocation-rooted).
@@ -213,7 +213,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         }
 
         // Create an INTERNAL span for the invocation.
-        var spanBuilder = tracer.spanBuilder("invocation")
+        var spanBuilder = tracer.spanBuilder("Invocation")
                 .setSpanKind(SpanKind.INTERNAL)
                 .setParent(parentContext)
                 .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())
@@ -278,7 +278,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         invocationSpan.end();
         invocationSpan = null;
 
-        // End the workflow span only on a terminal status, so it is exported exactly once per execution
+        // End the Workflow span only on a terminal status, so it is exported exactly once per execution
         // (SUCCEEDED -> OK, FAILED -> ERROR; non-terminal statuses leave it un-ended / not exported this invocation).
         if (workflowSpan != null) {
             if (isTerminal(info)) {
@@ -335,7 +335,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
             idGenerator.setNextSpanOperationId(info.id());
         }
 
-        // Link to the workflow span for execution-level correlation (operation stays parented to the invocation span).
+        // Link to the Workflow span for execution-level correlation (operation stays parented to the invocation span).
         addWorkflowLink(spanBuilder);
 
         if (info.name() != null) {
@@ -539,7 +539,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         return Context.current();
     }
 
-    /** Adds a link to the workflow span, if one exists, for execution-level correlation. */
+    /** Adds a link to the Workflow span, if one exists, for execution-level correlation. */
     private void addWorkflowLink(SpanBuilder spanBuilder) {
         var currentWorkflowSpan = workflowSpan;
         if (currentWorkflowSpan != null) {

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -75,7 +75,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
 
     private static final Logger logger = LoggerFactory.getLogger(InvocationOtelPlugin.class);
     private static final String INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
-    private static final String DEFAULT_WORKFLOW_SPAN_NAME = "Workflow";
+    private static final String DEFAULT_WORKFLOW_SPAN_NAME = "workflow";
 
     private final SdkTracerProvider tracerProvider;
     private final Tracer tracer;

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -75,13 +75,14 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
 
     private static final Logger logger = LoggerFactory.getLogger(InvocationOtelPlugin.class);
     private static final String INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
-    private static final String WORKFLOW_SPAN_NAME = "Workflow";
+    private static final String DEFAULT_WORKFLOW_SPAN_NAME = "Workflow";
 
     private final SdkTracerProvider tracerProvider;
     private final Tracer tracer;
     private final DeterministicIdGenerator idGenerator;
     private final ContextExtractor contextExtractor;
     private final boolean enableMdc;
+    private final String workflowSpanName;
 
     // Per-invocation state
     private volatile Span workflowSpan;
@@ -129,7 +130,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
     }
 
     /**
-     * Creates an OTel plugin with full configuration.
+     * Creates an OTel plugin with the given context extractor and MDC setting, using the default Workflow span name.
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
@@ -137,6 +138,22 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
      */
     public InvocationOtelPlugin(
             SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor, boolean enableMdc) {
+        this(tracerProviderBuilder, contextExtractor, enableMdc, DEFAULT_WORKFLOW_SPAN_NAME);
+    }
+
+    /**
+     * Creates an OTel plugin with full configuration.
+     *
+     * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
+     * @param contextExtractor extracts parent trace context from the Lambda environment
+     * @param enableMdc if true, injects traceId/spanId/traceSampled into SLF4J MDC for log correlation
+     * @param workflowSpanName the name for the Workflow span
+     */
+    public InvocationOtelPlugin(
+            SdkTracerProviderBuilder tracerProviderBuilder,
+            ContextExtractor contextExtractor,
+            boolean enableMdc,
+            String workflowSpanName) {
         this.idGenerator = new DeterministicIdGenerator();
 
         // Set service.name to "invocation" for the exported spans' resource.
@@ -147,6 +164,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         this.tracer = tracerProvider.get(INSTRUMENTATION_NAME);
         this.contextExtractor = contextExtractor;
         this.enableMdc = enableMdc;
+        this.workflowSpanName = workflowSpanName != null ? workflowSpanName : DEFAULT_WORKFLOW_SPAN_NAME;
     }
 
     // ─── Invocation hooks ────────────────────────────────────────────────
@@ -171,7 +189,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         // X-Ray parent below). Deterministic span ID from the ARN so it is the same across invocations; exported once,
         // on the terminal invocation. Operation and attempt spans link to it for execution-level correlation while
         // remaining parented to the per-invocation span (this plugin stays invocation-rooted).
-        var workflowSpanBuilder = tracer.spanBuilder(WORKFLOW_SPAN_NAME)
+        var workflowSpanBuilder = tracer.spanBuilder(workflowSpanName)
                 .setSpanKind(SpanKind.INTERNAL)
                 .setNoParent()
                 .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -28,7 +28,7 @@ class ExecutionOtelPluginTest {
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> null,
                 false,
-                "Workflow");
+                "workflow");
     }
 
     // ─── Workflow root span lifecycle ────────────────────────────────────
@@ -41,7 +41,7 @@ class ExecutionOtelPluginTest {
         var spans = spanExporter.getFinishedSpanItems();
         assertEquals(2, spans.size(), "Terminal invocation should export the Workflow span and the invocation span");
 
-        var workflowSpan = spanByName(spans, "Workflow");
+        var workflowSpan = spanByName(spans, "workflow");
         var invocationSpan = spanByName(spans, "invocation");
 
         assertEquals(StatusCode.OK, workflowSpan.getStatus().getStatusCode());
@@ -53,7 +53,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
-        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "Workflow");
+        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "workflow");
         assertEquals(
                 "workflow",
                 workflowSpan
@@ -68,7 +68,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, start));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
-        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "Workflow");
+        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "workflow");
         assertEquals(
                 start.toEpochMilli(),
                 workflowSpan.getStartEpochNanos() / 1_000_000,
@@ -82,7 +82,7 @@ class ExecutionOtelPluginTest {
 
         assertEquals(
                 SpanKind.INTERNAL,
-                spanByName(spanExporter.getFinishedSpanItems(), "Workflow").getKind(),
+                spanByName(spanExporter.getFinishedSpanItems(), "workflow").getKind(),
                 "Workflow span must be INTERNAL kind");
     }
 
@@ -92,7 +92,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        var workflowSpan = spanByName(spans, "Workflow");
+        var workflowSpan = spanByName(spans, "workflow");
         var invocationSpan = spanByName(spans, "invocation");
 
         assertFalse(
@@ -124,7 +124,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
         assertTrue(
                 spanExporter.getFinishedSpanItems().stream()
-                        .noneMatch(s -> s.getName().equals("Workflow")),
+                        .noneMatch(s -> s.getName().equals("workflow")),
                 "Workflow span must not be exported on a non-terminal invocation");
         spanExporter.reset();
 
@@ -132,7 +132,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
 
-        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "Workflow");
+        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "workflow");
         assertEquals(StatusCode.OK, workflowSpan.getStatus().getStatusCode());
         assertTrue(workflowSpan.getSpanId().matches("[0-9a-f]{16}"));
     }
@@ -146,7 +146,7 @@ class ExecutionOtelPluginTest {
                 new InvocationEndInfo("req-1", ARN, true, InvocationStatus.FAILED, new RuntimeException("boom")));
 
         var spans = spanExporter.getFinishedSpanItems();
-        assertEquals(StatusCode.ERROR, spanByName(spans, "Workflow").getStatus().getStatusCode());
+        assertEquals(StatusCode.ERROR, spanByName(spans, "workflow").getStatus().getStatusCode());
         assertEquals(
                 StatusCode.ERROR, spanByName(spans, "invocation").getStatus().getStatusCode());
     }
@@ -229,7 +229,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        var workflowSpan = spanByName(spans, "Workflow");
+        var workflowSpan = spanByName(spans, "workflow");
         var invocationSpan = spanByName(spans, "invocation");
         var operationSpan = spanByName(spans, "step-a");
 
@@ -443,7 +443,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
         var firstWorkflowSpanId =
-                spanByName(spanExporter.getFinishedSpanItems(), "Workflow").getSpanId();
+                spanByName(spanExporter.getFinishedSpanItems(), "workflow").getSpanId();
         spanExporter.reset();
 
         // A second (independent) plugin for the same execution ARN must derive the same Workflow span ID.
@@ -452,11 +452,11 @@ class ExecutionOtelPluginTest {
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter2)),
                 () -> null,
                 false,
-                "Workflow");
+                "workflow");
         plugin2.onInvocationStart(new InvocationInfo("req-9", ARN, true, Instant.now()));
         plugin2.onInvocationEnd(new InvocationEndInfo("req-9", ARN, true, InvocationStatus.SUCCEEDED, null));
         var secondWorkflowSpanId =
-                spanByName(exporter2.getFinishedSpanItems(), "Workflow").getSpanId();
+                spanByName(exporter2.getFinishedSpanItems(), "workflow").getSpanId();
 
         assertEquals(
                 firstWorkflowSpanId,
@@ -475,7 +475,7 @@ class ExecutionOtelPluginTest {
                         .addSpanProcessor(SimpleSpanProcessor.create(exporter)),
                 () -> null,
                 false,
-                "Workflow");
+                "workflow");
         sampledPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         sampledPlugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
         assertTrue(exporter.getFinishedSpanItems().isEmpty(), "No spans should be exported with 0% sampling");
@@ -491,7 +491,7 @@ class ExecutionOtelPluginTest {
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
                 () -> new ExtractedContext(xrayTraceId, null),
                 false,
-                "Workflow");
+                "workflow");
         xrayPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -28,7 +28,7 @@ class ExecutionOtelPluginTest {
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
                 () -> null,
                 false,
-                "workflow");
+                "Workflow");
     }
 
     // ─── Workflow root span lifecycle ────────────────────────────────────
@@ -41,8 +41,8 @@ class ExecutionOtelPluginTest {
         var spans = spanExporter.getFinishedSpanItems();
         assertEquals(2, spans.size(), "Terminal invocation should export the Workflow span and the invocation span");
 
-        var workflowSpan = spanByName(spans, "workflow");
-        var invocationSpan = spanByName(spans, "invocation");
+        var workflowSpan = spanByName(spans, "Workflow");
+        var invocationSpan = spanByName(spans, "Invocation");
 
         assertEquals(StatusCode.OK, workflowSpan.getStatus().getStatusCode());
         assertEquals(StatusCode.OK, invocationSpan.getStatus().getStatusCode());
@@ -53,7 +53,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
-        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "workflow");
+        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "Workflow");
         assertEquals(
                 "workflow",
                 workflowSpan
@@ -68,7 +68,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, start));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
-        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "workflow");
+        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "Workflow");
         assertEquals(
                 start.toEpochMilli(),
                 workflowSpan.getStartEpochNanos() / 1_000_000,
@@ -82,7 +82,7 @@ class ExecutionOtelPluginTest {
 
         assertEquals(
                 SpanKind.INTERNAL,
-                spanByName(spanExporter.getFinishedSpanItems(), "workflow").getKind(),
+                spanByName(spanExporter.getFinishedSpanItems(), "Workflow").getKind(),
                 "Workflow span must be INTERNAL kind");
     }
 
@@ -92,8 +92,8 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        var workflowSpan = spanByName(spans, "workflow");
-        var invocationSpan = spanByName(spans, "invocation");
+        var workflowSpan = spanByName(spans, "Workflow");
+        var invocationSpan = spanByName(spans, "Invocation");
 
         assertFalse(
                 invocationSpan.getParentSpanContext().getSpanId().equals("0000000000000000"),
@@ -113,7 +113,7 @@ class ExecutionOtelPluginTest {
         var spans = spanExporter.getFinishedSpanItems();
         // Only the invocation span is exported; the Workflow span is not ended on non-terminal status.
         assertEquals(1, spans.size());
-        assertEquals("invocation", spans.get(0).getName());
+        assertEquals("Invocation", spans.get(0).getName());
         assertEquals(StatusCode.OK, spans.get(0).getStatus().getStatusCode(), "PENDING invocation span maps to OK");
     }
 
@@ -124,7 +124,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
         assertTrue(
                 spanExporter.getFinishedSpanItems().stream()
-                        .noneMatch(s -> s.getName().equals("workflow")),
+                        .noneMatch(s -> s.getName().equals("Workflow")),
                 "Workflow span must not be exported on a non-terminal invocation");
         spanExporter.reset();
 
@@ -132,7 +132,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
 
-        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "workflow");
+        var workflowSpan = spanByName(spanExporter.getFinishedSpanItems(), "Workflow");
         assertEquals(StatusCode.OK, workflowSpan.getStatus().getStatusCode());
         assertTrue(workflowSpan.getSpanId().matches("[0-9a-f]{16}"));
     }
@@ -146,9 +146,9 @@ class ExecutionOtelPluginTest {
                 new InvocationEndInfo("req-1", ARN, true, InvocationStatus.FAILED, new RuntimeException("boom")));
 
         var spans = spanExporter.getFinishedSpanItems();
-        assertEquals(StatusCode.ERROR, spanByName(spans, "workflow").getStatus().getStatusCode());
+        assertEquals(StatusCode.ERROR, spanByName(spans, "Workflow").getStatus().getStatusCode());
         assertEquals(
-                StatusCode.ERROR, spanByName(spans, "invocation").getStatus().getStatusCode());
+                StatusCode.ERROR, spanByName(spans, "Invocation").getStatus().getStatusCode());
     }
 
     @Test
@@ -160,7 +160,7 @@ class ExecutionOtelPluginTest {
         var spans = spanExporter.getFinishedSpanItems();
         assertEquals(1, spans.size(), "RETRYING is non-terminal — Workflow span not exported");
         var invocationSpan = spans.get(0);
-        assertEquals("invocation", invocationSpan.getName());
+        assertEquals("Invocation", invocationSpan.getName());
         assertEquals(
                 StatusCode.UNSET,
                 invocationSpan.getStatus().getStatusCode(),
@@ -229,8 +229,8 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        var workflowSpan = spanByName(spans, "workflow");
-        var invocationSpan = spanByName(spans, "invocation");
+        var workflowSpan = spanByName(spans, "Workflow");
+        var invocationSpan = spanByName(spans, "Invocation");
         var operationSpan = spanByName(spans, "step-a");
 
         assertEquals(
@@ -257,7 +257,7 @@ class ExecutionOtelPluginTest {
 
         var spans = spanExporter.getFinishedSpanItems();
         var operationSpan = spanByName(spans, "compute");
-        var invocationSpan = spanByName(spans, "invocation");
+        var invocationSpan = spanByName(spans, "Invocation");
         var attemptSpan = spans.stream()
                 .filter(s -> s.getName().contains("attempt"))
                 .findFirst()
@@ -354,7 +354,7 @@ class ExecutionOtelPluginTest {
         // Only the invocation span is exported. The still-open operation span is NOT force-ended (no PENDING
         // span here), and the Workflow span is not exported on a non-terminal invocation.
         assertEquals(1, spans.size());
-        assertEquals("invocation", spans.get(0).getName());
+        assertEquals("Invocation", spans.get(0).getName());
         assertTrue(
                 spans.stream().noneMatch(s -> s.getName().equals("my-wait")),
                 "An operation still open at invocation end must not be ended/exported in onInvocationEnd");
@@ -382,7 +382,7 @@ class ExecutionOtelPluginTest {
         var waitSpans =
                 spans.stream().filter(s -> s.getName().equals("my-wait")).toList();
         assertEquals(1, waitSpans.size(), "The operation must be exported exactly once, when it completes");
-        var invocationSpan = spanByName(spans, "invocation");
+        var invocationSpan = spanByName(spans, "Invocation");
         assertTrue(
                 waitSpans.get(0).getLinks().stream()
                         .anyMatch(l -> l.getSpanContext().getSpanId().equals(invocationSpan.getSpanId())),
@@ -430,7 +430,7 @@ class ExecutionOtelPluginTest {
 
         var spans = spanExporter.getFinishedSpanItems();
         var continuationSpan = spanByName(spans, "my-wait");
-        var invocationSpan = spanByName(spans, "invocation");
+        var invocationSpan = spanByName(spans, "Invocation");
         assertFalse(continuationSpan.getLinks().isEmpty(), "Continuation span should have a link");
         assertTrue(
                 continuationSpan.getLinks().stream()
@@ -443,7 +443,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
         var firstWorkflowSpanId =
-                spanByName(spanExporter.getFinishedSpanItems(), "workflow").getSpanId();
+                spanByName(spanExporter.getFinishedSpanItems(), "Workflow").getSpanId();
         spanExporter.reset();
 
         // A second (independent) plugin for the same execution ARN must derive the same Workflow span ID.
@@ -452,11 +452,11 @@ class ExecutionOtelPluginTest {
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter2)),
                 () -> null,
                 false,
-                "workflow");
+                "Workflow");
         plugin2.onInvocationStart(new InvocationInfo("req-9", ARN, true, Instant.now()));
         plugin2.onInvocationEnd(new InvocationEndInfo("req-9", ARN, true, InvocationStatus.SUCCEEDED, null));
         var secondWorkflowSpanId =
-                spanByName(exporter2.getFinishedSpanItems(), "workflow").getSpanId();
+                spanByName(exporter2.getFinishedSpanItems(), "Workflow").getSpanId();
 
         assertEquals(
                 firstWorkflowSpanId,
@@ -475,7 +475,7 @@ class ExecutionOtelPluginTest {
                         .addSpanProcessor(SimpleSpanProcessor.create(exporter)),
                 () -> null,
                 false,
-                "workflow");
+                "Workflow");
         sampledPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         sampledPlugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
         assertTrue(exporter.getFinishedSpanItems().isEmpty(), "No spans should be exported with 0% sampling");
@@ -491,7 +491,7 @@ class ExecutionOtelPluginTest {
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
                 () -> new ExtractedContext(xrayTraceId, null),
                 false,
-                "workflow");
+                "Workflow");
         xrayPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginIntegrationTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginIntegrationTest.java
@@ -58,7 +58,7 @@ class InvocationOtelPluginIntegrationTest {
         assertTrue(spans.size() >= 3, "Expected at least 3 spans, got " + spans.size());
 
         // Verify span names
-        assertSpanExists(spans, "invocation");
+        assertSpanExists(spans, "Invocation");
         assertSpanExists(spans, "greet");
         assertSpanExists(spans, "greet attempt 1");
 
@@ -157,7 +157,7 @@ class InvocationOtelPluginIntegrationTest {
 
         // Verify both invocations produced invocation spans
         var invocationSpans =
-                allSpans.stream().filter(s -> s.getName().equals("invocation")).toList();
+                allSpans.stream().filter(s -> s.getName().equals("Invocation")).toList();
         assertEquals(2, invocationSpans.size(), "Should have 2 invocation spans (one per run)");
     }
 
@@ -294,7 +294,7 @@ class InvocationOtelPluginIntegrationTest {
 
         // Invocation span should have error status
         var invocationSpan = spans.stream()
-                .filter(s -> s.getName().equals("invocation"))
+                .filter(s -> s.getName().equals("Invocation"))
                 .findFirst()
                 .orElseThrow();
         assertEquals(
@@ -477,7 +477,7 @@ class InvocationOtelPluginIntegrationTest {
 
         // Should have 3 invocation spans
         var invocationSpans =
-                allSpans.stream().filter(s -> s.getName().equals("invocation")).toList();
+                allSpans.stream().filter(s -> s.getName().equals("Invocation")).toList();
         assertEquals(3, invocationSpans.size(), "Should have 3 invocation spans");
 
         // Should have wait-A and wait-B spans

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -1028,6 +1028,28 @@ class InvocationOtelPluginTest {
                 "Default 'Workflow' name should not appear when a custom name is configured");
     }
 
+    @Test
+    void failedInvocation_setsErrorOnBothWorkflowAndInvocationSpans() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
+        plugin.onInvocationEnd(new InvocationEndInfo(
+                "req-1", "arn:exec1", true, InvocationStatus.FAILED, new RuntimeException("boom")));
+
+        var workflowSpan = spanByName("Workflow");
+        var invocationSpan = spanByName("Invocation");
+
+        assertEquals(
+                StatusCode.ERROR,
+                workflowSpan.getStatus().getStatusCode(),
+                "Workflow span should be ERROR on a FAILED invocation");
+        assertEquals(
+                StatusCode.ERROR,
+                invocationSpan.getStatus().getStatusCode(),
+                "Invocation span should be ERROR on a FAILED invocation");
+        assertTrue(
+                workflowSpan.getEvents().stream().anyMatch(e -> e.getName().equals("exception")),
+                "Workflow span should record the execution exception on FAILED");
+    }
+
     // ─── Helpers ─────────────────────────────────────────────────────────
 
     private io.opentelemetry.sdk.trace.data.SpanData spanByName(String name) {

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -46,7 +46,7 @@ class InvocationOtelPluginTest {
         assertEquals(2, spans.size()); // invocation + Workflow
 
         var span = spans.get(0);
-        assertEquals("invocation", span.getName());
+        assertEquals("Invocation", span.getName());
         assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
     }
 
@@ -936,7 +936,7 @@ class InvocationOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec-wf", true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec-wf", true, InvocationStatus.SUCCEEDED, null));
 
-        var workflow = spanByName("workflow");
+        var workflow = spanByName("Workflow");
         assertEquals(SpanKind.INTERNAL, workflow.getKind(), "Workflow span must be INTERNAL");
         assertEquals(StatusCode.OK, workflow.getStatus().getStatusCode());
         assertTrue(workflow.getSpanId().matches("[0-9a-f]{16}"), "Workflow span ID should be 16 hex chars");
@@ -949,7 +949,7 @@ class InvocationOtelPluginTest {
 
         assertTrue(
                 spanExporter.getFinishedSpanItems().stream()
-                        .noneMatch(s -> s.getName().equals("workflow")),
+                        .noneMatch(s -> s.getName().equals("Workflow")),
                 "Workflow span must not be exported on a non-terminal invocation");
     }
 
@@ -965,7 +965,7 @@ class InvocationOtelPluginTest {
                 "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", 1, false, null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec-wf", true, InvocationStatus.SUCCEEDED, null));
 
-        var workflowId = spanByName("workflow").getSpanId();
+        var workflowId = spanByName("Workflow").getSpanId();
         var operationSpan = spanByName("step-a");
         var attemptSpan = spanExporter.getFinishedSpanItems().stream()
                 .filter(s -> s.getName().contains("attempt"))
@@ -992,7 +992,7 @@ class InvocationOtelPluginTest {
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var workflowId = exporter.getFinishedSpanItems().stream()
-                .filter(s -> s.getName().equals("workflow"))
+                .filter(s -> s.getName().equals("Workflow"))
                 .findFirst()
                 .orElseThrow()
                 .getSpanId();
@@ -1024,7 +1024,7 @@ class InvocationOtelPluginTest {
                 "Workflow span should use the configured name");
         assertTrue(
                 exporter.getFinishedSpanItems().stream()
-                        .noneMatch(s -> s.getName().equals("workflow")),
+                        .noneMatch(s -> s.getName().equals("Workflow")),
                 "Default 'Workflow' name should not appear when a custom name is configured");
     }
 

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -936,7 +936,7 @@ class InvocationOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec-wf", true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec-wf", true, InvocationStatus.SUCCEEDED, null));
 
-        var workflow = spanByName("Workflow");
+        var workflow = spanByName("workflow");
         assertEquals(SpanKind.INTERNAL, workflow.getKind(), "Workflow span must be INTERNAL");
         assertEquals(StatusCode.OK, workflow.getStatus().getStatusCode());
         assertTrue(workflow.getSpanId().matches("[0-9a-f]{16}"), "Workflow span ID should be 16 hex chars");
@@ -949,7 +949,7 @@ class InvocationOtelPluginTest {
 
         assertTrue(
                 spanExporter.getFinishedSpanItems().stream()
-                        .noneMatch(s -> s.getName().equals("Workflow")),
+                        .noneMatch(s -> s.getName().equals("workflow")),
                 "Workflow span must not be exported on a non-terminal invocation");
     }
 
@@ -965,7 +965,7 @@ class InvocationOtelPluginTest {
                 "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", 1, false, null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec-wf", true, InvocationStatus.SUCCEEDED, null));
 
-        var workflowId = spanByName("Workflow").getSpanId();
+        var workflowId = spanByName("workflow").getSpanId();
         var operationSpan = spanByName("step-a");
         var attemptSpan = spanExporter.getFinishedSpanItems().stream()
                 .filter(s -> s.getName().contains("attempt"))
@@ -992,7 +992,7 @@ class InvocationOtelPluginTest {
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var workflowId = exporter.getFinishedSpanItems().stream()
-                .filter(s -> s.getName().equals("Workflow"))
+                .filter(s -> s.getName().equals("workflow"))
                 .findFirst()
                 .orElseThrow()
                 .getSpanId();
@@ -1024,7 +1024,7 @@ class InvocationOtelPluginTest {
                 "Workflow span should use the configured name");
         assertTrue(
                 exporter.getFinishedSpanItems().stream()
-                        .noneMatch(s -> s.getName().equals("Workflow")),
+                        .noneMatch(s -> s.getName().equals("workflow")),
                 "Default 'Workflow' name should not appear when a custom name is configured");
     }
 

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -43,7 +43,7 @@ class InvocationOtelPluginTest {
                 null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        assertEquals(1, spans.size());
+        assertEquals(2, spans.size()); // invocation + Workflow
 
         var span = spans.get(0);
         assertEquals("invocation", span.getName());
@@ -175,7 +175,7 @@ class InvocationOtelPluginTest {
                 "req-123", "arn:exec1", true, InvocationStatus.FAILED, new RuntimeException("boom")));
 
         var spans = spanExporter.getFinishedSpanItems();
-        assertEquals(1, spans.size());
+        assertEquals(2, spans.size()); // invocation + Workflow
         assertEquals(StatusCode.ERROR, spans.get(0).getStatus().getStatusCode());
     }
 
@@ -210,7 +210,7 @@ class InvocationOtelPluginTest {
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        assertEquals(2, spans.size());
+        assertEquals(3, spans.size()); // operation + invocation + Workflow
 
         var operationSpan = spans.stream()
                 .filter(s -> s.getName().contains("step"))
@@ -232,7 +232,7 @@ class InvocationOtelPluginTest {
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        assertEquals(2, spans.size());
+        assertEquals(3, spans.size()); // attempt + invocation + Workflow
 
         var attemptSpan = spans.stream()
                 .filter(s -> s.getName().contains("attempt"))
@@ -297,8 +297,8 @@ class InvocationOtelPluginTest {
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        // 2 attempt spans + 2 operation spans + 1 invocation span = 5
-        assertEquals(5, spans.size());
+        // 2 attempt spans + 2 operation spans + 1 invocation span + 1 Workflow span = 6
+        assertEquals(6, spans.size());
 
         // All spans should share the same trace ID
         var traceId = spans.get(0).getTraceId();
@@ -385,7 +385,7 @@ class InvocationOtelPluginTest {
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        assertEquals(1, spans.size());
+        assertEquals(2, spans.size()); // invocation + Workflow
         assertEquals(xrayTraceId, spans.get(0).getTraceId(), "Span should use the extracted X-Ray trace ID");
     }
 
@@ -434,7 +434,7 @@ class InvocationOtelPluginTest {
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        assertEquals(1, spans.size());
+        assertEquals(2, spans.size()); // invocation + Workflow
 
         var invocationSpan = spans.get(0);
         assertEquals(xrayTraceId, invocationSpan.getTraceId());
@@ -459,7 +459,7 @@ class InvocationOtelPluginTest {
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        assertEquals(1, spans.size());
+        assertEquals(2, spans.size()); // invocation + Workflow
 
         var invocationSpan = spans.get(0);
         assertEquals(xrayTraceId, invocationSpan.getTraceId());
@@ -524,7 +524,7 @@ class InvocationOtelPluginTest {
         noXrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        assertEquals(1, spans.size());
+        assertEquals(2, spans.size()); // invocation + Workflow
 
         var traceId = spans.get(0).getTraceId();
         assertNotNull(traceId);
@@ -580,7 +580,7 @@ class InvocationOtelPluginTest {
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
-        assertEquals(2, spans.size());
+        assertEquals(3, spans.size()); // continuation + invocation + Workflow
 
         var continuationSpan = spans.stream()
                 .filter(s -> s.getName().contains("wait"))
@@ -803,8 +803,8 @@ class InvocationOtelPluginTest {
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", arn, false, InvocationStatus.SUCCEEDED, null));
 
         var inv2Spans = spanExporter.getFinishedSpanItems();
-        // wait continuation + step-B op + step-B attempt + invocation = 4
-        assertEquals(4, inv2Spans.size());
+        // wait continuation + step-B op + step-B attempt + invocation + Workflow = 5
+        assertEquals(5, inv2Spans.size());
 
         // Same trace ID across invocations
         var inv2TraceId = inv2Spans.get(0).getTraceId();
@@ -890,8 +890,8 @@ class InvocationOtelPluginTest {
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", arn, false, InvocationStatus.SUCCEEDED, null));
 
         var inv2Spans = spanExporter.getFinishedSpanItems();
-        // operation span + attempt 2 span + invocation span = 3
-        assertEquals(3, inv2Spans.size());
+        // operation span + attempt 2 span + invocation span + Workflow span = 4
+        assertEquals(4, inv2Spans.size());
 
         var inv2OperationSpan = inv2Spans.stream()
                 .filter(s ->
@@ -927,5 +927,96 @@ class InvocationOtelPluginTest {
         assertTrue(
                 allSpans.stream().allMatch(s -> s.getTraceId().equals(traceId)),
                 "All spans across invocations should share the same trace ID");
+    }
+
+    // ─── Workflow span + links ───────────────────────────────────────────
+
+    @Test
+    void workflowSpan_exportedOnTerminal_internal_deterministicId() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec-wf", true, Instant.now()));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec-wf", true, InvocationStatus.SUCCEEDED, null));
+
+        var workflow = spanByName("Workflow");
+        assertEquals(SpanKind.INTERNAL, workflow.getKind(), "Workflow span must be INTERNAL");
+        assertEquals(StatusCode.OK, workflow.getStatus().getStatusCode());
+        assertTrue(workflow.getSpanId().matches("[0-9a-f]{16}"), "Workflow span ID should be 16 hex chars");
+    }
+
+    @Test
+    void workflowSpan_notExportedOnNonTerminal() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.PENDING, null));
+
+        assertTrue(
+                spanExporter.getFinishedSpanItems().stream()
+                        .noneMatch(s -> s.getName().equals("Workflow")),
+                "Workflow span must not be exported on a non-terminal invocation");
+    }
+
+    @Test
+    void operationAndAttemptSpans_linkToWorkflowSpan() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec-wf", true, Instant.now()));
+        plugin.onOperationStart(new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));
+        plugin.onUserFunctionStart(
+                new UserFunctionStartInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), false, 1));
+        plugin.onUserFunctionEnd(new UserFunctionEndInfo(
+                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+        plugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", 1, false, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec-wf", true, InvocationStatus.SUCCEEDED, null));
+
+        var workflowId = spanByName("Workflow").getSpanId();
+        var operationSpan = spanByName("step-a");
+        var attemptSpan = spanExporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().contains("attempt"))
+                .findFirst()
+                .orElseThrow();
+
+        assertTrue(hasLinkTo(operationSpan, workflowId), "Operation span should link to the Workflow span");
+        assertTrue(hasLinkTo(attemptSpan, workflowId), "Attempt span should link to the Workflow span");
+    }
+
+    @Test
+    void operationLinksToWorkflow_withXRayContext() {
+        // "Other case": invocation span is parented to the X-Ray segment, but operation spans still link to Workflow.
+        var exporter = InMemorySpanExporter.create();
+        var xrayPlugin = new InvocationOtelPlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
+                () -> new ExtractedContext("5759e988bd862e3fe1be46a994272793", "53995c3f42cd8ad8"),
+                false);
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
+        xrayPlugin.onOperationStart(
+                new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));
+        xrayPlugin.onOperationEnd(new OperationEndInfo(
+                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+        xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var workflowId = exporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().equals("Workflow"))
+                .findFirst()
+                .orElseThrow()
+                .getSpanId();
+        var operationSpan = exporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().equals("step-a"))
+                .findFirst()
+                .orElseThrow();
+        assertTrue(
+                operationSpan.getLinks().stream()
+                        .anyMatch(l -> l.getSpanContext().getSpanId().equals(workflowId)),
+                "Operation span should link to Workflow span even when the invocation is parented to the X-Ray segment");
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────
+
+    private io.opentelemetry.sdk.trace.data.SpanData spanByName(String name) {
+        return spanExporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No span named '" + name + "'"));
+    }
+
+    private static boolean hasLinkTo(io.opentelemetry.sdk.trace.data.SpanData span, String spanId) {
+        return span.getLinks().stream()
+                .anyMatch(l -> l.getSpanContext().getSpanId().equals(spanId));
     }
 }

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -1006,6 +1006,28 @@ class InvocationOtelPluginTest {
                 "Operation span should link to Workflow span even when the invocation is parented to the X-Ray segment");
     }
 
+    @Test
+    void workflowSpanName_isConfigurable() {
+        var exporter = InMemorySpanExporter.create();
+        var customPlugin = new InvocationOtelPlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
+                () -> null,
+                false,
+                "MyWorkflow");
+        customPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
+        customPlugin.onInvocationEnd(
+                new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        assertTrue(
+                exporter.getFinishedSpanItems().stream()
+                        .anyMatch(s -> s.getName().equals("MyWorkflow")),
+                "Workflow span should use the configured name");
+        assertTrue(
+                exporter.getFinishedSpanItems().stream()
+                        .noneMatch(s -> s.getName().equals("Workflow")),
+                "Default 'Workflow' name should not appear when a custom name is configured");
+    }
+
     // ─── Helpers ─────────────────────────────────────────────────────────
 
     private io.opentelemetry.sdk.trace.data.SpanData spanByName(String name) {


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available https://github.com/aws/aws-durable-execution-conformance-tests/issues/23#issuecomment-5109655796

### Description

Add a Workflow span to the invocation-rooted plugin so operation and attempt spans can be correlated to the overall durable execution. Mirrors ExecutionOtelPlugin's Workflow span (deterministic span ID from the ARN, SpanKind.INTERNAL, no parent, start = executionStartTime, exported once on the terminal invocation), but the plugin stays invocation-rooted: operations/attempts remain parented to the per-invocation span and additionally carry a LINK to the Workflow span.

Applies unconditionally (the Java plugin has no default-vs-owned provider mode): the Workflow span is created and linked in both onInvocationStart branches — whether the invocation span is parented to the X-Ray segment or is a root.

Links added on operation spans (first-exec + replay + continuation branches) and attempt spans. Workflow span ended only on terminal status (SUCCEEDED->OK, FAILED->ERROR); non-terminal leaves it un-exported.

Updated existing span-count assertions (terminal invocations now export +1 Workflow span) and added workflowSpan_exportedOnTerminal_internal_deterministicId, workflowSpan_notExportedOnNonTerminal, operationAndAttemptSpans_linkToWorkflowSpan, and operationLinksToWorkflow_withXRayContext.

Also renamed "invocation" spans to "Invocation" to match conformance testing.

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [ ] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes?

#### Integration Tests

Have integration tests been written for these changes?

#### Examples

Has a new example been added for the change? (if applicable)
