### PR TITLE
style: format plugin conformance handlers

### DIFF
--- a/conformance-tests/src/main/java/plugin/PluginFaultyAndHealthy.java
+++ b/conformance-tests/src/main/java/plugin/PluginFaultyAndHealthy.java
@@ -18,9 +18,9 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  *
  * <p>A single greeting step configured with TWO plugins registered together, in order: first a faulty plugin whose
  * every exercised hook (invocation-start, operation-start, attempt-start, attempt-end, operation-end, invocation-end)
- * logs a record then throws, then a healthy plugin that logs the corresponding six records normally. The SDK's {@code
- * PluginRunner} isolates each plugin at every hook boundary (swallows the faulty plugin's exceptions), so the healthy
- * plugin still receives every hook and the execution result/history are identical to running without the faulty
+ * logs a record then throws, then a healthy plugin that logs the corresponding six records normally. The SDK's
+ * {@code PluginRunner} isolates each plugin at every hook boundary (swallows the faulty plugin's exceptions), so the
+ * healthy plugin still receives every hook and the execution result/history are identical to running without the faulty
  * plugin. Attempt boundaries are the real user-function hooks ({@code onUserFunctionStart}/{@code onUserFunctionEnd},
  * filtered to step attempts); the healthy attempt-end reports the SDK's real success/failure outcome.
  */

--- a/conformance-tests/src/main/java/plugin/PluginParallelBranchHooks.java
+++ b/conformance-tests/src/main/java/plugin/PluginParallelBranchHooks.java
@@ -20,8 +20,8 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  *
  * <p>A parallel operation named "parallel" with two branches (max-concurrency 1, so they run sequentially in index
  * order); each branch returns a constant directly. The plugin, filtering to parallel-branch operations, logs fn-start
- * and fn-end (with outcome) from the real user-function hooks, carrying the branch operation id and the parallel
- * parent id. These hooks run on the branch's own thread, so start-before-end order per branch is deterministic.
+ * and fn-end (with outcome) from the real user-function hooks, carrying the branch operation id and the parallel parent
+ * id. These hooks run on the branch's own thread, so start-before-end order per branch is deterministic.
  */
 @SuppressWarnings("deprecation")
 public class PluginParallelBranchHooks extends DurableHandler<Object, List<String>> {

--- a/conformance-tests/src/main/java/plugin/PluginReplayFlags.java
+++ b/conformance-tests/src/main/java/plugin/PluginReplayFlags.java
@@ -17,10 +17,10 @@ import software.amazon.lambda.durable.retry.RetryStrategies;
 /**
  * 10-13: Non-terminal operations replay with replay=true; terminal operations are not re-emitted.
  *
- * <p>Two sequential steps. Step A succeeds on its first attempt (terminal before the retry invocation). Step B fails
- * on its first attempt and succeeds on the second, using the SDK's built-in exponential-backoff retry strategy
- * (~1s delay). The plugin, filtering to step-type operations, logs operation-start with the SDK's is-replayed
- * indicator ({@code OperationInfo#isReplay()}) and operation-end with the terminal status.
+ * <p>Two sequential steps. Step A succeeds on its first attempt (terminal before the retry invocation). Step B fails on
+ * its first attempt and succeeds on the second, using the SDK's built-in exponential-backoff retry strategy (~1s
+ * delay). The plugin, filtering to step-type operations, logs operation-start with the SDK's is-replayed indicator
+ * ({@code OperationInfo#isReplay()}) and operation-end with the terminal status.
  */
 @SuppressWarnings("deprecation")
 public class PluginReplayFlags extends DurableHandler<Object, String> {

--- a/conformance-tests/src/main/java/plugin/PluginRetryExhaustion.java
+++ b/conformance-tests/src/main/java/plugin/PluginRetryExhaustion.java
@@ -18,8 +18,8 @@ import software.amazon.lambda.durable.retry.RetryStrategies;
 /**
  * 10-15: Attempt hooks fire for every attempt until exhaustion, then operation-end reports FAILED.
  *
- * <p>A single step that always throws, configured with the SDK's built-in exponential-backoff retry strategy allowing
- * 2 total attempts (1 initial + 1 retry, ~1s delay). The plugin, filtering to step-type operations, logs attempt-start
+ * <p>A single step that always throws, configured with the SDK's built-in exponential-backoff retry strategy allowing 2
+ * total attempts (1 initial + 1 retry, ~1s delay). The plugin, filtering to step-type operations, logs attempt-start
  * and attempt-end (with outcome) from the real user-function hooks (which carry the 1-based attempt number) and
  * operation-end when the step reaches its terminal FAILED status.
  */

--- a/conformance-tests/src/main/java/plugin/PluginSupport.java
+++ b/conformance-tests/src/main/java/plugin/PluginSupport.java
@@ -5,16 +5,19 @@ package plugin;
 /**
  * Shared helpers for the plugin conformance handlers (requirements 10-8..10-18).
  *
- * <p>Every plugin captures the durable execution ARN from the invocation-start hook's info parameter and stamps it as
- * a top-level {@code durableExecutionArn} field on every stdout JSON record, so the runner's execution-scoped
- * CloudWatch filter ({@code $.durableExecutionArn = "<arn>"}) locates the records. These helpers only format that
- * field and classify operation types reported by the real SDK; no behavior is fabricated here.
+ * <p>Every plugin captures the durable execution ARN from the invocation-start hook's info parameter and stamps it as a
+ * top-level {@code durableExecutionArn} field on every stdout JSON record, so the runner's execution-scoped CloudWatch
+ * filter ({@code $.durableExecutionArn = "<arn>"}) locates the records. These helpers only format that field and
+ * classify operation types reported by the real SDK; no behavior is fabricated here.
  */
 final class PluginSupport {
 
     private PluginSupport() {}
 
-    /** Operation type token for step operations as reported by {@code OperationInfo#type()} (AWS SDK {@code OperationType}). */
+    /**
+     * Operation type token for step operations as reported by {@code OperationInfo#type()} (AWS SDK
+     * {@code OperationType}).
+     */
     static boolean isStep(String type) {
         return "STEP".equals(type);
     }

--- a/conformance-tests/src/main/java/plugin/PluginWaitOperationHooks.java
+++ b/conformance-tests/src/main/java/plugin/PluginWaitOperationHooks.java
@@ -16,8 +16,8 @@ import software.amazon.lambda.durable.plugin.OperationInfo;
  * 10-10: Plugin operation-start and operation-end hooks fire for wait-type operations.
  *
  * <p>A single 2-second wait. The plugin, filtering to wait-type operations, logs operation-start when the wait's
- * STARTED checkpoint is observed and operation-end with the terminal status. The type token is normalized to
- * upper-case (WAIT).
+ * STARTED checkpoint is observed and operation-end with the terminal status. The type token is normalized to upper-case
+ * (WAIT).
  */
 @SuppressWarnings("deprecation")
 public class PluginWaitOperationHooks extends DurableHandler<Object, String> {


### PR DESCRIPTION
## Summary
- apply the repository's configured Spotless formatting to six plugin conformance handlers
- restore a clean project-wide `spotless:check`
- make no behavioral changes

spotless check was failing, e.g.: https://github.com/aws/aws-durable-execution-sdk-java/actions/runs/30674290202/job/91298216229?pr=585

## Validation
- `mvn -q spotless:check` — passed
- `mvn -q -pl conformance-tests package -DskipTests` — passed
- verified the diff contains exactly the six files reported by Spotless