### PR TITLE
ci: split Maven release workflow

### DIFF
--- a/.github/scripts/maven_publish.sh
+++ b/.github/scripts/maven_publish.sh
@@ -1,7 +1,7 @@
 
 #!/bin/bash
 # publish-maven.sh
-# Builds, signs, and publishes to Maven Central using central-publishing-maven-plugin
+# Builds, signs, and uploads to Sonatype Central Portal using central-publishing-maven-plugin
 set -euo pipefail
 
 SETTINGS_FILE="./settings.xml"
@@ -40,10 +40,10 @@ EOF
 
 echo "settings.xml written."
 
-echo "=== Step 3: Deploy to Maven Central ==="
+echo "=== Step 3: Upload to Sonatype Central Portal ==="
 
 mvn clean deploy -s "${SETTINGS_FILE}" -pl sdk -P publishing -DskipTests --no-transfer-progress
 mvn clean deploy -s "${SETTINGS_FILE}" -pl sdk-testing -P publishing -DskipTests --no-transfer-progress
 mvn clean deploy -s "${SETTINGS_FILE}" -pl otel-plugin -P publishing -DskipTests --no-transfer-progress
 
-echo "=== Release ${RELEASE_VERSION} published successfully! ==="
+echo "=== Release ${RELEASE_VERSION} uploaded successfully; review and publish it in Sonatype Central Portal. ==="

--- a/.github/workflows/publish_maven.yml
+++ b/.github/workflows/publish_maven.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build artifacts
         run: mvn clean install -q -Dlog4j2.level=WARN -Dlog4j.configurationFile=log4j2-quiet.xml --no-transfer-progress
 
-      - name: Sign and publish to Maven Central
+      - name: Sign and upload to Sonatype Central Portal
         run: bash .github/scripts/maven_publish.sh
         env:
           MVN_GPG_KEYS_GPGPRIVATEKEY: ${{ secrets.MVN_GPG_KEYS_GPGPRIVATEKEY }}

--- a/.github/workflows/publish_maven.yml
+++ b/.github/workflows/publish_maven.yml
@@ -39,7 +39,11 @@ jobs:
           patch="${BASH_REMATCH[3]}"
           suffix="${BASH_REMATCH[4]}"
           release_version="${major}.${minor}.${patch}${suffix}"
-          next_version="${major}.${minor}.$((10#$patch + 1))-SNAPSHOT"
+          if [ -n "$suffix" ]; then
+            next_version="${major}.${minor}.${patch}-SNAPSHOT"
+          else
+            next_version="${major}.${minor}.$((10#$patch + 1))-SNAPSHOT"
+          fi
 
           echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
           echo "NEXT_VERSION=$next_version" >> "$GITHUB_ENV"

