### PR TITLE
docs: Add testing requirements to contributing and agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,12 @@ void testAgainstRealLambda() {
 }
 ```
 
+### Testing Requirements
+
+All changes MUST include related tests. At minimum, include **unit tests**. Include **integration tests** when the change affects cross-component behavior, public API surfaces, or end-to-end workflows. For isolated bug fixes where a unit test alone sufficiently covers the fix, integration tests are not required.
+
+Do NOT add conformance tests — conformance tests live in a separate repository ([aws-durable-execution-conformance-tests](https://github.com/aws/aws-durable-execution-conformance-tests)) and are managed by the team. If a change warrants a new conformance test, note it in the PR description or [open an issue](https://github.com/aws/aws-durable-execution-conformance-tests/issues/new?template=new_requirement.yml) in that repository.
+
 ### Test Guidelines
 
 - Test business logic, replay behavior, suspension/resume behavior, and edge cases.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,11 @@ To send us a pull request, please:
 
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+3. Write tests for your changes and ensure all tests pass. At minimum, include related **unit tests**. Include **integration tests** when the change affects cross-component behavior, public API surfaces, or end-to-end workflows. For isolated bug fixes where a unit test alone sufficiently covers the fix, integration tests are not required. See [docs/advanced/testing.md](docs/advanced/testing.md) for details on running tests and the testing architecture.
+4. Do **not** add conformance tests. If you believe your change warrants a conformance test, please mention it in your PR description or open an issue in the [Conformance Tests repository](https://github.com/aws/aws-durable-execution-conformance-tests/issues/new?template=new_requirement.yml).
+5. Commit to your fork using clear commit messages.
+6. Send us a pull request, answering any default questions in the pull request interface.
+7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).

--- a/docs/advanced/testing.md
+++ b/docs/advanced/testing.md
@@ -85,3 +85,8 @@ var runner = CloudDurableTestRunner.create(
 var result = runner.run(new Order("order-123", items));
 assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
 ```
+
+
+### Conformance Tests
+
+Conformance tests verify cross-SDK behavioral parity and live in a separate repository: [aws-durable-execution-conformance-tests](https://github.com/aws/aws-durable-execution-conformance-tests). Contributors do not need to add conformance tests. If you believe a change warrants one, mention it in your PR description or [open an issue](https://github.com/aws/aws-durable-execution-conformance-tests/issues/new?template=new_requirement.yml) in that repository.


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available
N/A

### Description
Add explicit testing requirements and conformance test guidance to contributor-facing documentation.
Similar to https://github.com/aws/aws-durable-execution-sdk-js/pull/791

### Demo/Screenshots
N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
