### PR TITLE
fix: keep parallel results consistent for late branches

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
@@ -1207,9 +1207,26 @@ class ParallelIntegrationTest {
             }
             assertEquals(ConcurrencyCompletionStatus.MIN_SUCCESSFUL_REACHED, result.completionStatus());
             assertTrue(result.completionStatus().isSucceeded());
-            assertTrue(result.size() >= 2 && result.size() <= 5);
-            assertEquals(ParallelResult.Status.SKIPPED, result.statuses().get(0));
-            assertEquals(ParallelResult.Status.SKIPPED, result.statuses().get(1));
+            assertEquals(5, result.size());
+            assertTrue(result.succeeded() >= 2);
+            assertEquals(0, result.failed());
+            assertEquals(result.size(), result.statuses().size());
+            assertEquals(result.size(), result.succeeded() + result.failed() + result.skipped());
+            assertEquals(
+                    result.succeeded(),
+                    result.statuses().stream()
+                            .filter(status -> status == ParallelResult.Status.SUCCEEDED)
+                            .count());
+            assertEquals(
+                    result.failed(),
+                    result.statuses().stream()
+                            .filter(status -> status == ParallelResult.Status.FAILED)
+                            .count());
+            assertEquals(
+                    result.skipped(),
+                    result.statuses().stream()
+                            .filter(status -> status == ParallelResult.Status.SKIPPED)
+                            .count());
 
             return "done";
         });

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.operation;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import software.amazon.awssdk.services.lambda.model.ContextOptions;
@@ -107,16 +108,28 @@ public class ParallelOperation extends ConcurrencyOperation<ParallelResult> impl
     }
 
     private ParallelResult rebuildParallelResult() {
-        if (cachedResult != null && cachedResult.size() != getBranches().size()) {
-            return new ParallelResult(
-                    getBranches().size(), // size might be updated after cached result is built
-                    cachedResult.succeeded(),
-                    cachedResult.failed(),
-                    cachedResult.skipped(),
-                    cachedResult.completionStatus(),
-                    cachedResult.statuses());
+        if (cachedResult == null) {
+            return null;
         }
-        return cachedResult;
+
+        var statuses = new ArrayList<>(cachedResult.statuses());
+        while (statuses.size() < getBranches().size()) {
+            statuses.add(ParallelResult.Status.SKIPPED);
+        }
+
+        int succeededCount = Math.toIntExact(statuses.stream()
+                .filter(status -> status == ParallelResult.Status.SUCCEEDED)
+                .count());
+        int failedCount = Math.toIntExact(statuses.stream()
+                .filter(status -> status == ParallelResult.Status.FAILED)
+                .count());
+        return new ParallelResult(
+                statuses.size(),
+                succeededCount,
+                failedCount,
+                statuses.size() - succeededCount - failedCount,
+                cachedResult.completionStatus(),
+                List.copyOf(statuses));
     }
 
     @Override

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/ParallelOperation.java
@@ -108,10 +108,6 @@ public class ParallelOperation extends ConcurrencyOperation<ParallelResult> impl
     }
 
     private ParallelResult rebuildParallelResult() {
-        if (cachedResult == null) {
-            return null;
-        }
-
         var statuses = new ArrayList<>(cachedResult.statuses());
         while (statuses.size() < getBranches().size()) {
             statuses.add(ParallelResult.Status.SKIPPED);

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/ParallelOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/ParallelOperationTest.java
@@ -8,9 +8,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.ContextDetails;
@@ -32,6 +35,7 @@ import software.amazon.lambda.durable.execution.ThreadType;
 import software.amazon.lambda.durable.model.ConcurrencyCompletionStatus;
 import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
+import software.amazon.lambda.durable.model.ParallelResult;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
 import software.amazon.lambda.durable.serde.SerDes;
 
@@ -48,12 +52,14 @@ class ParallelOperationTest {
     // Tests pre-populate this; doAnswer writes here before firing onCheckpointComplete,
     // guaranteeing visibility to any thread that reads after the future unblocks.
     private ConcurrentHashMap<String, Operation> operationStore;
+    private CountDownLatch parallelCheckpointLatch;
 
     @BeforeEach
     void setUp() {
         durableContext = mock(DurableContextImpl.class);
         executionManager = mock(ExecutionManager.class);
         operationStore = new ConcurrentHashMap<>();
+        parallelCheckpointLatch = new CountDownLatch(1);
 
         when(executionManager.getCurrentThreadContext()).thenReturn(new ThreadContext(null, ThreadType.CONTEXT));
         // Delegate to operationStore so all reads see the latest write, regardless of thread.
@@ -106,6 +112,7 @@ class ParallelOperationTest {
                         if (op != null) {
                             op.onCheckpointComplete(succeededParallelOp);
                         }
+                        parallelCheckpointLatch.countDown();
                     }
                     return CompletableFuture.completedFuture(null);
                 })
@@ -257,6 +264,40 @@ class ParallelOperationTest {
         assertEquals(0, result.failed());
         assertEquals(ConcurrencyCompletionStatus.MIN_SUCCESSFUL_REACHED, result.completionStatus());
         assertTrue(result.completionStatus().isSucceeded());
+    }
+
+    @Test
+    void minSuccessful_branchRegisteredAfterCheckpointIsIncludedAsSkipped() throws Exception {
+        when(executionManager.getOperationAndUpdateReplayState(CHILD_OP_1))
+                .thenReturn(Operation.builder()
+                        .id(CHILD_OP_1)
+                        .name("branch-1")
+                        .type(OperationType.CONTEXT)
+                        .subType(OperationSubType.PARALLEL_BRANCH.getValue())
+                        .status(OperationStatus.SUCCEEDED)
+                        .contextDetails(
+                                ContextDetails.builder().result("\"r1\"").build())
+                        .build());
+
+        var op = createOperation(CompletionConfig.minSuccessful(1));
+        op.enqueueItem(
+                "branch-1", ctx -> "r1", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH, false);
+
+        assertTrue(parallelCheckpointLatch.await(5, TimeUnit.SECONDS));
+
+        op.enqueueItem(
+                "branch-2", ctx -> "r2", TypeToken.get(String.class), SER_DES, OperationSubType.PARALLEL_BRANCH, false);
+
+        var result = op.get();
+
+        assertEquals(2, result.size());
+        assertEquals(1, result.succeeded());
+        assertEquals(0, result.failed());
+        assertEquals(1, result.skipped());
+        assertEquals(ConcurrencyCompletionStatus.MIN_SUCCESSFUL_REACHED, result.completionStatus());
+        assertEquals(List.of(ParallelResult.Status.SUCCEEDED, ParallelResult.Status.SKIPPED), result.statuses());
+        assertEquals(result.size(), result.statuses().size());
+        assertEquals(result.size(), result.succeeded() + result.failed() + result.skipped());
     }
 
     @Test


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Fixes #409

### Description

A parallel operation can satisfy an early-completion condition before the handler finishes registering branches. The checkpointed result then contains only the branches known at completion time, while the returned result previously updated only `size`, leaving `statuses` and `skipped` inconsistent and allowing replay to return a structurally different result.

This change pads branches registered after the checkpoint with `SKIPPED`, recalculates all summary counts from the normalized status list, and returns an immutable list. Early-completion behavior remains unchanged.

### Demo/Screenshots

Not applicable.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Yes. Added a deterministic regression test that waits for the parent parallel checkpoint, registers another branch, and verifies a consistent `[SUCCEEDED, SKIPPED]` result.

- `mvn -pl sdk -Dtest=ParallelOperationTest test`

#### Integration Tests

Yes. Strengthened the existing early-termination replay test to verify result counts and status-list invariants without assuming which branches win the scheduling race.

- Targeted `ParallelIntegrationTest.testParallelWithMinSuccessful_earlyTermination_consistentResult` for both nesting modes
- Full reactor `mvn test` on Java 17; the Byte Buddy agent was preloaded locally because macOS blocked Mockito dynamic attachment

#### Examples

Not applicable; no user-facing API usage changed.