### PR TITLE
feat(otel): OtelPluginConfig parameter to replace constructor overloads for configuration options

### DIFF
--- a/otel-plugin/README.md
+++ b/otel-plugin/README.md
@@ -215,21 +215,9 @@ With Lambda's `LoggingConfig: JSON` (required for durable functions), CloudWatch
 
 ## Configuration
 
-### Constructor Options
-
-```java
-// Default: ADOT Java agent global provider, X-Ray context extraction, MDC enabled
-new InvocationOtelPlugin();
-
-// Custom tracer provider pipeline
-new InvocationOtelPlugin(tracerProviderBuilder);
-
-// Custom context extractor, MDC enabled
-new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor);
-
-// Full configuration
-new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc);
-```
+Both plugins take a required `SdkTracerProviderBuilder` (your exporter/processor pipeline) plus an optional
+`OtelPluginConfig` built with a named-field builder. This replaces the older telescoping constructors, giving readable,
+type-safe call sites, and matches the `OtelPluginConfig` object in the JavaScript and Python SDKs.
 
 ### InvocationOtelPlugin
 
@@ -237,46 +225,53 @@ new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc);
 // Default: ADOT Java agent global provider, X-Ray context extraction, MDC enabled
 new InvocationOtelPlugin();
 
-// Custom tracer provider pipeline
+// Custom tracer provider pipeline, all other options defaulted
 new InvocationOtelPlugin(tracerProviderBuilder);
 
-// Custom context extractor, MDC enabled
-new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor);
-
-// Full configuration
-new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc);
+// Full configuration via the builder
+new InvocationOtelPlugin(
+    tracerProviderBuilder,
+    OtelPluginConfig.builder()
+        .contextExtractor(new XRayContextExtractor())
+        .enableMdc(true)
+        .workflowSpanName("Workflow")
+        .instrumentationName("aws-durable-execution-sdk-java")
+        .build());
 ```
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `tracerProviderBuilder` | `SdkTracerProviderBuilder` with your exporter/processor configured | Not used by `new InvocationOtelPlugin()`; the default constructor uses the ADOT Java agent provider |
-| `contextExtractor` | Extracts parent trace context from the Lambda environment | `XRayContextExtractor` |
-| `enableMdc` | If true, injects `trace_id`/`span_id`/`traceSampled` into SLF4J MDC | `true` |
 
 ### ExecutionOtelPlugin
 
-The `ExecutionOtelPlugin` renders the Workflow span as the trace root with operations as siblings of the invocation span. It supports the same constructor options:
+The `ExecutionOtelPlugin` renders the Workflow span as the trace root with operations as siblings of the invocation
+span. It takes the same `(SdkTracerProviderBuilder, OtelPluginConfig)` constructor:
 
 ```java
 // Default: ADOT Java agent global provider, X-Ray context extraction, MDC enabled
 new ExecutionOtelPlugin();
 
-// Custom tracer provider pipeline
+// Custom tracer provider pipeline, all other options defaulted
 new ExecutionOtelPlugin(tracerProviderBuilder);
 
