### PR TITLE
fix(otel): align MDC log-correlation keys with JS and Python SDKs

### DIFF
--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -150,7 +150,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
-     * @param enableMdc if true, injects traceId/spanId/traceSampled into SLF4J MDC for log correlation
+     * @param enableMdc if true, injects traceId/spanId/otelTraceSampled into SLF4J MDC for log correlation
      * @param workflowSpanName the name for the Workflow root span
      */
     public ExecutionOtelPlugin(

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -165,7 +165,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
-     * @param enableMdc if true, injects traceId/spanId/traceSampled into SLF4J MDC for log correlation
+     * @param enableMdc if true, injects traceId/spanId/otelTraceSampled into SLF4J MDC for log correlation
      */
     public InvocationOtelPlugin(
             SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor, boolean enableMdc) {
@@ -177,7 +177,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      * @param contextExtractor extracts parent trace context from the Lambda environment
-     * @param enableMdc if true, injects traceId/spanId/traceSampled into SLF4J MDC for log correlation
+     * @param enableMdc if true, injects traceId/spanId/otelTraceSampled into SLF4J MDC for log correlation
      * @param workflowSpanName the name for the Workflow span
      */
     public InvocationOtelPlugin(

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
@@ -11,12 +11,12 @@ import org.slf4j.MDC;
  * <p>When used with structured logging (Log4j2 JSON, Logback JSON), these MDC fields appear in every log line, enabling
  * tools like CloudWatch Application Signals and Datadog to correlate logs with traces.
  *
- * <p>MDC keys injected:
+ * <p>MDC keys injected (aligned with the JS and Python SDK OTel plugins):
  *
  * <ul>
- *   <li>{@code trace_id} — the W3C trace ID (32 hex chars)
- *   <li>{@code span_id} — the current span ID (16 hex chars)
- *   <li>{@code traceSampled} — whether the trace is sampled (true/false)
+ *   <li>{@code traceId} — the W3C trace ID (32 hex chars)
+ *   <li>{@code spanId} — the current span ID (16 hex chars)
+ *   <li>{@code otelTraceSampled} — whether the trace is sampled (true/false)
  * </ul>
  *
  * <p>Usage: Call {@link #inject()} in {@code onUserFunctionStart} (after span is active) and {@link #clear()} in
@@ -28,9 +28,14 @@ import org.slf4j.MDC;
 @Deprecated
 public final class MdcSpanEnricher {
 
-    public static final String MDC_TRACE_ID = "trace_id";
-    public static final String MDC_SPAN_ID = "span_id";
-    public static final String MDC_TRACE_SAMPLED = "traceSampled";
+    // MDC key names are aligned with the JS and Python SDK OTel plugins
+    // (enrichLogContext -> traceId/spanId/otelTraceSampled) so log-trace
+    // correlation uses one consistent field schema across all three SDKs.
+    // Note: SLF4J MDC values are always strings, so otelTraceSampled is the
+    // string "true"/"false" here (a boolean in the JS/Python log records).
+    public static final String MDC_TRACE_ID = "traceId";
+    public static final String MDC_SPAN_ID = "spanId";
+    public static final String MDC_TRACE_SAMPLED = "otelTraceSampled";
 
     private MdcSpanEnricher() {}
 

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
@@ -21,6 +21,16 @@ class MdcSpanEnricherTest {
     }
 
     @Test
+    void mdcKeyNames_matchJsAndPythonSchema() {
+        // The JS (enrichLogContext) and Python (OtelContextLogFilter) plugins emit
+        // traceId / spanId / otelTraceSampled. Java's MDC keys must match so all
+        // three SDKs share one log-trace-correlation field schema.
+        assertEquals("traceId", MdcSpanEnricher.MDC_TRACE_ID);
+        assertEquals("spanId", MdcSpanEnricher.MDC_SPAN_ID);
+        assertEquals("otelTraceSampled", MdcSpanEnricher.MDC_TRACE_SAMPLED);
+    }
+
+    @Test
     void clear_removesAllMdcKeys() {
         MDC.put(MdcSpanEnricher.MDC_TRACE_ID, "abc123");
         MDC.put(MdcSpanEnricher.MDC_SPAN_ID, "def456");


### PR DESCRIPTION
## Issue

https://github.com/aws/aws-durable-execution-conformance-tests/issues/23#issuecomment-5185676173

## Summary

`MdcSpanEnricher` injected the MDC keys `trace_id` / `span_id` / `traceSampled`, but the **JS** (`enrichLogContext`) and **Python** (`OtelContextLogFilter`) plugins emit `traceId` / `spanId` / `otelTraceSampled`. Log↔trace correlation was therefore using two different field schemas across the SDKs (and Java's own naming was internally inconsistent — snake_case IDs but camelCase `traceSampled`).

This PR renames the three MDC keys to `traceId` / `spanId` / `otelTraceSampled` so all six plugins (JS / Python / Java × Execution / Invocation) share **one** field schema.

Both Java plugins reference these via the `MdcSpanEnricher.MDC_*` constants, so this reconciles **both** `ExecutionOtelPlugin` and `InvocationOtelPlugin` in a single change.

## Field schema (after this PR)

| | trace ID | span ID | sampled |
|---|---|---|---|
| JS (both) | `traceId` | `spanId` | `otelTraceSampled` (boolean) |
| Python (both) | `traceId` | `spanId` | `otelTraceSampled` (boolean) |
| **Java (both)** | `traceId` | `spanId` | `otelTraceSampled` (string) |

**Residual difference (inherent, documented):** SLF4J MDC stores only strings, so Java's `otelTraceSampled` is the string `"true"`/`"false"` rather than a boolean. The **key names** are now unified across all three SDKs.

## Compatibility

⚠️ This changes the MDC key names emitted into structured logs. Anyone parsing the old `trace_id` / `span_id` / `traceSampled` keys (log formatters, CloudWatch/Datadog field mappings) must update to the new names.

## Tests

+1 test asserting the exact key strings (`traceId`/`spanId`/`otelTraceSampled`); existing MDC + both plugin suites pass unchanged (they reference the constants).