### PR TITLE
feat(plugin): Add result accessor to OperationEndInfo

### DIFF
--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -75,7 +75,18 @@ class ExecutionOtelPluginTest {
         defaultPlugin.onOperationStart(
                 new OperationInfo("op-1", "step", "STEP", "Step", null, Instant.now(), null, null, false));
         defaultPlugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         defaultPlugin.onInvocationEnd(
                 new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -230,7 +241,18 @@ class ExecutionOtelPluginTest {
         plugin.onOperationStart(
                 new OperationInfo("op-1", "flaky", "STEP", "Step", null, Instant.now(), null, null, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "flaky", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", 3, false, null));
+                "op-1",
+                "flaky",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                3,
+                false,
+                null,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var operationSpan = spanByName(spanExporter.getFinishedSpanItems(), "flaky");
@@ -247,7 +269,18 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false, Instant.now()));
         // No matching onOperationStart in this invocation — continuation branch.
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "flaky", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", 2, false, null));
+                "op-1",
+                "flaky",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                2,
+                false,
+                null,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
 
         var operationSpan = spanByName(spanExporter.getFinishedSpanItems(), "flaky");
@@ -266,7 +299,7 @@ class ExecutionOtelPluginTest {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onOperationStart(new OperationInfo("op-1", "step-a", "STEP", "Step", null, opStart, null, null, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-a", "STEP", "Step", null, opStart, opEnd, "SUCCEEDED", null, false, null));
+                "op-1", "step-a", "STEP", "Step", null, opStart, opEnd, "SUCCEEDED", null, false, null, null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var operationSpan = spanByName(spanExporter.getFinishedSpanItems(), "step-a");
@@ -282,7 +315,18 @@ class ExecutionOtelPluginTest {
         plugin.onOperationStart(
                 new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, null, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step-a",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -310,7 +354,18 @@ class ExecutionOtelPluginTest {
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "compute", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "compute", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "compute",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -350,6 +405,7 @@ class ExecutionOtelPluginTest {
                 "SUCCEEDED",
                 null,
                 false,
+                null,
                 null));
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-parent",
@@ -362,6 +418,7 @@ class ExecutionOtelPluginTest {
                 "SUCCEEDED",
                 null,
                 false,
+                null,
                 null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
@@ -424,7 +481,18 @@ class ExecutionOtelPluginTest {
         plugin.onOperationStart(
                 new OperationInfo("op-1", "step-ok", "STEP", "Step", null, Instant.now(), null, null, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-ok", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step-ok",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var operationSpan = spanByName(spanExporter.getFinishedSpanItems(), "step-ok");
@@ -450,6 +518,7 @@ class ExecutionOtelPluginTest {
                 "CANCELLED",
                 null,
                 false,
+                null,
                 null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
@@ -473,6 +542,7 @@ class ExecutionOtelPluginTest {
                 "TIMED_OUT",
                 null,
                 false,
+                null,
                 null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
 
@@ -488,7 +558,18 @@ class ExecutionOtelPluginTest {
         plugin.onOperationStart(
                 new OperationInfo("op-ctx", "my-ctx", "CONTEXT", null, null, Instant.now(), null, null, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-ctx", "my-ctx", "CONTEXT", null, null, Instant.now(), Instant.now(), null, null, false, null));
+                "op-ctx",
+                "my-ctx",
+                "CONTEXT",
+                null,
+                null,
+                Instant.now(),
+                Instant.now(),
+                null,
+                null,
+                false,
+                null,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var operationSpan = spanByName(spanExporter.getFinishedSpanItems(), "my-ctx");
@@ -528,7 +609,18 @@ class ExecutionOtelPluginTest {
         // Invocation 2: the operation completes → materialized once via onOperationEnd, linked to this invocation.
         plugin.onInvocationStart(new InvocationInfo("req-2", ARN, false, Instant.now()));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "my-wait", "WAIT", "Wait", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "my-wait",
+                "WAIT",
+                "Wait",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -550,7 +642,18 @@ class ExecutionOtelPluginTest {
         plugin.onOperationStart(
                 new OperationInfo("op-1", "step-1", "STEP", "Step", null, Instant.now(), null, null, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-1", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step-1",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
         var firstTraceId = spanExporter.getFinishedSpanItems().get(0).getTraceId();
         spanExporter.reset();
@@ -579,6 +682,7 @@ class ExecutionOtelPluginTest {
                 "SUCCEEDED",
                 null,
                 false,
+                null,
                 null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", ARN, false, InvocationStatus.SUCCEEDED, null));
 
@@ -650,7 +754,18 @@ class ExecutionOtelPluginTest {
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, null, false));
         xrayPlugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step-a",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var spans = exporter.getFinishedSpanItems();

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -98,7 +98,18 @@ class InvocationOtelPluginTest {
         defaultPlugin.onOperationStart(
                 new OperationInfo("op-1", "step", "STEP", "Step", null, Instant.now(), null, null, false));
         defaultPlugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         defaultPlugin.onInvocationEnd(
                 new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -136,7 +147,18 @@ class InvocationOtelPluginTest {
         defaultPlugin.onOperationStart(
                 new OperationInfo("op-1", "step", "STEP", "Step", null, Instant.now(), null, null, false));
         defaultPlugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         defaultPlugin.onInvocationEnd(
                 new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -260,6 +282,7 @@ class InvocationOtelPluginTest {
                 "SUCCEEDED",
                 null,
                 false,
+                null,
                 null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -299,7 +322,18 @@ class InvocationOtelPluginTest {
         plugin.onOperationStart(
                 new OperationInfo("op-1", "flaky", "STEP", "Step", null, Instant.now(), null, null, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "flaky", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", 3, false, null));
+                "op-1",
+                "flaky",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                3,
+                false,
+                null,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var operationSpan = spanExporter.getFinishedSpanItems().stream()
@@ -337,7 +371,18 @@ class InvocationOtelPluginTest {
 
         // No onOperationStart in this invocation → onOperationEnd takes the continuation-span branch.
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "flaky", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", 2, false, null));
+                "op-1",
+                "flaky",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                2,
+                false,
+                null,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var continuationSpan = spanExporter.getFinishedSpanItems().stream()
@@ -392,7 +437,7 @@ class InvocationOtelPluginTest {
 
         // Operation span ended at completion
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-hash-1", "my-step", "STEP", "Step", null, start, end, "SUCCEEDED", null, false, null));
+                "op-hash-1", "my-step", "STEP", "Step", null, start, end, "SUCCEEDED", null, false, null, null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -483,7 +528,18 @@ class InvocationOtelPluginTest {
         plugin.onOperationStart(
                 new OperationInfo("op-1", "step-ok", "STEP", "Step", null, Instant.now(), null, null, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-ok", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step-ok",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -516,6 +572,7 @@ class InvocationOtelPluginTest {
                 "CANCELLED",
                 null,
                 false,
+                null,
                 null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
@@ -544,6 +601,7 @@ class InvocationOtelPluginTest {
                 "TIMED_OUT",
                 null,
                 false,
+                null,
                 null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
@@ -564,7 +622,18 @@ class InvocationOtelPluginTest {
         plugin.onOperationStart(
                 new OperationInfo("op-ctx", "my-ctx", "CONTEXT", null, null, Instant.now(), null, null, false));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-ctx", "my-ctx", "CONTEXT", null, null, Instant.now(), Instant.now(), null, null, false, null));
+                "op-ctx",
+                "my-ctx",
+                "CONTEXT",
+                null,
+                null,
+                Instant.now(),
+                Instant.now(),
+                null,
+                null,
+                false,
+                null,
+                null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -588,7 +657,18 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step-a",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
 
         // Step 2: operation starts, user function runs, operation completes
         plugin.onOperationStart(
@@ -598,7 +678,18 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-2", "step-b", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-2", "step-b", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-2",
+                "step-b",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.SUCCEEDED, null));
 
@@ -684,7 +775,18 @@ class InvocationOtelPluginTest {
         sampledPlugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         sampledPlugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         sampledPlugin.onInvocationEnd(
                 new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -731,7 +833,18 @@ class InvocationOtelPluginTest {
         xrayPlugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         xrayPlugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step-a",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var spans = spanExporter.getFinishedSpanItems();
@@ -813,7 +926,18 @@ class InvocationOtelPluginTest {
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-1", "step-1", "STEP", "Step", null, Instant.now(), null, null, false));
         xrayPlugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-1", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step-1",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.PENDING, null));
 
         // Second invocation (same execution, same X-Ray Root from backend)
@@ -821,7 +945,18 @@ class InvocationOtelPluginTest {
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-2", "step-2", "STEP", "Step", null, Instant.now(), null, null, false));
         xrayPlugin.onOperationEnd(new OperationEndInfo(
-                "op-2", "step-2", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-2",
+                "step-2",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         xrayPlugin.onInvocationEnd(
                 new InvocationEndInfo("req-2", "arn:exec1", false, InvocationStatus.SUCCEEDED, null));
 
@@ -898,6 +1033,7 @@ class InvocationOtelPluginTest {
                 "SUCCEEDED",
                 null,
                 false,
+                null,
                 null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
@@ -932,6 +1068,7 @@ class InvocationOtelPluginTest {
                 "SUCCEEDED",
                 null,
                 false,
+                null,
                 null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
@@ -962,7 +1099,8 @@ class InvocationOtelPluginTest {
                 "FAILED",
                 null,
                 false,
-                new RuntimeException("timed out")));
+                new RuntimeException("timed out"),
+                null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -1054,6 +1192,7 @@ class InvocationOtelPluginTest {
                 "SUCCEEDED",
                 null,
                 false,
+                null,
                 null));
 
         plugin.onOperationEnd(new OperationEndInfo(
@@ -1067,6 +1206,7 @@ class InvocationOtelPluginTest {
                 "SUCCEEDED",
                 null,
                 false,
+                null,
                 null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
@@ -1103,7 +1243,18 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step-A", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-A", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step-A",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         plugin.onOperationStart(
                 new OperationInfo("op-2", "pause", "WAIT", "Wait", null, Instant.now(), null, null, false));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.PENDING, null));
@@ -1117,7 +1268,18 @@ class InvocationOtelPluginTest {
         // Invocation 2: wait completed between invocations, new step runs
         plugin.onInvocationStart(new InvocationInfo("req-2", arn, false, Instant.now()));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-2", "pause", "WAIT", "Wait", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-2",
+                "pause",
+                "WAIT",
+                "Wait",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         plugin.onOperationStart(
                 new OperationInfo("op-3", "step-B", "STEP", "Step", null, Instant.now(), null, null, false));
         plugin.onUserFunctionStart(
@@ -1125,7 +1287,18 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-3", "step-B", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-3", "step-B", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-3",
+                "step-B",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", arn, false, InvocationStatus.SUCCEEDED, null));
 
         var inv2Spans = spanExporter.getFinishedSpanItems();
@@ -1212,6 +1385,7 @@ class InvocationOtelPluginTest {
                 "SUCCEEDED",
                 null,
                 false,
+                null,
                 null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-2", arn, false, InvocationStatus.SUCCEEDED, null));
 
@@ -1289,7 +1463,18 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
                 "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
         plugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", 1, false, null));
+                "op-1",
+                "step-a",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                1,
+                false,
+                null,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec-wf", true, InvocationStatus.SUCCEEDED, null));
 
         var workflowId = spanByName("Workflow").getSpanId();
@@ -1315,7 +1500,18 @@ class InvocationOtelPluginTest {
         xrayPlugin.onOperationStart(
                 new OperationInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), null, null, false));
         xrayPlugin.onOperationEnd(new OperationEndInfo(
-                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null));
+                "op-1",
+                "step-a",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null));
         xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var workflowId = exporter.getFinishedSpanItems().stream()

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -334,6 +334,25 @@ class PluginIntegrationTest {
     }
 
     @Test
+    void plugin_operationEnd_includesResult_whenStepSucceeds() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class, (input, context) -> context.step("my-step", String.class, stepCtx -> "task-a"), config);
+
+        runner.runUntilComplete("input");
+
+        var stepEnd = plugin.operationEnds.stream()
+                .filter(info -> "my-step".equals(info.name()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(stepEnd, "onOperationEnd should fire for successful step");
+        assertNotNull(stepEnd.result(), "result should be present for successful step");
+        assertEquals("\"task-a\"", stepEnd.result(), "result should contain the serialized step output");
+    }
+
+    @Test
     void plugin_operationStartAndEnd_balanced_forEmptyMap() {
         var plugin = new RecordingPlugin();
         // withCheckpointEmptyMap is a temporary flag expected to be removed in a future major version.

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationEndInfo.java
@@ -18,6 +18,7 @@ import java.time.Instant;
  * @param attempt the total number of attempts for retriable operations (STEP, WAIT_FOR_CONDITION) — null for others
  * @param isReplay true if this operation already existed in the execution state (completed in a prior invocation)
  * @param error non-null if the operation failed
+ * @param result the serialized result of the operation (may be null if the operation failed or has no result)
  * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
 @Deprecated
@@ -32,4 +33,5 @@ public record OperationEndInfo(
         String status,
         Integer attempt,
         boolean isReplay,
-        Throwable error) {}
+        Throwable error,
+        String result) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationEndInfo.java
@@ -34,4 +34,52 @@ public record OperationEndInfo(
         Integer attempt,
         boolean isReplay,
         @Experimental Throwable error,
-        @Experimental String result) {}
+        @Experimental String result) {
+
+    /**
+     * Creates operation-end information without a result.
+     *
+     * <p>Retained so callers written before {@code result} was added keep compiling and linking; {@code result}
+     * resolves to null.
+     *
+     * @param id operation ID
+     * @param name human-readable operation name (may be null)
+     * @param type operation type
+     * @param subType operation sub-type (may be null)
+     * @param parentId parent operation ID (null for root-level operations)
+     * @param startTimestamp when the operation started
+     * @param endTimestamp when the operation ended
+     * @param status the operation's terminal status
+     * @param attempt the total number of attempts for retriable operations
+     * @param isReplay true if this operation already existed in the execution state
+     * @param error non-null if the operation failed
+     */
+    public OperationEndInfo(
+            String id,
+            String name,
+            String type,
+            String subType,
+            String parentId,
+            Instant startTimestamp,
+            Instant endTimestamp,
+            String status,
+            Integer attempt,
+            boolean isReplay,
+            Throwable error) {
+        this(id, name, type, subType, parentId, startTimestamp, endTimestamp, status, attempt, isReplay, error, null);
+    }
+
+    /**
+     * Returns a representation that omits {@code result}.
+     *
+     * <p>The generated representation would render the operation result, so plugins that log this object whole would
+     * start emitting customer payloads, potentially including secrets or personal data. Read the component explicitly
+     * to record it.
+     */
+    @Override
+    public String toString() {
+        return "OperationEndInfo[id=" + id + ", name=" + name + ", type=" + type + ", subType=" + subType
+                + ", parentId=" + parentId + ", startTimestamp=" + startTimestamp + ", endTimestamp=" + endTimestamp
+                + ", status=" + status + ", attempt=" + attempt + ", isReplay=" + isReplay + ", error=" + error + "]";
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
@@ -69,7 +69,33 @@ public final class PluginInfoConverter {
                         ? operation.stepDetails().attempt()
                         : null,
                 isReplay,
-                error);
+                error,
+                extractResult(operation));
+    }
+
+    /**
+     * Extracts the serialized result from an operation based on its type. Returns null if the operation has no result
+     * (e.g., failed or still running).
+     */
+    private static String extractResult(Operation operation) {
+        if (operation == null || operation.type() == null) {
+            return null;
+        }
+        return switch (operation.type()) {
+            case STEP ->
+                operation.stepDetails() != null ? operation.stepDetails().result() : null;
+            case CHAINED_INVOKE ->
+                operation.chainedInvokeDetails() != null
+                        ? operation.chainedInvokeDetails().result()
+                        : null;
+            case CALLBACK ->
+                operation.callbackDetails() != null
+                        ? operation.callbackDetails().result()
+                        : null;
+            case CONTEXT ->
+                operation.contextDetails() != null ? operation.contextDetails().result() : null;
+            default -> null;
+        };
     }
 
     /**

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.services.lambda.model.Operation;
+import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.operation.BaseDurableOperation;
 
@@ -71,9 +72,14 @@ public final class PluginInfoConverter {
     /**
      * Extracts the serialized result from an operation based on its type. Returns null if the operation has no result
      * (e.g., failed or still running).
+     *
+     * <p>Only a SUCCEEDED operation reports a result. The status guard is required, not just defensive: a
+     * wait-for-condition is checkpointed as {@link OperationType#STEP} and reuses {@code stepDetails().result()} to
+     * carry its intermediate check-loop state between attempts, so a failed one can still hold state that must not be
+     * surfaced as that operation's result.
      */
     private static String extractResult(Operation operation) {
-        if (operation == null || operation.type() == null) {
+        if (operation == null || operation.type() == null || operation.status() != OperationStatus.SUCCEEDED) {
             return null;
         }
         return switch (operation.type()) {

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginInfoConverterTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginInfoConverterTest.java
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.lambda.model.CallbackDetails;
+import software.amazon.awssdk.services.lambda.model.ChainedInvokeDetails;
+import software.amazon.awssdk.services.lambda.model.ContextDetails;
 import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.awssdk.services.lambda.model.OperationType;
@@ -111,6 +114,103 @@ class PluginInfoConverterTest {
         var info = PluginInfoConverter.toOperationEndInfo(operation, STEP_IDENTIFIER, null, false, null);
 
         assertEquals("\"hello\"", info.result());
+    }
+
+    @Test
+    void toOperationEndInfo_extractsResult_fromSucceededChainedInvoke() {
+        var operation = Operation.builder()
+                .startTimestamp(START)
+                .endTimestamp(END)
+                .type(OperationType.CHAINED_INVOKE)
+                .status(OperationStatus.SUCCEEDED)
+                .chainedInvokeDetails(
+                        ChainedInvokeDetails.builder().result("\"invoked\"").build())
+                .build();
+
+        var info = PluginInfoConverter.toOperationEndInfo(operation, STEP_IDENTIFIER, null, false, null);
+
+        assertEquals("\"invoked\"", info.result());
+    }
+
+    @Test
+    void toOperationEndInfo_extractsResult_fromSucceededCallback() {
+        var operation = Operation.builder()
+                .startTimestamp(START)
+                .endTimestamp(END)
+                .type(OperationType.CALLBACK)
+                .status(OperationStatus.SUCCEEDED)
+                .callbackDetails(
+                        CallbackDetails.builder().result("\"called-back\"").build())
+                .build();
+
+        var info = PluginInfoConverter.toOperationEndInfo(operation, STEP_IDENTIFIER, null, false, null);
+
+        assertEquals("\"called-back\"", info.result());
+    }
+
+    @Test
+    void toOperationEndInfo_extractsResult_fromSucceededContext() {
+        var operation = Operation.builder()
+                .startTimestamp(START)
+                .endTimestamp(END)
+                .type(OperationType.CONTEXT)
+                .status(OperationStatus.SUCCEEDED)
+                .contextDetails(
+                        ContextDetails.builder().result("\"child-done\"").build())
+                .build();
+
+        var info = PluginInfoConverter.toOperationEndInfo(operation, STEP_IDENTIFIER, null, false, null);
+
+        assertEquals("\"child-done\"", info.result());
+    }
+
+    @Test
+    void toOperationEndInfo_resultIsNull_whenFailedWaitForConditionRetainsCheckpointState() {
+        // A wait-for-condition is checkpointed as STEP and reuses stepDetails().result() to carry its
+        // intermediate check-loop state between attempts, so a failed one can still hold state.
+        var operation = Operation.builder()
+                .startTimestamp(START)
+                .endTimestamp(END)
+                .type(OperationType.STEP)
+                .status(OperationStatus.FAILED)
+                .stepDetails(
+                        StepDetails.builder().attempt(3).result("{\"polls\":2}").build())
+                .build();
+
+        var info = PluginInfoConverter.toOperationEndInfo(operation, STEP_IDENTIFIER, null, false, null);
+
+        assertNull(info.result(), "a failed operation must not report intermediate state as its result");
+    }
+
+    @Test
+    void operationEndInfo_compatibilityConstructor_leavesResultNull() {
+        var info = new OperationEndInfo(
+                OPERATION_ID, OPERATION_NAME, "STEP", "Step", PARENT_ID, START, END, "SUCCEEDED", 1, false, null);
+
+        assertNull(info.result());
+    }
+
+    @Test
+    void operationEndInfo_toString_omitsResult() {
+        var info = new OperationEndInfo(
+                OPERATION_ID,
+                OPERATION_NAME,
+                "STEP",
+                "Step",
+                PARENT_ID,
+                START,
+                END,
+                "SUCCEEDED",
+                1,
+                false,
+                null,
+                "s3cret-result");
+
+        var rendered = info.toString();
+
+        assertFalse(rendered.contains("s3cret-result"), "operation result must not leak into logs");
+        assertTrue(rendered.contains(OPERATION_ID));
+        assertTrue(rendered.contains("SUCCEEDED"));
     }
 
     @Test

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginInfoConverterTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginInfoConverterTest.java
@@ -8,6 +8,8 @@ import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
+import software.amazon.awssdk.services.lambda.model.OperationType;
+import software.amazon.awssdk.services.lambda.model.StepDetails;
 import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
 
@@ -94,6 +96,35 @@ class PluginInfoConverterTest {
         var info = PluginInfoConverter.toOperationEndInfo(operation, STEP_IDENTIFIER, null, false, null);
 
         assertNull(info.error());
+    }
+
+    @Test
+    void toOperationEndInfo_extractsResult_fromSucceededStep() {
+        var operation = Operation.builder()
+                .startTimestamp(START)
+                .endTimestamp(END)
+                .type(OperationType.STEP)
+                .status(OperationStatus.SUCCEEDED)
+                .stepDetails(StepDetails.builder().result("\"hello\"").build())
+                .build();
+
+        var info = PluginInfoConverter.toOperationEndInfo(operation, STEP_IDENTIFIER, null, false, null);
+
+        assertEquals("\"hello\"", info.result());
+    }
+
+    @Test
+    void toOperationEndInfo_resultIsNull_whenOperationHasNoResult() {
+        var operation = Operation.builder()
+                .startTimestamp(START)
+                .endTimestamp(END)
+                .type(OperationType.WAIT)
+                .status(OperationStatus.SUCCEEDED)
+                .build();
+
+        var info = PluginInfoConverter.toOperationEndInfo(operation, WAIT_IDENTIFIER, null, false, null);
+
+        assertNull(info.result());
     }
 
     // ─── toUserFunctionStartInfo ────────────────────────────────────────

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
@@ -151,7 +151,18 @@ class PluginRunnerTest {
 
     private static OperationEndInfo operationEndInfo() {
         return new OperationEndInfo(
-                "op-1", "test-step", "STEP", null, null, Instant.now(), Instant.now(), "SUCCEEDED", null, false, null);
+                "op-1",
+                "test-step",
+                "STEP",
+                null,
+                null,
+                Instant.now(),
+                Instant.now(),
+                "SUCCEEDED",
+                null,
+                false,
+                null,
+                null);
     }
 
     private static OperationChangeInfo operationChangeInfo() {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
https://github.com/aws/aws-durable-execution-sdk-java/issues/579

### Description
OperationEndInfo exposed error() for failed operations but had no way for plugins to access the serialized result of successful operations.

- Added String result field to the OperationEndInfo record
- Added extractResult(Operation) in PluginInfoConverter that pulls the serialized result from the operation's type-specific details (stepDetails, callbackDetails, chainedInvokeDetails, contextDetails)

### Demo/Screenshots
N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? Added

#### Integration Tests

Have integration tests been written for these changes? Added

#### Examples

Has a new example been added for the change? (if applicable) N/A