-// Custom context extractor, MDC enabled
-new ExecutionOtelPlugin(tracerProviderBuilder, contextExtractor);
-
-// Full configuration
-new ExecutionOtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc, workflowSpanName);
+// Full configuration via the builder
+new ExecutionOtelPlugin(
+    tracerProviderBuilder,
+    OtelPluginConfig.builder()
+        .enableMdc(false)
+        .workflowSpanName("Workflow")
+        .build());
 ```
 
-| Parameter | Description | Default |
+### OtelPluginConfig options
+
+| Builder method | Description | Default |
 |-----------|-------------|---------|
-| `tracerProviderBuilder` | `SdkTracerProviderBuilder` with your exporter/processor configured | Not used by `new ExecutionOtelPlugin()`; the default constructor uses the ADOT Java agent provider |
-| `contextExtractor` | Extracts parent trace context from the Lambda environment | `XRayContextExtractor` |
-| `enableMdc` | If true, injects `trace_id`/`span_id`/`traceSampled` into SLF4J MDC | `true` |
-| `workflowSpanName` | Name for the Workflow root span | `"Workflow"` |
+| `contextExtractor(...)` | Extracts parent trace context from the Lambda environment | `new XRayContextExtractor()` |
+| `enableMdc(...)` | If true, injects `trace_id`/`span_id`/`traceSampled` into SLF4J MDC | `true` |
+| `workflowSpanName(...)` | Name for the Workflow span | `"Workflow"` |
+| `instrumentationName(...)` | Instrumentation scope name registered with the tracer | `"aws-durable-execution-sdk-java"` |
+
+> The `tracerProviderBuilder` argument is not used by the no-arg `new InvocationOtelPlugin()` /
+> `new ExecutionOtelPlugin()` constructors; those use the ADOT Java agent's global provider. A `null` passed to any
+> `OtelPluginConfig` builder setter falls back to that option's default.
 
 ## Known Limitations
 

--- a/otel-plugin/pom.xml
+++ b/otel-plugin/pom.xml
@@ -33,12 +33,18 @@
             <version>${opentelemetry.version}</version>
         </dependency>
 
-        <!-- OpenTelemetry SDK (provided — users bring their own SDK configuration) -->
+        <!-- OpenTelemetry SDK (compile — needed for the auto-configured OTLP provider default;
+             the ADOT agent / a custom builder still override it at runtime). -->
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk</artifactId>
             <version>${opentelemetry.version}</version>
-            <scope>provided</scope>
+        </dependency>
+        <!-- OTLP/HTTP span exporter for the auto-configured provider (ProviderSource.AUTO_OTLP). -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <version>${opentelemetry.version}</version>
         </dependency>
         <!-- OpenTelemetry Java agent supplies this SPI when loading OTEL_JAVAAGENT_EXTENSIONS. -->
         <dependency>

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -162,18 +162,24 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
     /**
      * Creates a Workflow-rooted OTel plugin from configuration alone (no caller-supplied tracer provider builder).
      *
-     * <p>The provider is resolved from {@link OtelPluginConfig#resolveSource()}: {@link ProviderSource#GLOBAL} when
-     * {@code useDefaultTracerProvider(true)} (the ADOT/global provider), otherwise the default
-     * {@link ProviderSource#AUTO_OTLP} — a plugin-owned OTLP/HTTP provider (matching the JavaScript and Python SDK
-     * plugins).
+     * <p>The provider is taken from {@link OtelPluginConfig#providerSource()}: {@link ProviderSource#GLOBAL} uses the
+     * ADOT/global provider, otherwise the default {@link ProviderSource#AUTO_OTLP} builds a plugin-owned OTLP/HTTP
+     * provider (matching the JavaScript and Python SDK plugins). {@link ProviderSource#EXPLICIT} is rejected here —
+     * supply a {@code SdkTracerProviderBuilder} via the two-arg constructor for that.
      *
      * @param config the plugin configuration
+     * @throws IllegalArgumentException if {@code config.providerSource()} is {@link ProviderSource#EXPLICIT}
      */
     public ExecutionOtelPlugin(OtelPluginConfig config) {
         this.contextExtractor = config.contextExtractor();
         this.enableMdc = config.enableMdc();
         this.workflowSpanName = config.workflowSpanName();
-        this.providerSource = config.resolveSource();
+        this.providerSource = config.providerSource();
+
+        if (this.providerSource == ProviderSource.EXPLICIT) {
+            throw new IllegalArgumentException("OtelPluginConfig.providerSource(EXPLICIT) requires a caller-supplied "
+                    + "SdkTracerProviderBuilder; use the (SdkTracerProviderBuilder, OtelPluginConfig) constructor.");
+        }
 
         if (this.providerSource == ProviderSource.GLOBAL) {
             this.idGenerator = OtelPluginSupport.createDefaultIdGenerator();

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -117,7 +117,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      */
     public ExecutionOtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder) {
-        this(tracerProviderBuilder, new XRayContextExtractor(), true, DEFAULT_WORKFLOW_SPAN_NAME);
+        this(tracerProviderBuilder, OtelPluginConfig.defaults());
     }
 
     /**
@@ -131,56 +131,30 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
     }
 
     /**
-     * Creates a Workflow-rooted OTel plugin with a custom context extractor, MDC enabled, root span named
-     * {@code "Workflow"}.
+     * Creates a Workflow-rooted OTel plugin from the given tracer provider builder and configuration.
+     *
+     * <p>Customers configure exporters and span processors on the builder; all other tunables (context extractor, MDC
+     * toggle, Workflow span name, instrumentation scope name) come from {@link OtelPluginConfig}. Use
+     * {@link OtelPluginConfig#builder()} for readable, named configuration:
+     *
+     * <pre>{@code
+     * var plugin = new ExecutionOtelPlugin(
+     *     SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
+     *     OtelPluginConfig.builder().enableMdc(false).workflowSpanName("Workflow").build());
+     * }</pre>
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
-     * @param contextExtractor extracts parent trace context from the Lambda environment
+     * @param config the plugin configuration
      */
-    public ExecutionOtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor) {
-        this(tracerProviderBuilder, contextExtractor, true, DEFAULT_WORKFLOW_SPAN_NAME);
-    }
-
-    /**
-     * Creates a Workflow-rooted OTel plugin with full configuration.
-     *
-     * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
-     * @param contextExtractor extracts parent trace context from the Lambda environment
-     * @param enableMdc if true, injects traceId/spanId/otelTraceSampled into SLF4J MDC for log correlation
-     * @param workflowSpanName the name for the Workflow root span
-     */
-    public ExecutionOtelPlugin(
-            SdkTracerProviderBuilder tracerProviderBuilder,
-            ContextExtractor contextExtractor,
-            boolean enableMdc,
-            String workflowSpanName) {
-        this(tracerProviderBuilder, contextExtractor, enableMdc, workflowSpanName, INSTRUMENTATION_NAME);
-    }
-
-    /**
-     * Creates an OTel plugin with full configuration, including a custom instrumentation scope name.
-     *
-     * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
-     * @param contextExtractor extracts parent trace context from the Lambda environment
-     * @param enableMdc if true, injects traceId/spanId/otelTraceSampled into SLF4J MDC for log correlation
-     * @param workflowSpanName the name for the Workflow root span
-     * @param instrumentationName the instrumentation scope name registered with the tracer (defaults to
-     *     "aws-durable-execution-sdk-java" when null)
-     */
-    public ExecutionOtelPlugin(
-            SdkTracerProviderBuilder tracerProviderBuilder,
-            ContextExtractor contextExtractor,
-            boolean enableMdc,
-            String workflowSpanName,
-            String instrumentationName) {
+    public ExecutionOtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, OtelPluginConfig config) {
         this.idGenerator = new DeterministicIdGenerator();
 
         this.sdkTracerProvider =
                 tracerProviderBuilder.setIdGenerator(idGenerator).build();
-        this.tracer = sdkTracerProvider.get(instrumentationName != null ? instrumentationName : INSTRUMENTATION_NAME);
-        this.contextExtractor = contextExtractor;
-        this.enableMdc = enableMdc;
-        this.workflowSpanName = workflowSpanName != null ? workflowSpanName : DEFAULT_WORKFLOW_SPAN_NAME;
+        this.tracer = sdkTracerProvider.get(config.instrumentationName());
+        this.contextExtractor = config.contextExtractor();
+        this.enableMdc = config.enableMdc();
+        this.workflowSpanName = config.workflowSpanName();
     }
 
     private ExecutionOtelPlugin(TracerProvider tracerProvider, DeterministicIdGenerator idGenerator) {

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -174,24 +174,12 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         this.contextExtractor = config.contextExtractor();
         this.enableMdc = config.enableMdc();
         this.workflowSpanName = config.workflowSpanName();
-        this.providerSource = config.providerSource();
 
-        if (this.providerSource == ProviderSource.EXPLICIT) {
-            throw new IllegalArgumentException("OtelPluginConfig.providerSource(EXPLICIT) requires a caller-supplied "
-                    + "SdkTracerProviderBuilder; use the (SdkTracerProviderBuilder, OtelPluginConfig) constructor.");
-        }
-
-        if (this.providerSource == ProviderSource.GLOBAL) {
-            this.idGenerator = OtelPluginSupport.createDefaultIdGenerator();
-            var tracerProvider = getDefaultTracerProvider();
-            this.sdkTracerProvider =
-                    OtelPluginSupport.getSdkTracerProviderForFlush(tracerProvider, "ExecutionOtelPlugin");
-            this.tracer = tracerProvider.get(config.instrumentationName());
-        } else {
-            this.idGenerator = new DeterministicIdGenerator();
-            this.sdkTracerProvider = OtelPluginSupport.buildAutoOtlpProvider(config, this.idGenerator, null);
-            this.tracer = this.sdkTracerProvider.get(config.instrumentationName());
-        }
+        var setup = OtelPluginSupport.resolveConfiguredProvider(config, "ExecutionOtelPlugin");
+        this.providerSource = setup.source();
+        this.idGenerator = setup.idGenerator();
+        this.sdkTracerProvider = setup.sdkTracerProvider();
+        this.tracer = setup.tracer();
     }
 
     private ExecutionOtelPlugin(TracerProvider tracerProvider, DeterministicIdGenerator idGenerator) {

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -91,6 +91,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
     private final ContextExtractor contextExtractor;
     private final boolean enableMdc;
     private final String workflowSpanName;
+    private final ProviderSource providerSource;
 
     // Per-invocation state
     private volatile Span workflowSpan;
@@ -155,6 +156,36 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         this.contextExtractor = config.contextExtractor();
         this.enableMdc = config.enableMdc();
         this.workflowSpanName = config.workflowSpanName();
+        this.providerSource = ProviderSource.EXPLICIT;
+    }
+
+    /**
+     * Creates a Workflow-rooted OTel plugin from configuration alone (no caller-supplied tracer provider builder).
+     *
+     * <p>The provider is resolved from {@link OtelPluginConfig#resolveSource()}: {@link ProviderSource#GLOBAL} when
+     * {@code useDefaultTracerProvider(true)} (the ADOT/global provider), otherwise the default
+     * {@link ProviderSource#AUTO_OTLP} — a plugin-owned OTLP/HTTP provider (matching the JavaScript and Python SDK
+     * plugins).
+     *
+     * @param config the plugin configuration
+     */
+    public ExecutionOtelPlugin(OtelPluginConfig config) {
+        this.contextExtractor = config.contextExtractor();
+        this.enableMdc = config.enableMdc();
+        this.workflowSpanName = config.workflowSpanName();
+        this.providerSource = config.resolveSource();
+
+        if (this.providerSource == ProviderSource.GLOBAL) {
+            this.idGenerator = OtelPluginSupport.createDefaultIdGenerator();
+            var tracerProvider = getDefaultTracerProvider();
+            this.sdkTracerProvider =
+                    OtelPluginSupport.getSdkTracerProviderForFlush(tracerProvider, "ExecutionOtelPlugin");
+            this.tracer = tracerProvider.get(config.instrumentationName());
+        } else {
+            this.idGenerator = new DeterministicIdGenerator();
+            this.sdkTracerProvider = OtelPluginSupport.buildAutoOtlpProvider(config, this.idGenerator, null);
+            this.tracer = this.sdkTracerProvider.get(config.instrumentationName());
+        }
     }
 
     private ExecutionOtelPlugin(TracerProvider tracerProvider, DeterministicIdGenerator idGenerator) {
@@ -165,6 +196,12 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         this.contextExtractor = new XRayContextExtractor();
         this.enableMdc = true;
         this.workflowSpanName = DEFAULT_WORKFLOW_SPAN_NAME;
+        this.providerSource = ProviderSource.GLOBAL;
+    }
+
+    /** The tier that produced this plugin's tracer provider. */
+    public ProviderSource providerSource() {
+        return providerSource;
     }
 
     // ─── Invocation hooks ────────────────────────────────────────────────

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -13,7 +13,6 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -82,8 +81,6 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
 public class ExecutionOtelPlugin implements DurableExecutionPlugin {
 
     private static final Logger logger = LoggerFactory.getLogger(ExecutionOtelPlugin.class);
-    private static final String INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
-    private static final String DEFAULT_WORKFLOW_SPAN_NAME = "Workflow";
 
     private final SdkTracerProvider sdkTracerProvider;
     private final Tracer tracer;
@@ -128,7 +125,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
      * {@code OtelPluginAutoConfigurationCustomizerProvider}.
      */
     public ExecutionOtelPlugin() {
-        this(getDefaultTracerProvider(), createDefaultIdGenerator());
+        this(OtelPluginConfig.defaults());
     }
 
     /**
@@ -180,17 +177,6 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         this.idGenerator = setup.idGenerator();
         this.sdkTracerProvider = setup.sdkTracerProvider();
         this.tracer = setup.tracer();
-    }
-
-    private ExecutionOtelPlugin(TracerProvider tracerProvider, DeterministicIdGenerator idGenerator) {
-        this.idGenerator = idGenerator;
-        this.sdkTracerProvider = OtelPluginSupport.getSdkTracerProviderForFlush(tracerProvider, "ExecutionOtelPlugin");
-        this.tracer = tracerProvider.get(INSTRUMENTATION_NAME);
-
-        this.contextExtractor = new XRayContextExtractor();
-        this.enableMdc = true;
-        this.workflowSpanName = DEFAULT_WORKFLOW_SPAN_NAME;
-        this.providerSource = ProviderSource.GLOBAL;
     }
 
     /** The tier that produced this plugin's tracer provider. */
@@ -601,13 +587,5 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
 
     private static ExtractedContext extractCurrentSpanContext() {
         return OtelPluginSupport.extractCurrentSpanContext();
-    }
-
-    private static TracerProvider getDefaultTracerProvider() {
-        return OtelPluginSupport.getDefaultTracerProvider("ExecutionOtelPlugin");
-    }
-
-    private static DeterministicIdGenerator createDefaultIdGenerator() {
-        return OtelPluginSupport.createDefaultIdGenerator();
     }
 }

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -158,6 +158,25 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
             ContextExtractor contextExtractor,
             boolean enableMdc,
             String workflowSpanName) {
+        this(tracerProviderBuilder, contextExtractor, enableMdc, workflowSpanName, INSTRUMENTATION_NAME);
+    }
+
+    /**
+     * Creates an OTel plugin with full configuration, including a custom instrumentation scope name.
+     *
+     * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
+     * @param contextExtractor extracts parent trace context from the Lambda environment
+     * @param enableMdc if true, injects traceId/spanId/otelTraceSampled into SLF4J MDC for log correlation
+     * @param workflowSpanName the name for the Workflow root span
+     * @param instrumentationName the instrumentation scope name registered with the tracer (defaults to
+     *     "aws-durable-execution-sdk-java" when null)
+     */
+    public ExecutionOtelPlugin(
+            SdkTracerProviderBuilder tracerProviderBuilder,
+            ContextExtractor contextExtractor,
+            boolean enableMdc,
+            String workflowSpanName,
+            String instrumentationName) {
         this.idGenerator = new DeterministicIdGenerator();
 
         // Set service.name so this plugin's spans group under a distinct "workflow" node in X-Ray/OTLP backends.
@@ -166,7 +185,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
 
         this.sdkTracerProvider =
                 tracerProviderBuilder.setIdGenerator(idGenerator).build();
-        this.tracer = sdkTracerProvider.get(INSTRUMENTATION_NAME);
+        this.tracer = sdkTracerProvider.get(instrumentationName != null ? instrumentationName : INSTRUMENTATION_NAME);
         this.contextExtractor = contextExtractor;
         this.enableMdc = enableMdc;
         this.workflowSpanName = workflowSpanName != null ? workflowSpanName : DEFAULT_WORKFLOW_SPAN_NAME;

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -185,11 +185,30 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
             ContextExtractor contextExtractor,
             boolean enableMdc,
             String workflowSpanName) {
+        this(tracerProviderBuilder, contextExtractor, enableMdc, workflowSpanName, INSTRUMENTATION_NAME);
+    }
+
+    /**
+     * Creates an OTel plugin with full configuration, including a custom instrumentation scope name.
+     *
+     * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
+     * @param contextExtractor extracts parent trace context from the Lambda environment
+     * @param enableMdc if true, injects traceId/spanId/otelTraceSampled into SLF4J MDC for log correlation
+     * @param workflowSpanName the name for the Workflow span
+     * @param instrumentationName the instrumentation scope name registered with the tracer (defaults to
+     *     "aws-durable-execution-sdk-java" when null)
+     */
+    public InvocationOtelPlugin(
+            SdkTracerProviderBuilder tracerProviderBuilder,
+            ContextExtractor contextExtractor,
+            boolean enableMdc,
+            String workflowSpanName,
+            String instrumentationName) {
         this.idGenerator = new DeterministicIdGenerator();
 
         this.sdkTracerProvider =
                 tracerProviderBuilder.setIdGenerator(idGenerator).build();
-        this.tracer = sdkTracerProvider.get(INSTRUMENTATION_NAME);
+        this.tracer = sdkTracerProvider.get(instrumentationName != null ? instrumentationName : INSTRUMENTATION_NAME);
         this.contextExtractor = contextExtractor;
         this.enableMdc = enableMdc;
         this.workflowSpanName = workflowSpanName != null ? workflowSpanName : DEFAULT_WORKFLOW_SPAN_NAME;

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -194,24 +194,12 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         this.contextExtractor = config.contextExtractor();
         this.enableMdc = config.enableMdc();
         this.workflowSpanName = config.workflowSpanName();
-        this.providerSource = config.providerSource();
 
-        if (this.providerSource == ProviderSource.EXPLICIT) {
-            throw new IllegalArgumentException("OtelPluginConfig.providerSource(EXPLICIT) requires a caller-supplied "
-                    + "SdkTracerProviderBuilder; use the (SdkTracerProviderBuilder, OtelPluginConfig) constructor.");
-        }
-
-        if (this.providerSource == ProviderSource.GLOBAL) {
-            this.idGenerator = OtelPluginSupport.createDefaultIdGenerator();
-            var tracerProvider = getDefaultTracerProvider();
-            this.sdkTracerProvider =
-                    OtelPluginSupport.getSdkTracerProviderForFlush(tracerProvider, "InvocationOtelPlugin");
-            this.tracer = tracerProvider.get(config.instrumentationName());
-        } else {
-            this.idGenerator = new DeterministicIdGenerator();
-            this.sdkTracerProvider = OtelPluginSupport.buildAutoOtlpProvider(config, this.idGenerator, null);
-            this.tracer = this.sdkTracerProvider.get(config.instrumentationName());
-        }
+        var setup = OtelPluginSupport.resolveConfiguredProvider(config, "InvocationOtelPlugin");
+        this.providerSource = setup.source();
+        this.idGenerator = setup.idGenerator();
+        this.sdkTracerProvider = setup.sdkTracerProvider();
+        this.tracer = setup.tracer();
     }
 
     private InvocationOtelPlugin(TracerProvider tracerProvider, DeterministicIdGenerator idGenerator) {

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -103,6 +103,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
     private final ContextExtractor contextExtractor;
     private final boolean enableMdc;
     private final String workflowSpanName;
+    private final ProviderSource providerSource;
 
     // Per-invocation state
     private volatile Span workflowSpan;
@@ -175,6 +176,36 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         this.contextExtractor = config.contextExtractor();
         this.enableMdc = config.enableMdc();
         this.workflowSpanName = config.workflowSpanName();
+        this.providerSource = ProviderSource.EXPLICIT;
+    }
+
+    /**
+     * Creates an OTel plugin from configuration alone (no caller-supplied tracer provider builder).
+     *
+     * <p>The provider is resolved from {@link OtelPluginConfig#resolveSource()}: {@link ProviderSource#GLOBAL} when
+     * {@code useDefaultTracerProvider(true)} (the ADOT/global provider), otherwise the default
+     * {@link ProviderSource#AUTO_OTLP} — a plugin-owned OTLP/HTTP provider (matching the JavaScript and Python SDK
+     * plugins).
+     *
+     * @param config the plugin configuration
+     */
+    public InvocationOtelPlugin(OtelPluginConfig config) {
+        this.contextExtractor = config.contextExtractor();
+        this.enableMdc = config.enableMdc();
+        this.workflowSpanName = config.workflowSpanName();
+        this.providerSource = config.resolveSource();
+
+        if (this.providerSource == ProviderSource.GLOBAL) {
+            this.idGenerator = OtelPluginSupport.createDefaultIdGenerator();
+            var tracerProvider = getDefaultTracerProvider();
+            this.sdkTracerProvider =
+                    OtelPluginSupport.getSdkTracerProviderForFlush(tracerProvider, "InvocationOtelPlugin");
+            this.tracer = tracerProvider.get(config.instrumentationName());
+        } else {
+            this.idGenerator = new DeterministicIdGenerator();
+            this.sdkTracerProvider = OtelPluginSupport.buildAutoOtlpProvider(config, this.idGenerator, null);
+            this.tracer = this.sdkTracerProvider.get(config.instrumentationName());
+        }
     }
 
     private InvocationOtelPlugin(TracerProvider tracerProvider, DeterministicIdGenerator idGenerator) {
@@ -185,6 +216,12 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         this.contextExtractor = new XRayContextExtractor();
         this.enableMdc = true;
         this.workflowSpanName = DEFAULT_WORKFLOW_SPAN_NAME;
+        this.providerSource = ProviderSource.GLOBAL;
+    }
+
+    /** The tier that produced this plugin's tracer provider. */
+    public ProviderSource providerSource() {
+        return providerSource;
     }
 
     // ─── Invocation hooks ────────────────────────────────────────────────

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -182,18 +182,24 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
     /**
      * Creates an OTel plugin from configuration alone (no caller-supplied tracer provider builder).
      *
-     * <p>The provider is resolved from {@link OtelPluginConfig#resolveSource()}: {@link ProviderSource#GLOBAL} when
-     * {@code useDefaultTracerProvider(true)} (the ADOT/global provider), otherwise the default
-     * {@link ProviderSource#AUTO_OTLP} — a plugin-owned OTLP/HTTP provider (matching the JavaScript and Python SDK
-     * plugins).
+     * <p>The provider is taken from {@link OtelPluginConfig#providerSource()}: {@link ProviderSource#GLOBAL} uses the
+     * ADOT/global provider, otherwise the default {@link ProviderSource#AUTO_OTLP} builds a plugin-owned OTLP/HTTP
+     * provider (matching the JavaScript and Python SDK plugins). {@link ProviderSource#EXPLICIT} is rejected here —
+     * supply a {@code SdkTracerProviderBuilder} via the two-arg constructor for that.
      *
      * @param config the plugin configuration
+     * @throws IllegalArgumentException if {@code config.providerSource()} is {@link ProviderSource#EXPLICIT}
      */
     public InvocationOtelPlugin(OtelPluginConfig config) {
         this.contextExtractor = config.contextExtractor();
         this.enableMdc = config.enableMdc();
         this.workflowSpanName = config.workflowSpanName();
-        this.providerSource = config.resolveSource();
+        this.providerSource = config.providerSource();
+
+        if (this.providerSource == ProviderSource.EXPLICIT) {
+            throw new IllegalArgumentException("OtelPluginConfig.providerSource(EXPLICIT) requires a caller-supplied "
+                    + "SdkTracerProviderBuilder; use the (SdkTracerProviderBuilder, OtelPluginConfig) constructor.");
+        }
 
         if (this.providerSource == ProviderSource.GLOBAL) {
             this.idGenerator = OtelPluginSupport.createDefaultIdGenerator();

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -13,7 +13,6 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -94,8 +93,6 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
 public class InvocationOtelPlugin implements DurableExecutionPlugin {
 
     private static final Logger logger = LoggerFactory.getLogger(InvocationOtelPlugin.class);
-    private static final String INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
-    private static final String DEFAULT_WORKFLOW_SPAN_NAME = "Workflow";
 
     private final SdkTracerProvider sdkTracerProvider;
     private final Tracer tracer;
@@ -148,7 +145,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
      * {@code OtelPluginAutoConfigurationCustomizerProvider}.
      */
     public InvocationOtelPlugin() {
-        this(getDefaultTracerProvider(), createDefaultIdGenerator());
+        this(OtelPluginConfig.defaults());
     }
 
     /**
@@ -200,17 +197,6 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         this.idGenerator = setup.idGenerator();
         this.sdkTracerProvider = setup.sdkTracerProvider();
         this.tracer = setup.tracer();
-    }
-
-    private InvocationOtelPlugin(TracerProvider tracerProvider, DeterministicIdGenerator idGenerator) {
-        this.idGenerator = idGenerator;
-        this.sdkTracerProvider = OtelPluginSupport.getSdkTracerProviderForFlush(tracerProvider, "InvocationOtelPlugin");
-        this.tracer = tracerProvider.get(INSTRUMENTATION_NAME);
-
-        this.contextExtractor = new XRayContextExtractor();
-        this.enableMdc = true;
-        this.workflowSpanName = DEFAULT_WORKFLOW_SPAN_NAME;
-        this.providerSource = ProviderSource.GLOBAL;
     }
 
     /** The tier that produced this plugin's tracer provider. */
@@ -657,13 +643,5 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
 
     private static ExtractedContext extractCurrentSpanContext() {
         return OtelPluginSupport.extractCurrentSpanContext();
-    }
-
-    private static TracerProvider getDefaultTracerProvider() {
-        return OtelPluginSupport.getDefaultTracerProvider("InvocationOtelPlugin");
-    }
-
-    private static DeterministicIdGenerator createDefaultIdGenerator() {
-        return OtelPluginSupport.createDefaultIdGenerator();
     }
 }

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -137,7 +137,7 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
      */
     public InvocationOtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder) {
-        this(tracerProviderBuilder, new XRayContextExtractor(), true);
+        this(tracerProviderBuilder, OtelPluginConfig.defaults());
     }
 
     /**
@@ -151,67 +151,30 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
     }
 
     /**
-     * Creates an OTel plugin with a custom context extractor, MDC enabled.
+     * Creates an OTel plugin from the given tracer provider builder and configuration.
+     *
+     * <p>Customers configure exporters and span processors on the builder; all other tunables (context extractor, MDC
+     * toggle, Workflow span name, instrumentation scope name) come from {@link OtelPluginConfig}. Use
+     * {@link OtelPluginConfig#builder()} for readable, named configuration:
+     *
+     * <pre>{@code
+     * var plugin = new InvocationOtelPlugin(
+     *     SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
+     *     OtelPluginConfig.builder().enableMdc(false).workflowSpanName("Workflow").build());
+     * }</pre>
      *
      * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
-     * @param contextExtractor extracts parent trace context from the Lambda environment
+     * @param config the plugin configuration
      */
-    public InvocationOtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor) {
-        this(tracerProviderBuilder, contextExtractor, true);
-    }
-
-    /**
-     * Creates an OTel plugin with the given context extractor and MDC setting, using the default Workflow span name.
-     *
-     * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
-     * @param contextExtractor extracts parent trace context from the Lambda environment
-     * @param enableMdc if true, injects traceId/spanId/otelTraceSampled into SLF4J MDC for log correlation
-     */
-    public InvocationOtelPlugin(
-            SdkTracerProviderBuilder tracerProviderBuilder, ContextExtractor contextExtractor, boolean enableMdc) {
-        this(tracerProviderBuilder, contextExtractor, enableMdc, DEFAULT_WORKFLOW_SPAN_NAME);
-    }
-
-    /**
-     * Creates an OTel plugin with full configuration.
-     *
-     * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
-     * @param contextExtractor extracts parent trace context from the Lambda environment
-     * @param enableMdc if true, injects traceId/spanId/otelTraceSampled into SLF4J MDC for log correlation
-     * @param workflowSpanName the name for the Workflow span
-     */
-    public InvocationOtelPlugin(
-            SdkTracerProviderBuilder tracerProviderBuilder,
-            ContextExtractor contextExtractor,
-            boolean enableMdc,
-            String workflowSpanName) {
-        this(tracerProviderBuilder, contextExtractor, enableMdc, workflowSpanName, INSTRUMENTATION_NAME);
-    }
-
-    /**
-     * Creates an OTel plugin with full configuration, including a custom instrumentation scope name.
-     *
-     * @param tracerProviderBuilder the tracer provider builder (ID generator will be overridden)
-     * @param contextExtractor extracts parent trace context from the Lambda environment
-     * @param enableMdc if true, injects traceId/spanId/otelTraceSampled into SLF4J MDC for log correlation
-     * @param workflowSpanName the name for the Workflow span
-     * @param instrumentationName the instrumentation scope name registered with the tracer (defaults to
-     *     "aws-durable-execution-sdk-java" when null)
-     */
-    public InvocationOtelPlugin(
-            SdkTracerProviderBuilder tracerProviderBuilder,
-            ContextExtractor contextExtractor,
-            boolean enableMdc,
-            String workflowSpanName,
-            String instrumentationName) {
+    public InvocationOtelPlugin(SdkTracerProviderBuilder tracerProviderBuilder, OtelPluginConfig config) {
         this.idGenerator = new DeterministicIdGenerator();
 
         this.sdkTracerProvider =
                 tracerProviderBuilder.setIdGenerator(idGenerator).build();
-        this.tracer = sdkTracerProvider.get(instrumentationName != null ? instrumentationName : INSTRUMENTATION_NAME);
-        this.contextExtractor = contextExtractor;
-        this.enableMdc = enableMdc;
-        this.workflowSpanName = workflowSpanName != null ? workflowSpanName : DEFAULT_WORKFLOW_SPAN_NAME;
+        this.tracer = sdkTracerProvider.get(config.instrumentationName());
+        this.contextExtractor = config.contextExtractor();
+        this.enableMdc = config.enableMdc();
+        this.workflowSpanName = config.workflowSpanName();
     }
 
     private InvocationOtelPlugin(TracerProvider tracerProvider, DeterministicIdGenerator idGenerator) {

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginConfig.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginConfig.java
@@ -26,8 +26,8 @@ import java.util.Map;
  * }</pre>
  *
  * <p>Defaults: {@code contextExtractor = new XRayContextExtractor()}, {@code enableMdc = true}, {@code workflowSpanName
- * = "Workflow"}, {@code instrumentationName = "aws-durable-execution-sdk-java"}. A {@code null} passed to any builder
- * setter falls back to the corresponding default.
+ * = "Workflow"}, {@code instrumentationName = "aws-durable-execution-sdk-java"}, {@code providerSource =
+ * ProviderSource.AUTO_OTLP}. A {@code null} passed to any builder setter falls back to the corresponding default.
  *
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
@@ -41,7 +41,7 @@ public final class OtelPluginConfig {
     private final boolean enableMdc;
     private final String workflowSpanName;
     private final String instrumentationName;
-    private final boolean useDefaultTracerProvider;
+    private final ProviderSource providerSource;
     private final String otlpEndpoint;
     private final Map<String, String> otlpHeaders;
 
@@ -53,7 +53,7 @@ public final class OtelPluginConfig {
                 builder.workflowSpanName != null ? builder.workflowSpanName : DEFAULT_WORKFLOW_SPAN_NAME;
         this.instrumentationName =
                 builder.instrumentationName != null ? builder.instrumentationName : DEFAULT_INSTRUMENTATION_NAME;
-        this.useDefaultTracerProvider = builder.useDefaultTracerProvider;
+        this.providerSource = builder.providerSource != null ? builder.providerSource : ProviderSource.AUTO_OTLP;
         this.otlpEndpoint = builder.otlpEndpoint;
         this.otlpHeaders = builder.otlpHeaders != null ? Map.copyOf(builder.otlpHeaders) : Map.of();
     }
@@ -89,11 +89,15 @@ public final class OtelPluginConfig {
     }
 
     /**
-     * Whether to use the globally configured (ADOT) provider instead of an auto-configured OTLP provider. Only
-     * consulted when no {@code SdkTracerProviderBuilder} was supplied. Defaults to {@code false}.
+     * The tracer-provider source to use when no {@code SdkTracerProviderBuilder} is supplied (the config-only
+     * constructors). {@link ProviderSource#GLOBAL} uses the globally configured (ADOT) provider;
+     * {@link ProviderSource#AUTO_OTLP} (the default) makes the plugin build and own an OTLP/HTTP provider.
+     *
+     * <p>{@link ProviderSource#EXPLICIT} is not valid here — it is implied by using a {@code (SdkTracerProviderBuilder,
+     * OtelPluginConfig)} constructor and is rejected by the config-only constructors.
      */
-    public boolean useDefaultTracerProvider() {
-        return useDefaultTracerProvider;
+    public ProviderSource providerSource() {
+        return providerSource;
     }
 
     /** OTLP/HTTP endpoint for the auto-configured provider, or {@code null} to use the OTel default / env var. */
@@ -104,17 +108,6 @@ public final class OtelPluginConfig {
     /** Extra headers sent by the auto-configured OTLP exporter (never {@code null}). */
     public Map<String, String> otlpHeaders() {
         return otlpHeaders;
-    }
-
-    /**
-     * The provider source selected by this config when no {@code SdkTracerProviderBuilder} is supplied.
-     *
-     * <p>Returns {@link ProviderSource#GLOBAL} when {@link #useDefaultTracerProvider()} is true, otherwise
-     * {@link ProviderSource#AUTO_OTLP}. (A supplied builder is always {@link ProviderSource#EXPLICIT}, decided by the
-     * constructor rather than the config.)
-     */
-    public ProviderSource resolveSource() {
-        return useDefaultTracerProvider ? ProviderSource.GLOBAL : ProviderSource.AUTO_OTLP;
     }
 
     /**
@@ -129,7 +122,7 @@ public final class OtelPluginConfig {
         private boolean enableMdc = true;
         private String workflowSpanName;
         private String instrumentationName;
-        private boolean useDefaultTracerProvider = false;
+        private ProviderSource providerSource = ProviderSource.AUTO_OTLP;
         private String otlpEndpoint;
         private Map<String, String> otlpHeaders;
 
@@ -181,14 +174,18 @@ public final class OtelPluginConfig {
         }
 
         /**
-         * Sets whether to use the globally configured (ADOT) provider instead of an auto-configured OTLP provider. Only
-         * consulted when no {@code SdkTracerProviderBuilder} is supplied. Defaults to {@code false} (auto-OTLP).
+         * Sets the tracer-provider source used when no {@code SdkTracerProviderBuilder} is supplied. Defaults to
+         * {@link ProviderSource#AUTO_OTLP} (a plugin-owned OTLP/HTTP provider); pass {@link ProviderSource#GLOBAL} to
+         * use the globally configured (ADOT) provider. A {@code null} falls back to {@link ProviderSource#AUTO_OTLP}.
          *
-         * @param useDefaultTracerProvider if true, resolve to {@link ProviderSource#GLOBAL}
+         * <p>{@link ProviderSource#EXPLICIT} is not accepted through the config-only constructors — supply a
+         * {@code SdkTracerProviderBuilder} via the two-arg constructor instead.
+         *
+         * @param providerSource the provider source, {@link ProviderSource#GLOBAL} or {@link ProviderSource#AUTO_OTLP}
          * @return this builder
          */
-        public Builder useDefaultTracerProvider(boolean useDefaultTracerProvider) {
-            this.useDefaultTracerProvider = useDefaultTracerProvider;
+        public Builder providerSource(ProviderSource providerSource) {
+            this.providerSource = providerSource != null ? providerSource : ProviderSource.AUTO_OTLP;
             return this;
         }
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginConfig.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginConfig.java
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.otel;
 
+import java.util.Map;
+
 /**
  * Immutable configuration for {@link InvocationOtelPlugin} and {@link ExecutionOtelPlugin}.
  *
@@ -39,6 +41,9 @@ public final class OtelPluginConfig {
     private final boolean enableMdc;
     private final String workflowSpanName;
     private final String instrumentationName;
+    private final boolean useDefaultTracerProvider;
+    private final String otlpEndpoint;
+    private final Map<String, String> otlpHeaders;
 
     private OtelPluginConfig(Builder builder) {
         this.contextExtractor =
@@ -48,6 +53,9 @@ public final class OtelPluginConfig {
                 builder.workflowSpanName != null ? builder.workflowSpanName : DEFAULT_WORKFLOW_SPAN_NAME;
         this.instrumentationName =
                 builder.instrumentationName != null ? builder.instrumentationName : DEFAULT_INSTRUMENTATION_NAME;
+        this.useDefaultTracerProvider = builder.useDefaultTracerProvider;
+        this.otlpEndpoint = builder.otlpEndpoint;
+        this.otlpHeaders = builder.otlpHeaders != null ? Map.copyOf(builder.otlpHeaders) : Map.of();
     }
 
     /** Returns a new builder with all fields defaulted. */
@@ -81,6 +89,35 @@ public final class OtelPluginConfig {
     }
 
     /**
+     * Whether to use the globally configured (ADOT) provider instead of an auto-configured OTLP provider. Only
+     * consulted when no {@code SdkTracerProviderBuilder} was supplied. Defaults to {@code false}.
+     */
+    public boolean useDefaultTracerProvider() {
+        return useDefaultTracerProvider;
+    }
+
+    /** OTLP/HTTP endpoint for the auto-configured provider, or {@code null} to use the OTel default / env var. */
+    public String otlpEndpoint() {
+        return otlpEndpoint;
+    }
+
+    /** Extra headers sent by the auto-configured OTLP exporter (never {@code null}). */
+    public Map<String, String> otlpHeaders() {
+        return otlpHeaders;
+    }
+
+    /**
+     * The provider source selected by this config when no {@code SdkTracerProviderBuilder} is supplied.
+     *
+     * <p>Returns {@link ProviderSource#GLOBAL} when {@link #useDefaultTracerProvider()} is true, otherwise
+     * {@link ProviderSource#AUTO_OTLP}. (A supplied builder is always {@link ProviderSource#EXPLICIT}, decided by the
+     * constructor rather than the config.)
+     */
+    public ProviderSource resolveSource() {
+        return useDefaultTracerProvider ? ProviderSource.GLOBAL : ProviderSource.AUTO_OTLP;
+    }
+
+    /**
      * Builder for {@link OtelPluginConfig}.
      *
      * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
@@ -92,6 +129,9 @@ public final class OtelPluginConfig {
         private boolean enableMdc = true;
         private String workflowSpanName;
         private String instrumentationName;
+        private boolean useDefaultTracerProvider = false;
+        private String otlpEndpoint;
+        private Map<String, String> otlpHeaders;
 
         private Builder() {}
 
@@ -137,6 +177,41 @@ public final class OtelPluginConfig {
          */
         public Builder instrumentationName(String instrumentationName) {
             this.instrumentationName = instrumentationName;
+            return this;
+        }
+
+        /**
+         * Sets whether to use the globally configured (ADOT) provider instead of an auto-configured OTLP provider. Only
+         * consulted when no {@code SdkTracerProviderBuilder} is supplied. Defaults to {@code false} (auto-OTLP).
+         *
+         * @param useDefaultTracerProvider if true, resolve to {@link ProviderSource#GLOBAL}
+         * @return this builder
+         */
+        public Builder useDefaultTracerProvider(boolean useDefaultTracerProvider) {
+            this.useDefaultTracerProvider = useDefaultTracerProvider;
+            return this;
+        }
+
+        /**
+         * Sets the OTLP/HTTP endpoint for the auto-configured provider. When null, the OTel default (or
+         * {@code OTEL_EXPORTER_OTLP_ENDPOINT}) is used.
+         *
+         * @param otlpEndpoint the OTLP/HTTP traces endpoint
+         * @return this builder
+         */
+        public Builder otlpEndpoint(String otlpEndpoint) {
+            this.otlpEndpoint = otlpEndpoint;
+            return this;
+        }
+
+        /**
+         * Sets extra headers for the auto-configured OTLP exporter (e.g. auth headers for a third-party endpoint).
+         *
+         * @param otlpHeaders header name/value pairs; null is treated as empty
+         * @return this builder
+         */
+        public Builder otlpHeaders(Map<String, String> otlpHeaders) {
+            this.otlpHeaders = otlpHeaders;
             return this;
         }
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginConfig.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginConfig.java
@@ -27,7 +27,7 @@ import java.util.Map;
  *
  * <p>Defaults: {@code contextExtractor = new XRayContextExtractor()}, {@code enableMdc = true}, {@code workflowSpanName
  * = "Workflow"}, {@code instrumentationName = "aws-durable-execution-sdk-java"}, {@code providerSource =
- * ProviderSource.AUTO_OTLP}. A {@code null} passed to any builder setter falls back to the corresponding default.
+ * ProviderSource.GLOBAL}. A {@code null} passed to any builder setter falls back to the corresponding default.
  *
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
@@ -53,7 +53,7 @@ public final class OtelPluginConfig {
                 builder.workflowSpanName != null ? builder.workflowSpanName : DEFAULT_WORKFLOW_SPAN_NAME;
         this.instrumentationName =
                 builder.instrumentationName != null ? builder.instrumentationName : DEFAULT_INSTRUMENTATION_NAME;
-        this.providerSource = builder.providerSource != null ? builder.providerSource : ProviderSource.AUTO_OTLP;
+        this.providerSource = builder.providerSource != null ? builder.providerSource : ProviderSource.GLOBAL;
         this.otlpEndpoint = builder.otlpEndpoint;
         this.otlpHeaders = builder.otlpHeaders != null ? Map.copyOf(builder.otlpHeaders) : Map.of();
     }
@@ -90,8 +90,8 @@ public final class OtelPluginConfig {
 
     /**
      * The tracer-provider source to use when no {@code SdkTracerProviderBuilder} is supplied (the config-only
-     * constructors). {@link ProviderSource#GLOBAL} uses the globally configured (ADOT) provider;
-     * {@link ProviderSource#AUTO_OTLP} (the default) makes the plugin build and own an OTLP/HTTP provider.
+     * constructors). {@link ProviderSource#GLOBAL} (the default) uses the globally configured (ADOT) provider;
+     * {@link ProviderSource#AUTO_OTLP} makes the plugin build and own an OTLP/HTTP provider.
      *
      * <p>{@link ProviderSource#EXPLICIT} is not valid here — it is implied by using a {@code (SdkTracerProviderBuilder,
      * OtelPluginConfig)} constructor and is rejected by the config-only constructors.
@@ -122,7 +122,7 @@ public final class OtelPluginConfig {
         private boolean enableMdc = true;
         private String workflowSpanName;
         private String instrumentationName;
-        private ProviderSource providerSource = ProviderSource.AUTO_OTLP;
+        private ProviderSource providerSource = ProviderSource.GLOBAL;
         private String otlpEndpoint;
         private Map<String, String> otlpHeaders;
 
@@ -175,8 +175,9 @@ public final class OtelPluginConfig {
 
         /**
          * Sets the tracer-provider source used when no {@code SdkTracerProviderBuilder} is supplied. Defaults to
-         * {@link ProviderSource#AUTO_OTLP} (a plugin-owned OTLP/HTTP provider); pass {@link ProviderSource#GLOBAL} to
-         * use the globally configured (ADOT) provider. A {@code null} falls back to {@link ProviderSource#AUTO_OTLP}.
+         * {@link ProviderSource#GLOBAL} (the globally configured ADOT provider); pass {@link ProviderSource#AUTO_OTLP}
+         * to make the plugin build and own an OTLP/HTTP provider. A {@code null} falls back to
+         * {@link ProviderSource#GLOBAL}.
          *
          * <p>{@link ProviderSource#EXPLICIT} is not accepted through the config-only constructors — supply a
          * {@code SdkTracerProviderBuilder} via the two-arg constructor instead.
@@ -185,7 +186,7 @@ public final class OtelPluginConfig {
          * @return this builder
          */
         public Builder providerSource(ProviderSource providerSource) {
-            this.providerSource = providerSource != null ? providerSource : ProviderSource.AUTO_OTLP;
+            this.providerSource = providerSource != null ? providerSource : ProviderSource.GLOBAL;
             return this;
         }
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginConfig.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginConfig.java
@@ -1,0 +1,148 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.otel;
+
+/**
+ * Immutable configuration for {@link InvocationOtelPlugin} and {@link ExecutionOtelPlugin}.
+ *
+ * <p>Replaces the previous telescoping constructor overloads with a single named-field builder, giving readable,
+ * type-safe call sites and forward compatibility (new options are added as builder methods, not new constructors). This
+ * mirrors the {@code OtelPluginConfig} object in the JavaScript SDK and the {@code OtelPluginConfig} dataclass in the
+ * Python SDK for cross-SDK parity.
+ *
+ * <p>Construct via {@link #builder()} and pass to a plugin's {@code (SdkTracerProviderBuilder, OtelPluginConfig)}
+ * constructor:
+ *
+ * <pre>{@code
+ * var config = OtelPluginConfig.builder()
+ *     .contextExtractor(new XRayContextExtractor())
+ *     .enableMdc(true)
+ *     .workflowSpanName("Workflow")
+ *     .instrumentationName("my-scope")
+ *     .build();
+ * var plugin = new InvocationOtelPlugin(tracerProviderBuilder, config);
+ * }</pre>
+ *
+ * <p>Defaults: {@code contextExtractor = new XRayContextExtractor()}, {@code enableMdc = true}, {@code workflowSpanName
+ * = "Workflow"}, {@code instrumentationName = "aws-durable-execution-sdk-java"}. A {@code null} passed to any builder
+ * setter falls back to the corresponding default.
+ *
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public final class OtelPluginConfig {
+
+    static final String DEFAULT_INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
+    static final String DEFAULT_WORKFLOW_SPAN_NAME = "Workflow";
+
+    private final ContextExtractor contextExtractor;
+    private final boolean enableMdc;
+    private final String workflowSpanName;
+    private final String instrumentationName;
+
+    private OtelPluginConfig(Builder builder) {
+        this.contextExtractor =
+                builder.contextExtractor != null ? builder.contextExtractor : new XRayContextExtractor();
+        this.enableMdc = builder.enableMdc;
+        this.workflowSpanName =
+                builder.workflowSpanName != null ? builder.workflowSpanName : DEFAULT_WORKFLOW_SPAN_NAME;
+        this.instrumentationName =
+                builder.instrumentationName != null ? builder.instrumentationName : DEFAULT_INSTRUMENTATION_NAME;
+    }
+
+    /** Returns a new builder with all fields defaulted. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Returns a config with all default values. */
+    public static OtelPluginConfig defaults() {
+        return new Builder().build();
+    }
+
+    /** The context extractor used to read parent trace context from the Lambda environment. */
+    public ContextExtractor contextExtractor() {
+        return contextExtractor;
+    }
+
+    /** Whether traceId/spanId/otelTraceSampled are injected into the SLF4J MDC for log correlation. */
+    public boolean enableMdc() {
+        return enableMdc;
+    }
+
+    /** The name used for the Workflow span. */
+    public String workflowSpanName() {
+        return workflowSpanName;
+    }
+
+    /** The instrumentation scope name registered with the tracer. */
+    public String instrumentationName() {
+        return instrumentationName;
+    }
+
+    /**
+     * Builder for {@link OtelPluginConfig}.
+     *
+     * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+     */
+    @Deprecated
+    public static final class Builder {
+
+        private ContextExtractor contextExtractor;
+        private boolean enableMdc = true;
+        private String workflowSpanName;
+        private String instrumentationName;
+
+        private Builder() {}
+
+        /**
+         * Sets the context extractor. Defaults to {@link XRayContextExtractor} when null.
+         *
+         * @param contextExtractor extracts parent trace context from the Lambda environment
+         * @return this builder
+         */
+        public Builder contextExtractor(ContextExtractor contextExtractor) {
+            this.contextExtractor = contextExtractor;
+            return this;
+        }
+
+        /**
+         * Sets whether to inject traceId/spanId/otelTraceSampled into the SLF4J MDC. Defaults to {@code true}.
+         *
+         * @param enableMdc if true, enables MDC log correlation
+         * @return this builder
+         */
+        public Builder enableMdc(boolean enableMdc) {
+            this.enableMdc = enableMdc;
+            return this;
+        }
+
+        /**
+         * Sets the Workflow span name. Defaults to {@code "Workflow"} when null.
+         *
+         * @param workflowSpanName the name for the Workflow span
+         * @return this builder
+         */
+        public Builder workflowSpanName(String workflowSpanName) {
+            this.workflowSpanName = workflowSpanName;
+            return this;
+        }
+
+        /**
+         * Sets the instrumentation scope name registered with the tracer. Defaults to
+         * {@code "aws-durable-execution-sdk-java"} when null.
+         *
+         * @param instrumentationName the instrumentation scope name
+         * @return this builder
+         */
+        public Builder instrumentationName(String instrumentationName) {
+            this.instrumentationName = instrumentationName;
+            return this;
+        }
+
+        /** Builds an immutable {@link OtelPluginConfig}. */
+        public OtelPluginConfig build() {
+            return new OtelPluginConfig(this);
+        }
+    }
+}

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginSupport.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginSupport.java
@@ -3,9 +3,15 @@
 package software.amazon.lambda.durable.otel;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.TracerProvider;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.semconv.ServiceAttributes;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.slf4j.Logger;
@@ -43,6 +49,92 @@ final class OtelPluginSupport {
     /** Creates a new DeterministicIdGenerator for the application-side state bridge. */
     static DeterministicIdGenerator createDefaultIdGenerator() {
         return new DeterministicIdGenerator();
+    }
+
+    /**
+     * Builds a plugin-owned {@link SdkTracerProvider} that exports over OTLP/HTTP (the {@link ProviderSource#AUTO_OTLP}
+     * default). Mirrors the auto-configured provider in the JavaScript and Python SDK plugins: an OTLP/HTTP exporter, a
+     * batch span processor, an env-driven sampler, Lambda resource attributes, and the deterministic ID generator.
+     *
+     * @param config the plugin configuration (endpoint + headers)
+     * @param idGenerator the deterministic ID generator to install
+     * @param additionalResource extra resource attributes to merge (e.g. ExecutionOtelPlugin's service.name), or null
+     */
+    static SdkTracerProvider buildAutoOtlpProvider(
+            OtelPluginConfig config, DeterministicIdGenerator idGenerator, Resource additionalResource) {
+        var exporterBuilder = OtlpHttpSpanExporter.builder();
+        var endpoint = resolveOtlpEndpoint(config);
+        if (endpoint != null) {
+            exporterBuilder.setEndpoint(endpoint);
+        }
+        for (var header : config.otlpHeaders().entrySet()) {
+            exporterBuilder.addHeader(header.getKey(), header.getValue());
+        }
+
+        var resource = buildLambdaResource();
+        if (additionalResource != null) {
+            resource = resource.merge(additionalResource);
+        }
+
+        return SdkTracerProvider.builder()
+                .setIdGenerator(idGenerator)
+                .setSampler(resolveSampler())
+                .setResource(resource)
+                .addSpanProcessor(
+                        BatchSpanProcessor.builder(exporterBuilder.build()).build())
+                .build();
+    }
+
+    /** Resolves the OTLP/HTTP traces endpoint (config -> env -> exporter default), appending the signal path. */
+    private static String resolveOtlpEndpoint(OtelPluginConfig config) {
+        if (config.otlpEndpoint() != null && !config.otlpEndpoint().isBlank()) {
+            return config.otlpEndpoint();
+        }
+        var envEndpoint = System.getenv("OTEL_EXPORTER_OTLP_ENDPOINT");
+        if (envEndpoint != null && !envEndpoint.isBlank()) {
+            var base = envEndpoint.endsWith("/") ? envEndpoint.substring(0, envEndpoint.length() - 1) : envEndpoint;
+            return base.endsWith("/v1/traces") ? base : base + "/v1/traces";
+        }
+        // null -> the OTLP/HTTP exporter's own default (http://localhost:4318/v1/traces)
+        return null;
+    }
+
+    /** Builds the sampler from {@code OTEL_DURABLE_SAMPLING_RATIO}, falling back to always-on. */
+    private static Sampler resolveSampler() {
+        var raw = System.getenv("OTEL_DURABLE_SAMPLING_RATIO");
+        if (raw != null) {
+            try {
+                var ratio = Double.parseDouble(raw);
+                if (ratio >= 0.0 && ratio <= 1.0) {
+                    return Sampler.traceIdRatioBased(ratio);
+                }
+            } catch (NumberFormatException ignored) {
+                // fall through to always-on
+            }
+        }
+        return Sampler.alwaysOn();
+    }
+
+    /** Builds Lambda resource attributes from AWS_* env vars, merged onto the default resource. */
+    private static Resource buildLambdaResource() {
+        var functionName = System.getenv("AWS_LAMBDA_FUNCTION_NAME");
+        if (functionName == null || functionName.isBlank()) {
+            return Resource.getDefault();
+        }
+        var attributes = Attributes.builder()
+                .put(ServiceAttributes.SERVICE_NAME, functionName)
+                .put("faas.name", functionName)
+                .put("cloud.provider", "aws")
+                .put("cloud.platform", "aws_lambda");
+        var region = System.getenv("AWS_REGION");
+        if (region != null && !region.isBlank()) {
+            attributes.put("cloud.region", region);
+        }
+        var version = System.getenv("AWS_LAMBDA_FUNCTION_VERSION");
+        if (version != null && !version.isBlank()) {
+            attributes.put("faas.version", version);
+        }
+        return Resource.getDefault().merge(Resource.create(attributes.build()));
     }
 
     /** Extracts trace context from the current OTel span (fallback when X-Ray header is unavailable). */

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginSupport.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginSupport.java
@@ -5,6 +5,7 @@ package software.amazon.lambda.durable.otel;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.sdk.resources.Resource;
@@ -83,6 +84,65 @@ final class OtelPluginSupport {
                 .addSpanProcessor(
                         BatchSpanProcessor.builder(exporterBuilder.build()).build())
                 .build();
+    }
+
+    /**
+     * The tracer provider, tracer, and ID generator resolved for a config-only plugin constructor, plus the
+     * {@link ProviderSource} that produced them.
+     *
+     * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+     */
+    @Deprecated
+    record ProviderSetup(
+            ProviderSource source,
+            SdkTracerProvider sdkTracerProvider,
+            Tracer tracer,
+            DeterministicIdGenerator idGenerator) {}
+
+    /**
+     * Resolves the tracer provider for the config-only plugin constructors from
+     * {@link OtelPluginConfig#providerSource()}, centralizing the {@link ProviderSource} branching shared by
+     * {@link InvocationOtelPlugin} and {@link ExecutionOtelPlugin}:
+     *
+     * <ul>
+     *   <li>{@link ProviderSource#GLOBAL} — binds to the ADOT/global provider (not plugin-owned); the deterministic ID
+     *       generator is created for the application-side state bridge.
+     *   <li>{@link ProviderSource#AUTO_OTLP} — builds a plugin-owned OTLP/HTTP provider (see
+     *       {@link #buildAutoOtlpProvider}).
+     *   <li>{@link ProviderSource#EXPLICIT} — rejected: an explicit provider requires the
+     *       {@code (SdkTracerProviderBuilder, OtelPluginConfig)} constructor.
+     * </ul>
+     *
+     * @param config the plugin configuration
+     * @param pluginName the plugin name used in diagnostics/flush logging
+     * @return the resolved provider, tracer, ID generator, and source
+     * @throws IllegalArgumentException if {@code config.providerSource()} is {@link ProviderSource#EXPLICIT}
+     */
+    static ProviderSetup resolveConfiguredProvider(OtelPluginConfig config, String pluginName) {
+        return switch (config.providerSource()) {
+            case GLOBAL -> {
+                var idGenerator = createDefaultIdGenerator();
+                var tracerProvider = getDefaultTracerProvider(pluginName);
+                yield new ProviderSetup(
+                        ProviderSource.GLOBAL,
+                        getSdkTracerProviderForFlush(tracerProvider, pluginName),
+                        tracerProvider.get(config.instrumentationName()),
+                        idGenerator);
+            }
+            case AUTO_OTLP -> {
+                var idGenerator = new DeterministicIdGenerator();
+                var sdkTracerProvider = buildAutoOtlpProvider(config, idGenerator, null);
+                yield new ProviderSetup(
+                        ProviderSource.AUTO_OTLP,
+                        sdkTracerProvider,
+                        sdkTracerProvider.get(config.instrumentationName()),
+                        idGenerator);
+            }
+            case EXPLICIT ->
+                throw new IllegalArgumentException(
+                        "OtelPluginConfig.providerSource(EXPLICIT) requires a caller-supplied SdkTracerProviderBuilder; "
+                                + "use the (SdkTracerProviderBuilder, OtelPluginConfig) constructor.");
+        };
     }
 
     /** Resolves the OTLP/HTTP traces endpoint (config -> env -> exporter default), appending the signal path. */

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ProviderSource.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ProviderSource.java
@@ -11,10 +11,14 @@ package software.amazon.lambda.durable.otel;
  *   <li>{@link #EXPLICIT} — the caller supplied a {@link io.opentelemetry.sdk.trace.SdkTracerProviderBuilder} (the
  *       {@code (SdkTracerProviderBuilder, OtelPluginConfig)} constructors); the plugin builds and owns that provider.
  *   <li>{@link #GLOBAL} — {@code GlobalOpenTelemetry} / the ADOT Java agent (the no-arg constructor, or a config with
- *       {@code useDefaultTracerProvider(true)}); the plugin does not own the provider.
- *   <li>{@link #AUTO_OTLP} — the default when only an {@link OtelPluginConfig} is supplied and
- *       {@code useDefaultTracerProvider} is false: the plugin builds and owns an OTLP/HTTP provider.
+ *       {@code providerSource(GLOBAL)}); the plugin does not own the provider.
+ *   <li>{@link #AUTO_OTLP} — the default when only an {@link OtelPluginConfig} is supplied (its {@code providerSource}
+ *       left at {@code AUTO_OTLP}): the plugin builds and owns an OTLP/HTTP provider.
  * </ul>
+ *
+ * <p>This is the single knob that selects a plugin's tracer provider. {@link OtelPluginConfig#providerSource()} carries
+ * it for the config-only constructors; the {@code (SdkTracerProviderBuilder, OtelPluginConfig)} constructors always
+ * report {@link #EXPLICIT}.
  *
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
@@ -25,10 +29,5 @@ public enum ProviderSource {
     /** Globally configured provider (ADOT Java agent); not plugin-owned. */
     GLOBAL,
     /** Auto-configured OTLP/HTTP provider; plugin-owned. */
-    AUTO_OTLP;
-
-    /** True when the plugin created (and therefore manages/flushes) the provider. */
-    public boolean ownsProvider() {
-        return this == EXPLICIT || this == AUTO_OTLP;
-    }
+    AUTO_OTLP
 }

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ProviderSource.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ProviderSource.java
@@ -10,10 +10,11 @@ package software.amazon.lambda.durable.otel;
  * <ul>
  *   <li>{@link #EXPLICIT} — the caller supplied a {@link io.opentelemetry.sdk.trace.SdkTracerProviderBuilder} (the
  *       {@code (SdkTracerProviderBuilder, OtelPluginConfig)} constructors); the plugin builds and owns that provider.
- *   <li>{@link #GLOBAL} — {@code GlobalOpenTelemetry} / the ADOT Java agent (the no-arg constructor, or a config with
- *       {@code providerSource(GLOBAL)}); the plugin does not own the provider.
- *   <li>{@link #AUTO_OTLP} — the default when only an {@link OtelPluginConfig} is supplied (its {@code providerSource}
- *       left at {@code AUTO_OTLP}): the plugin builds and owns an OTLP/HTTP provider.
+ *   <li>{@link #GLOBAL} — {@code GlobalOpenTelemetry} / the ADOT Java agent (the no-arg constructor, or an
+ *       {@link OtelPluginConfig} with its {@code providerSource} left at the default {@code GLOBAL}); the plugin does
+ *       not own the provider.
+ *   <li>{@link #AUTO_OTLP} — opt-in via {@code providerSource(AUTO_OTLP)} on a config-only constructor: the plugin
+ *       builds and owns an OTLP/HTTP provider.
  * </ul>
  *
  * <p>This is the single knob that selects a plugin's tracer provider. {@link OtelPluginConfig#providerSource()} carries

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ProviderSource.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ProviderSource.java
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.otel;
+
+/**
+ * Which of the three resolution tiers produced a plugin's tracer provider.
+ *
+ * <p>Mirrors the {@code ProviderSource} used by the JavaScript and Python SDK OTel plugins for cross-SDK parity:
+ *
+ * <ul>
+ *   <li>{@link #EXPLICIT} — the caller supplied a {@link io.opentelemetry.sdk.trace.SdkTracerProviderBuilder} (the
+ *       {@code (SdkTracerProviderBuilder, OtelPluginConfig)} constructors); the plugin builds and owns that provider.
+ *   <li>{@link #GLOBAL} — {@code GlobalOpenTelemetry} / the ADOT Java agent (the no-arg constructor, or a config with
+ *       {@code useDefaultTracerProvider(true)}); the plugin does not own the provider.
+ *   <li>{@link #AUTO_OTLP} — the default when only an {@link OtelPluginConfig} is supplied and
+ *       {@code useDefaultTracerProvider} is false: the plugin builds and owns an OTLP/HTTP provider.
+ * </ul>
+ *
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public enum ProviderSource {
+    /** Caller-supplied {@code SdkTracerProviderBuilder}; plugin-owned. */
+    EXPLICIT,
+    /** Globally configured provider (ADOT Java agent); not plugin-owned. */
+    GLOBAL,
+    /** Auto-configured OTLP/HTTP provider; plugin-owned. */
+    AUTO_OTLP;
+
+    /** True when the plugin created (and therefore manages/flushes) the provider. */
+    public boolean ownsProvider() {
+        return this == EXPLICIT || this == AUTO_OTLP;
+    }
+}

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -80,13 +80,32 @@ class ExecutionOtelPluginTest {
     void configOnlyConstructor_defaultsToAutoOtlpProvider() {
         var plugin = new ExecutionOtelPlugin(OtelPluginConfig.defaults());
         assertEquals(ProviderSource.AUTO_OTLP, plugin.providerSource());
-        assertTrue(plugin.providerSource().ownsProvider());
     }
 
     @Test
     void builderConstructor_isExplicitSource() {
         var plugin = new ExecutionOtelPlugin(SdkTracerProvider.builder(), OtelPluginConfig.defaults());
         assertEquals(ProviderSource.EXPLICIT, plugin.providerSource());
+    }
+
+    @Test
+    void configProviderSource_defaultsToAutoOtlpAndHonorsGlobal() {
+        assertEquals(ProviderSource.AUTO_OTLP, OtelPluginConfig.defaults().providerSource());
+        assertEquals(
+                ProviderSource.GLOBAL,
+                OtelPluginConfig.builder()
+                        .providerSource(ProviderSource.GLOBAL)
+                        .build()
+                        .providerSource());
+    }
+
+    @Test
+    void configOnlyConstructor_rejectsExplicitProviderSource() {
+        var config = OtelPluginConfig.builder()
+                .providerSource(ProviderSource.EXPLICIT)
+                .build();
+        var error = assertThrows(IllegalArgumentException.class, () -> new ExecutionOtelPlugin(config));
+        assertTrue(error.getMessage().contains("SdkTracerProviderBuilder"));
     }
 
     @Test

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -39,9 +39,11 @@ class ExecutionOtelPluginTest {
                 SdkTracerProvider.builder()
                         .setResource(resource)
                         .addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> null,
-                false,
-                "Workflow");
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> null)
+                        .enableMdc(false)
+                        .workflowSpanName("Workflow")
+                        .build());
     }
 
     @AfterEach
@@ -58,10 +60,12 @@ class ExecutionOtelPluginTest {
         var exporter = InMemorySpanExporter.create();
         var customPlugin = new ExecutionOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
-                () -> null,
-                false,
-                "Workflow",
-                "my-custom-scope");
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> null)
+                        .enableMdc(false)
+                        .workflowSpanName("Workflow")
+                        .instrumentationName("my-custom-scope")
+                        .build());
         customPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         customPlugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
@@ -616,9 +620,11 @@ class ExecutionOtelPluginTest {
         var exporter2 = InMemorySpanExporter.create();
         var plugin2 = new ExecutionOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter2)),
-                () -> null,
-                false,
-                "Workflow");
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> null)
+                        .enableMdc(false)
+                        .workflowSpanName("Workflow")
+                        .build());
         plugin2.onInvocationStart(new InvocationInfo("req-9", ARN, true, Instant.now()));
         plugin2.onInvocationEnd(new InvocationEndInfo("req-9", ARN, true, InvocationStatus.SUCCEEDED, null));
         var secondWorkflowSpanId =
@@ -639,9 +645,11 @@ class ExecutionOtelPluginTest {
                 SdkTracerProvider.builder()
                         .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOff())
                         .addSpanProcessor(SimpleSpanProcessor.create(exporter)),
-                () -> null,
-                false,
-                "Workflow");
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> null)
+                        .enableMdc(false)
+                        .workflowSpanName("Workflow")
+                        .build());
         sampledPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         sampledPlugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
         assertTrue(exporter.getFinishedSpanItems().isEmpty(), "No spans should be exported with 0% sampling");
@@ -655,9 +663,11 @@ class ExecutionOtelPluginTest {
         var exporter = InMemorySpanExporter.create();
         var xrayPlugin = new ExecutionOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
-                () -> new ExtractedContext(xrayTraceId, null),
-                false,
-                "Workflow");
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> new ExtractedContext(xrayTraceId, null))
+                        .enableMdc(false)
+                        .workflowSpanName("Workflow")
+                        .build());
         xrayPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -77,6 +77,19 @@ class ExecutionOtelPluginTest {
     }
 
     @Test
+    void configOnlyConstructor_defaultsToAutoOtlpProvider() {
+        var plugin = new ExecutionOtelPlugin(OtelPluginConfig.defaults());
+        assertEquals(ProviderSource.AUTO_OTLP, plugin.providerSource());
+        assertTrue(plugin.providerSource().ownsProvider());
+    }
+
+    @Test
+    void builderConstructor_isExplicitSource() {
+        var plugin = new ExecutionOtelPlugin(SdkTracerProvider.builder(), OtelPluginConfig.defaults());
+        assertEquals(ProviderSource.EXPLICIT, plugin.providerSource());
+    }
+
+    @Test
     void defaultConstructor_throwsWhenAutoConfigurationCustomizerProviderIsNotInstalled() {
         GlobalOpenTelemetry.resetForTest();
         var error = assertThrows(IllegalStateException.class, ExecutionOtelPlugin::new);

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -77,8 +77,22 @@ class ExecutionOtelPluginTest {
     }
 
     @Test
-    void configOnlyConstructor_defaultsToAutoOtlpProvider() {
+    void configOnlyConstructor_defaultsToGlobalProvider() {
+        OtelPluginAutoConfigurationState.markInstalled();
+        GlobalOpenTelemetry.resetForTest();
+        OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder().build())
+                .buildAndRegisterGlobal();
+
         var plugin = new ExecutionOtelPlugin(OtelPluginConfig.defaults());
+        assertEquals(ProviderSource.GLOBAL, plugin.providerSource());
+    }
+
+    @Test
+    void configWithAutoOtlp_buildsPluginOwnedProvider() {
+        var plugin = new ExecutionOtelPlugin(OtelPluginConfig.builder()
+                .providerSource(ProviderSource.AUTO_OTLP)
+                .build());
         assertEquals(ProviderSource.AUTO_OTLP, plugin.providerSource());
     }
 
@@ -89,12 +103,12 @@ class ExecutionOtelPluginTest {
     }
 
     @Test
-    void configProviderSource_defaultsToAutoOtlpAndHonorsGlobal() {
-        assertEquals(ProviderSource.AUTO_OTLP, OtelPluginConfig.defaults().providerSource());
+    void configProviderSource_defaultsToGlobalAndHonorsAutoOtlp() {
+        assertEquals(ProviderSource.GLOBAL, OtelPluginConfig.defaults().providerSource());
         assertEquals(
-                ProviderSource.GLOBAL,
+                ProviderSource.AUTO_OTLP,
                 OtelPluginConfig.builder()
-                        .providerSource(ProviderSource.GLOBAL)
+                        .providerSource(ProviderSource.AUTO_OTLP)
                         .build()
                         .providerSource());
     }

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -46,6 +46,25 @@ class ExecutionOtelPluginTest {
     // ─── Default constructor ─────────────────────────────────────────────
 
     @Test
+    void customInstrumentationName_isUsedForTracerScope() {
+        var exporter = InMemorySpanExporter.create();
+        var customPlugin = new ExecutionOtelPlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
+                () -> null,
+                false,
+                "Workflow",
+                "my-custom-scope");
+        customPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
+        customPlugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = exporter.getFinishedSpanItems();
+        assertFalse(spans.isEmpty());
+        for (var span : spans) {
+            assertEquals("my-custom-scope", span.getInstrumentationScopeInfo().getName());
+        }
+    }
+
+    @Test
     void defaultConstructor_throwsWhenAutoConfigurationCustomizerProviderIsNotInstalled() {
         GlobalOpenTelemetry.resetForTest();
         var error = assertThrows(IllegalStateException.class, ExecutionOtelPlugin::new);

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginIntegrationTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginIntegrationTest.java
@@ -46,8 +46,10 @@ class InvocationOtelPluginIntegrationTest {
 
         var plugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> null,
-                false);
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> null)
+                        .enableMdc(false)
+                        .build());
 
         otelConfig = DurableConfig.builder().withPlugins(plugin).build();
     }
@@ -326,8 +328,10 @@ class InvocationOtelPluginIntegrationTest {
                 SdkTracerProvider.builder()
                         .setSampler(Sampler.alwaysOff())
                         .addSpanProcessor(SimpleSpanProcessor.create(sampledExporter)),
-                () -> null,
-                false);
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> null)
+                        .enableMdc(false)
+                        .build());
 
         var noSampleConfig = DurableConfig.builder().withPlugins(noSamplePlugin).build();
 

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -260,8 +260,22 @@ class InvocationOtelPluginTest {
     }
 
     @Test
-    void configOnlyConstructor_defaultsToAutoOtlpProvider() {
+    void configOnlyConstructor_defaultsToGlobalProvider() {
+        OtelPluginAutoConfigurationState.markInstalled();
+        GlobalOpenTelemetry.resetForTest();
+        OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder().build())
+                .buildAndRegisterGlobal();
+
         var plugin = new InvocationOtelPlugin(OtelPluginConfig.defaults());
+        assertEquals(ProviderSource.GLOBAL, plugin.providerSource());
+    }
+
+    @Test
+    void configWithAutoOtlp_buildsPluginOwnedProvider() {
+        var plugin = new InvocationOtelPlugin(OtelPluginConfig.builder()
+                .providerSource(ProviderSource.AUTO_OTLP)
+                .build());
         assertEquals(ProviderSource.AUTO_OTLP, plugin.providerSource());
     }
 
@@ -272,12 +286,12 @@ class InvocationOtelPluginTest {
     }
 
     @Test
-    void configProviderSource_defaultsToAutoOtlpAndHonorsGlobal() {
-        assertEquals(ProviderSource.AUTO_OTLP, OtelPluginConfig.defaults().providerSource());
+    void configProviderSource_defaultsToGlobalAndHonorsAutoOtlp() {
+        assertEquals(ProviderSource.GLOBAL, OtelPluginConfig.defaults().providerSource());
         assertEquals(
-                ProviderSource.GLOBAL,
+                ProviderSource.AUTO_OTLP,
                 OtelPluginConfig.builder()
-                        .providerSource(ProviderSource.GLOBAL)
+                        .providerSource(ProviderSource.AUTO_OTLP)
                         .build()
                         .providerSource());
     }

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -260,6 +260,30 @@ class InvocationOtelPluginTest {
     }
 
     @Test
+    void configOnlyConstructor_defaultsToAutoOtlpProvider() {
+        var plugin = new InvocationOtelPlugin(OtelPluginConfig.defaults());
+        assertEquals(ProviderSource.AUTO_OTLP, plugin.providerSource());
+        assertTrue(plugin.providerSource().ownsProvider());
+    }
+
+    @Test
+    void builderConstructor_isExplicitSource() {
+        var plugin = new InvocationOtelPlugin(SdkTracerProvider.builder(), OtelPluginConfig.defaults());
+        assertEquals(ProviderSource.EXPLICIT, plugin.providerSource());
+    }
+
+    @Test
+    void configResolveSource_reflectsUseDefaultTracerProvider() {
+        assertEquals(ProviderSource.AUTO_OTLP, OtelPluginConfig.defaults().resolveSource());
+        assertEquals(
+                ProviderSource.GLOBAL,
+                OtelPluginConfig.builder()
+                        .useDefaultTracerProvider(true)
+                        .build()
+                        .resolveSource());
+    }
+
+    @Test
     void invocationSpan_hasInternalKind() {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -236,6 +236,26 @@ class InvocationOtelPluginTest {
     }
 
     @Test
+    void customInstrumentationName_isUsedForTracerScope() {
+        var exporter = InMemorySpanExporter.create();
+        var customPlugin = new InvocationOtelPlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
+                () -> null,
+                false,
+                "Workflow",
+                "my-custom-scope");
+        customPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
+        customPlugin.onInvocationEnd(
+                new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = exporter.getFinishedSpanItems();
+        assertFalse(spans.isEmpty());
+        for (var span : spans) {
+            assertEquals("my-custom-scope", span.getInstrumentationScopeInfo().getName());
+        }
+    }
+
+    @Test
     void invocationSpan_hasInternalKind() {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -51,8 +51,10 @@ class InvocationOtelPluginTest {
 
         plugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> null,
-                false);
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> null)
+                        .enableMdc(false)
+                        .build());
     }
 
     @AfterEach
@@ -240,10 +242,12 @@ class InvocationOtelPluginTest {
         var exporter = InMemorySpanExporter.create();
         var customPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
-                () -> null,
-                false,
-                "Workflow",
-                "my-custom-scope");
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> null)
+                        .enableMdc(false)
+                        .workflowSpanName("Workflow")
+                        .instrumentationName("my-custom-scope")
+                        .build());
         customPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         customPlugin.onInvocationEnd(
                 new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
@@ -671,8 +675,10 @@ class InvocationOtelPluginTest {
                 SdkTracerProvider.builder()
                         .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOff())
                         .addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> null,
-                false);
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> null)
+                        .enableMdc(false)
+                        .build());
 
         sampledPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         sampledPlugin.onUserFunctionStart(
@@ -697,8 +703,10 @@ class InvocationOtelPluginTest {
         spanExporter = InMemorySpanExporter.create();
         var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> extractedContext,
-                false);
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> extractedContext)
+                        .enableMdc(false)
+                        .build());
 
         xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
@@ -716,8 +724,10 @@ class InvocationOtelPluginTest {
         spanExporter = InMemorySpanExporter.create();
         var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> extractedContext,
-                false);
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> extractedContext)
+                        .enableMdc(false)
+                        .build());
 
         xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         xrayPlugin.onOperationStart(
@@ -746,8 +756,10 @@ class InvocationOtelPluginTest {
         spanExporter = InMemorySpanExporter.create();
         var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> extractedContext,
-                false);
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> extractedContext)
+                        .enableMdc(false)
+                        .build());
 
         xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
@@ -771,8 +783,10 @@ class InvocationOtelPluginTest {
         spanExporter = InMemorySpanExporter.create();
         var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> extractedContext,
-                false);
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> extractedContext)
+                        .enableMdc(false)
+                        .build());
 
         xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
@@ -801,8 +815,10 @@ class InvocationOtelPluginTest {
         spanExporter = InMemorySpanExporter.create();
         var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> extractedContext,
-                false);
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> extractedContext)
+                        .enableMdc(false)
+                        .build());
 
         // First invocation
         xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
@@ -835,8 +851,10 @@ class InvocationOtelPluginTest {
         spanExporter = InMemorySpanExporter.create();
         var noXrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> null,
-                false);
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> null)
+                        .enableMdc(false)
+                        .build());
 
         var arn = "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1";
         noXrayPlugin.onInvocationStart(new InvocationInfo("req-1", arn, true, Instant.now()));
@@ -866,8 +884,10 @@ class InvocationOtelPluginTest {
         spanExporter = InMemorySpanExporter.create();
         var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> extractedContext,
-                false);
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> extractedContext)
+                        .enableMdc(false)
+                        .build());
 
         xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
@@ -1301,8 +1321,11 @@ class InvocationOtelPluginTest {
         var exporter = InMemorySpanExporter.create();
         var xrayPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
-                () -> new ExtractedContext("5759e988bd862e3fe1be46a994272793", "53995c3f42cd8ad8"),
-                false);
+                OtelPluginConfig.builder()
+                        .contextExtractor(
+                                () -> new ExtractedContext("5759e988bd862e3fe1be46a994272793", "53995c3f42cd8ad8"))
+                        .enableMdc(false)
+                        .build());
         xrayPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, false));
@@ -1330,9 +1353,11 @@ class InvocationOtelPluginTest {
         var exporter = InMemorySpanExporter.create();
         var customPlugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
-                () -> null,
-                false,
-                "MyWorkflow");
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> null)
+                        .enableMdc(false)
+                        .workflowSpanName("MyWorkflow")
+                        .build());
         customPlugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
         customPlugin.onInvocationEnd(
                 new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -263,7 +263,6 @@ class InvocationOtelPluginTest {
     void configOnlyConstructor_defaultsToAutoOtlpProvider() {
         var plugin = new InvocationOtelPlugin(OtelPluginConfig.defaults());
         assertEquals(ProviderSource.AUTO_OTLP, plugin.providerSource());
-        assertTrue(plugin.providerSource().ownsProvider());
     }
 
     @Test
@@ -273,14 +272,23 @@ class InvocationOtelPluginTest {
     }
 
     @Test
-    void configResolveSource_reflectsUseDefaultTracerProvider() {
-        assertEquals(ProviderSource.AUTO_OTLP, OtelPluginConfig.defaults().resolveSource());
+    void configProviderSource_defaultsToAutoOtlpAndHonorsGlobal() {
+        assertEquals(ProviderSource.AUTO_OTLP, OtelPluginConfig.defaults().providerSource());
         assertEquals(
                 ProviderSource.GLOBAL,
                 OtelPluginConfig.builder()
-                        .useDefaultTracerProvider(true)
+                        .providerSource(ProviderSource.GLOBAL)
                         .build()
-                        .resolveSource());
+                        .providerSource());
+    }
+
+    @Test
+    void configOnlyConstructor_rejectsExplicitProviderSource() {
+        var config = OtelPluginConfig.builder()
+                .providerSource(ProviderSource.EXPLICIT)
+                .build();
+        var error = assertThrows(IllegalArgumentException.class, () -> new InvocationOtelPlugin(config));
+        assertTrue(error.getMessage().contains("SdkTracerProviderBuilder"));
     }
 
     @Test

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
@@ -58,8 +58,10 @@ class MdcSpanEnricherTest {
 
         var plugin = new InvocationOtelPlugin(
                 SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)),
-                () -> null,
-                true);
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> null)
+                        .enableMdc(true)
+                        .build());
 
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec-mdc-test", true, Instant.now()));
 


### PR DESCRIPTION
https://github.com/aws/aws-durable-execution-conformance-tests/issues/23#issuecomment-5184325293

Replaces the OTel plugins' telescoping constructors with an immutable `OtelPluginConfig` builder and a config-only constructor, and uses a single `ProviderSource` enum (`EXPLICIT`/`GLOBAL`/`AUTO_OTLP`, default `GLOBAL`) to select the tracer provider; pass `AUTO_OTLP` for a plugin-owned OTLP/HTTP provider. Breaking (preview API). All tests pass.
