### PR TITLE
ci: run spotless on every pull request

### DIFF
--- a/.github/workflows/check-spotless.yml
+++ b/.github/workflows/check-spotless.yml
@@ -5,19 +5,25 @@
 #   proper import ordering, and license headers.
 #   Fails the build if any violations are found.
 #
+#   Deliberately has no `paths` filter: `mvn spotless:check` runs across every
+#   Maven module, so filtering by path would skip the job for changes it still
+#   validates. A module missing from such a filter (e.g. otel-plugin) can merge
+#   unformatted code and then break this check on unrelated pull requests.
+#
 # Triggers:
-#   - pull_request
+#   - pull_request: every PR targeting main
+#   - push: main, to catch any formatting drift that lands
+#   - workflow_dispatch: manual run
 name: Spotless
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
-    paths:
-      - 'sdk/**'
-      - 'sdk-testing/**'
-      - 'sdk-integration-tests/**'
-      - 'examples/**'
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -429,8 +429,17 @@ class ExecutionOtelPluginTest {
         plugin.onOperationStart(
                 new OperationInfo("op-cancel", "step-cancel", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-cancel", "step-cancel", "STEP", "Step", null, Instant.now(), Instant.now(), "CANCELLED", null,
-                false, null));
+                "op-cancel",
+                "step-cancel",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "CANCELLED",
+                null,
+                false,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var operationSpan = spanByName(spanExporter.getFinishedSpanItems(), "step-cancel");
@@ -443,8 +452,17 @@ class ExecutionOtelPluginTest {
         // TIMED_OUT terminal status must NOT be stamped OK.
         plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false, Instant.now()));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-cb-timeout", "my-callback", "CALLBACK", "Callback", null, Instant.now(), Instant.now(),
-                "TIMED_OUT", null, false, null));
+                "op-cb-timeout",
+                "my-callback",
+                "CALLBACK",
+                "Callback",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "TIMED_OUT",
+                null,
+                false,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
 
         var continuationSpan = spanByName(spanExporter.getFinishedSpanItems(), "my-callback");

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -501,8 +501,17 @@ class InvocationOtelPluginTest {
         plugin.onOperationStart(
                 new OperationInfo("op-cancel", "step-cancel", "STEP", "Step", null, Instant.now(), null, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-cancel", "step-cancel", "STEP", "Step", null, Instant.now(), Instant.now(), "CANCELLED", null,
-                false, null));
+                "op-cancel",
+                "step-cancel",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "CANCELLED",
+                null,
+                false,
+                null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -520,8 +529,17 @@ class InvocationOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-cb-timeout", "my-callback", "CALLBACK", "Callback", null, Instant.now(), Instant.now(),
-                "TIMED_OUT", null, false, null));
+                "op-cb-timeout",
+                "my-callback",
+                "CALLBACK",
+                "Callback",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "TIMED_OUT",
+                null,
+                false,
+                null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 


### PR DESCRIPTION
## Problem
`spotless-check` had a `paths` filter covering only `sdk/**`, `sdk-testing/**`, `sdk-integration-tests/**`, and `examples/**`, but `mvn spotless:check --file pom.xml` validates **every** Maven module. Modules missing from that filter — `otel-plugin`, `conformance-tests`, `coverage-report` — can merge unformatted code without the job ever running, and that code then fails the check on unrelated pull requests.

This has already happened twice:

| Commit | PR | Paths touched | Gate ran? | Spotless |
|---|---|---|---|---|
| `14ad139` | #578 | `otel-plugin/`, `examples/` | yes (matched `examples/**`) | clean |
| `acfa484` | #583 | `otel-plugin/` only | **no** | **fails** |

`#583` has no `spotless-check` entry in its check-runs at all. An earlier instance under `conformance-tests/**` was fixed by #586.

## Changes
- drop the `paths` filter so the job runs on every PR targeting `main`
- add `push` on `main` so drift is caught if anything else bypasses the gate
- add `workflow_dispatch` for manual runs
- reformat the two `otel-plugin` test files that are unformatted on `main` today

The Java changes are formatting-only: with all whitespace stripped, both files are byte-identical to `main` (Palantir split long constructor argument lists across lines).

## Validation
- `mvn -B -q spotless:check --file pom.xml` — passes (fails on `main` today)
- `mvn -pl otel-plugin test` — 145 passed
- workflow YAML parses; triggers are `pull_request`, `push`, `workflow_dispatch`
- diff contains exactly the three intended files

## Tradeoff
Removing the filter means every PR runs this job, including docs-only changes. The alternative — listing all seven modules — stays targeted but silently rots the next time a module is added, which is the root cause here.