--- a/.github/workflows/publish_maven.yml
+++ b/.github/workflows/publish_maven.yml
@@ -1,0 +1,135 @@
+name: Publish Maven Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: publish-maven-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      BASE_BRANCH: ${{ github.event.repository.default_branch }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+
+    steps:
+      - name: Checkout release
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Determine release versions
+        shell: bash
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Release tag must be a semantic version prefixed with v (for example, v1.2.0)." >&2
+            exit 1
+          fi
+
+          major="${BASH_REMATCH[1]}"
+          minor="${BASH_REMATCH[2]}"
+          patch="${BASH_REMATCH[3]}"
+          suffix="${BASH_REMATCH[4]}"
+          release_version="${major}.${minor}.${patch}${suffix}"
+          next_version="${major}.${minor}.$((10#$patch + 1))-SNAPSHOT"
+
+          echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+          echo "NEXT_VERSION=$next_version" >> "$GITHUB_ENV"
+
+      - name: Verify release source
+        shell: bash
+        run: |
+          git fetch origin "$BASE_BRANCH"
+          if ! git merge-base --is-ancestor "${RELEASE_TAG}^{commit}" "origin/${BASE_BRANCH}"; then
+            echo "Release tag $RELEASE_TAG does not point to a commit on $BASE_BRANCH." >&2
+            exit 1
+          fi
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+          cache: maven
+
+      - name: Verify release version
+        shell: bash
+        run: |
+          pom_version="$(mvn -q help:evaluate -Dexpression=project.version -DforceStdout)"
+          if [ "$pom_version" != "$RELEASE_VERSION" ]; then
+            echo "Release tag $RELEASE_TAG points to Maven version $pom_version, expected $RELEASE_VERSION." >&2
+            exit 1
+          fi
+
+      - name: Build artifacts
+        run: mvn clean install -q -Dlog4j2.level=WARN -Dlog4j.configurationFile=log4j2-quiet.xml --no-transfer-progress
+
+      - name: Sign and publish to Maven Central
+        run: bash .github/scripts/maven_publish.sh
+        env:
+          MVN_GPG_KEYS_GPGPRIVATEKEY: ${{ secrets.MVN_GPG_KEYS_GPGPRIVATEKEY }}
+          MVN_GPG_KEYS_GPGPASSPHRASE: ${{ secrets.MVN_GPG_KEYS_GPGPASSPHRASE }}
+          MVN_ACCOUNT_KEYS_USERNAME: ${{ secrets.MVN_ACCOUNT_KEYS_USERNAME }}
+          MVN_ACCOUNT_KEYS_PASSWORD: ${{ secrets.MVN_ACCOUNT_KEYS_PASSWORD }}
+
+      - name: Upload GitHub release artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$RELEASE_TAG" \
+            "sdk/target/aws-durable-execution-sdk-java-${RELEASE_VERSION}.jar" \
+            "sdk-testing/target/aws-durable-execution-sdk-java-testing-${RELEASE_VERSION}.jar" \
+            "otel-plugin/target/aws-durable-execution-sdk-java-plugin-otel-${RELEASE_VERSION}.jar" \
+            --clobber
+
+      - name: Checkout default branch
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Set next development version
+        shell: bash
+        run: |
+          pom_version="$(mvn -q help:evaluate -Dexpression=project.version -DforceStdout)"
+          if [ "$pom_version" != "$RELEASE_VERSION" ]; then
+            echo "Default branch Maven version is $pom_version, expected $RELEASE_VERSION." >&2
+            exit 1
+          fi
+
+          BRANCH_NAME="release/v${NEXT_VERSION}"
+          git switch --create "$BRANCH_NAME"
+          mvn -q versions:set -DnewVersion="$NEXT_VERSION" -DgenerateBackupPoms=false
+          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
+
+      - name: Commit next development version
+        env:
+          GIT_ACTOR: ${{ github.actor }}
+        run: |
+          git config user.email "${GIT_ACTOR}+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${GIT_ACTOR}+github-actions[bot]"
+          git add -- ':(glob)**/pom.xml'
+          git commit -m "chore: bump version to ${NEXT_VERSION}"
+
+      - name: Push next development branch
+        run: git push --set-upstream origin "$BRANCH_NAME"
+
+      - name: Create next development version pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr_url="$(gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$BRANCH_NAME" \
+            --title "chore: bump version to ${NEXT_VERSION}" \
+            --body "Bumps the Maven project version to ${NEXT_VERSION} after publishing ${RELEASE_TAG}.")"
+          echo "Created next development version pull request: $pr_url"
+          echo "Next development version pull request: $pr_url" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release_maven.yml
+++ b/.github/workflows/release_maven.yml
@@ -1,5 +1,4 @@
-
-name: Maven Release
+name: Prepare Maven Release
 
 on:
   workflow_dispatch:
@@ -8,33 +7,33 @@ on:
         description: 'Release version (e.g. 1.2.0)'
         required: true
         type: string
-      next_version:
-        description: 'Next development version (e.g. 1.3.0-SNAPSHOT)'
-        required: true
-        type: string
-      is_pre_release:
-        description: 'Is pre-release?'
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   contents: write
   issues: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
