### PR TITLE
ci: Add issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,13 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  triage:
+    permissions:
+      issues: write
+    uses: aws/aws-durable-execution-ci/.github/workflows/issue-triage.yml@043a1a0ac3e0a7f51f92826431aea93c234ad7cd


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
Followup on https://github.com/aws/aws-durable-execution-ci/pull/6

### Description
Adds a GitHub Actions workflow that automatically triages newly opened issues by delegating to the shared reusable workflow in `aws/aws-durable-execution-ci`.

### Demo/Screenshots
N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
