### PR TITLE
fix(otel): add subtype to execution attempt spans

### DIFF
--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -440,6 +440,9 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         if (info.name() != null) {
             spanBuilder.setAttribute(DURABLE_OPERATION_NAME, info.name());
         }
+        if (info.subType() != null) {
+            spanBuilder.setAttribute(DURABLE_OPERATION_SUBTYPE, info.subType());
+        }
         if (info.attempt() != null) {
             spanBuilder.setAttribute(DURABLE_ATTEMPT_NUMBER, info.attempt().longValue());
         }

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -333,6 +333,25 @@ class ExecutionOtelPluginTest {
     }
 
     @Test
+    void attemptSpan_carriesOperationSubtype() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
+        plugin.onUserFunctionStart(
+                new UserFunctionStartInfo("op-1", "process-order", "STEP", "Step", null, Instant.now(), false, 1));
+        plugin.onUserFunctionEnd(new UserFunctionEndInfo(
+                "op-1", "process-order", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var attemptSpan = spanExporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().contains("process-order"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(
+                "Step",
+                attemptSpan.getAttributes().get(AttributeKey.stringKey("durable.operation.subtype")),
+                "Attempt span should carry durable.operation.subtype from the operation");
+    }
+
+    @Test
     void childOperation_parentedToParentOperationSpan() {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onOperationStart(new OperationInfo(


### PR DESCRIPTION
## Summary
- emit `durable.operation.subtype` on `ExecutionOtelPlugin` attempt spans
- add regression coverage matching the invocation-view plugin behavior

## Testing
- `mvn spotless:apply`
- `mvn -pl otel-plugin -am -Dtest=ExecutionOtelPluginTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl otel-plugin -am test`

## Context
Fixes the missing subtype assertions observed in the [Java execution-view conformance job](https://github.com/aws/aws-durable-execution-conformance-tests/actions/runs/31059801062/job/92519884468).