-  release:
+  prepare:
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ github.event.inputs.release_version }}
-      NEXT_VERSION: ${{ github.event.inputs.next_version }}
+      BASE_BRANCH: ${{ github.event.repository.default_branch }}
+      RELEASE_VERSION: ${{ inputs.release_version }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Validate release version
+        shell: bash
+        run: |
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Release version must be a semantic version without a leading v (for example, 1.2.0)." >&2
+            exit 1
+          fi
 
       - name: Determine previous release tag
         id: previous_release
@@ -79,7 +78,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           PREVIOUS_TAG: ${{ steps.previous_release.outputs.tag }}
-          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
           RELEASE_COMMITS: ${{ steps.release_commits.outputs.shas }}
           RELEASE_PULL_REQUESTS: ${{ steps.release_pull_requests.outputs.numbers }}
         with:
@@ -261,7 +260,7 @@ jobs:
                 .map(formatBreakingReferences)
                 .join(', ')}) since ${previousTag}, but the major version was not bumped from ${previousMajor}.`
             );
-  
+
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
@@ -276,48 +275,25 @@ jobs:
         env:
           GIT_ACTOR: ${{ github.actor }}
         run: |
+          BRANCH_NAME="release/v${RELEASE_VERSION}"
+          git switch --create "$BRANCH_NAME"
           git config user.email "${GIT_ACTOR}+github-actions[bot]@users.noreply.github.com"
           git config user.name "${GIT_ACTOR}+github-actions[bot]"
-          git add .
+          git add -- ':(glob)**/pom.xml'
           git commit -m "chore: release version ${RELEASE_VERSION}"
-      
-      - name: Push changes
-        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
 
-      - name: Build artifacts
-        run: mvn clean install -q -Dlog4j2.level=WARN -Dlog4j.configurationFile=log4j2-quiet.xml --no-transfer-progress
+      - name: Push release branch
+        run: git push --set-upstream origin "$BRANCH_NAME"
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          tag_name: v${{ github.event.inputs.release_version }}
-          name: Release v${{ github.event.inputs.release_version }}
-          generate_release_notes: true
-          prerelease: ${{ github.event.inputs.is_pre_release }}
-          files: |
-            sdk/target/aws-durable-execution-sdk-java-${{ github.event.inputs.release_version }}.jar
-            sdk-testing/target/aws-durable-execution-sdk-java-testing-${{ github.event.inputs.release_version }}.jar
-            otel-plugin/target/aws-durable-execution-sdk-java-plugin-otel-${{ github.event.inputs.release_version }}.jar
-      
-      - name: Sign and publish
-        run: bash .github/scripts/maven_publish.sh
+      - name: Create release pull request
         env:
-          MVN_GPG_KEYS_GPGPRIVATEKEY: ${{ secrets.MVN_GPG_KEYS_GPGPRIVATEKEY }}
-          MVN_GPG_KEYS_GPGPASSPHRASE: ${{ secrets.MVN_GPG_KEYS_GPGPASSPHRASE }}
-          MVN_ACCOUNT_KEYS_USERNAME: ${{ secrets.MVN_ACCOUNT_KEYS_USERNAME }}
-          MVN_ACCOUNT_KEYS_PASSWORD: ${{ secrets.MVN_ACCOUNT_KEYS_PASSWORD }}
-
-      - name: Set next development version
-        run: mvn -q versions:set -DnewVersion="$NEXT_VERSION" -DgenerateBackupPoms=false
-
-      - name: Commit next development version
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git add .
-          git commit -m "chore: bump version to ${NEXT_VERSION}"
-      
-      - name: Push changes
-        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_url="$(gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$BRANCH_NAME" \
+            --title "chore: release version ${RELEASE_VERSION}" \
+            --body "Sets the Maven project version to ${RELEASE_VERSION}. After this PR is approved and merged, manually create and publish GitHub release v${RELEASE_VERSION}.")"
+          echo "Created release pull request: $pr_url"
+          echo "Release pull request: $pr_url" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ See [Deploy Lambda durable functions with Infrastructure as Code](https://docs.a
 - [<u>Error Handling</u>](docs/advanced/error-handling.md) - SDK exceptions for handling failures
 - [<u>Logging</u>](docs/advanced/logging.md) - How to use DurableLogger
 - [<u>Migrating from 1.x to 2.x</u>](docs/migration-1.x-to-2.x.md) - Upgrade guide for breaking changes since `v1.2.1`
+- [<u>Release Process</u>](RELEASE.md) - Prepare and publish Maven releases
 - [<u>Testing</u>](docs/advanced/testing.md) - Utilities for local development and cloud-based integration testing
 
 ## Related SDKs

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,13 +43,21 @@ The publication workflow:
 
 1. Verifies that the tag is a semantic version, points to a commit on the
    default branch, and matches the Maven version in the tagged POM.
-2. Builds and publishes the SDK, testing library, and OpenTelemetry plugin to
-   Maven Central.
+2. Builds, signs, and uploads the SDK, testing library, and OpenTelemetry plugin
+   to Sonatype Central Portal.
 3. Uploads the three JARs to the existing GitHub release.
 4. Increments the patch version, adds the `-SNAPSHOT` suffix, and opens a pull
    request for the next development version. For example, release `2.1.1`
    produces `2.1.2-SNAPSHOT`.
 
-Confirm that **Publish Maven Release** succeeds, the GitHub release contains the
-expected JARs, and the artifacts are available in Maven Central. Then review,
-approve, and merge the next development version pull request.
+After **Publish Maven Release** succeeds:
+
+1. Open [Publishing Deployments](https://central.sonatype.com/publishing/deployments)
+   in Sonatype Central Portal.
+2. Find the deployments for the release version and verify that they contain
+   the expected SDK, testing library, and OpenTelemetry plugin artifacts.
+3. Click **Publish** for each deployment and wait for publication to complete.
+   The workflow uses `autoPublish=false`, so this manual action is required.
+4. Confirm that the GitHub release contains the expected JARs and that the
+   artifacts are available in Maven Central.
+5. Review, approve, and merge the next development version pull request.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,55 @@
+# Release Process
+
+Releases use two GitHub Actions workflows with a manual approval boundary between
+them:
+
+- [`Prepare Maven Release`](.github/workflows/release_maven.yml) creates the
+  release version pull request.
+- [`Publish Maven Release`](.github/workflows/publish_maven.yml) publishes from a
+  manually created GitHub release.
+
+## 1. Prepare the release pull request
+
+1. Open **Actions**, select **Prepare Maven Release**, and choose **Run
+   workflow** from the default branch.
+2. Enter the release version without a leading `v`, for example `2.1.1`.
+3. Wait for the workflow to validate the release and open a pull request that
+   updates all Maven POMs to the release version.
+4. Review, approve, and merge the release version pull request.
+
+The preparation workflow validates that releases containing `BREAKING` changes
+increment the major version. It commits the version change to
+`release/v<version>` and stops after opening the pull request. It does not
+publish artifacts or create a GitHub release.
+
+## 2. Create the GitHub release
+
+After the release version pull request is merged:
+
+1. Open **Releases** and choose **Draft a new release**.
+2. Create the tag `v<version>`, for example `v2.1.1`, from the release version
+   pull request's merge commit on the default branch.
+3. Set the title to `Release v<version>` and generate or enter the release
+   notes.
+4. Mark the release as a prerelease when applicable.
+5. Publish the release.
+
+Publishing the GitHub release emits the `release.published` event. This starts
+the Maven publication workflow and the release notification workflow.
+
+## 3. Verify publication
+
+The publication workflow:
+
+1. Verifies that the tag is a semantic version, points to a commit on the
+   default branch, and matches the Maven version in the tagged POM.
+2. Builds and publishes the SDK, testing library, and OpenTelemetry plugin to
+   Maven Central.
+3. Uploads the three JARs to the existing GitHub release.
+4. Increments the patch version, adds the `-SNAPSHOT` suffix, and opens a pull
+   request for the next development version. For example, release `2.1.1`
+   produces `2.1.2-SNAPSHOT`.
+
+Confirm that **Publish Maven Release** succeeds, the GitHub release contains the
+expected JARs, and the artifacts are available in Maven Central. Then review,
+approve, and merge the next development version pull request.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,9 +46,10 @@ The publication workflow:
 2. Builds, signs, and uploads the SDK, testing library, and OpenTelemetry plugin
    to Sonatype Central Portal.
 3. Uploads the three JARs to the existing GitHub release.
-4. Increments the patch version, adds the `-SNAPSHOT` suffix, and opens a pull
-   request for the next development version. For example, release `2.1.1`
-   produces `2.1.2-SNAPSHOT`.
+4. Opens a pull request for the next development version. A final release
+   increments the patch version, so `2.1.1` produces `2.1.2-SNAPSHOT`. A
+   prerelease keeps the same base version, so `2.1.1-rc1` produces
+   `2.1.1-SNAPSHOT` until the final `2.1.1` release.
 
 After **Publish Maven Release** succeeds:
 


### PR DESCRIPTION
## Summary

- change Prepare Maven Release to commit the release version on a branch and open a pull request instead of pushing directly to main
- upload signed Maven artifacts from a separate release.published workflow, then require verification and the manual Publish action in Sonatype Central Portal
- attach artifacts to the GitHub release and open a follow-up pull request for the next patch snapshot version
- document the new release procedure and restore release notifications through manually published GitHub releases

## Validation

- /tmp/actionlint-1.7.12/actionlint .github/workflows/*.yml
- Ruby YAML parsing for all workflow files
- bash -n .github/scripts/maven_publish.sh
- mvn -q help:evaluate -Dexpression=project.version -DforceStdout
- git diff --check

Maven tests were not run because this change only updates GitHub Actions configuration, release script messaging, and documentation.

Fixes #189