### PR TITLE
fix(otel): keep continuation spans within invocation

### DIFF
--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -453,10 +453,6 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
                     .setAttribute(DURABLE_OPERATION_TYPE, info.type());
             addWorkflowLink(spanBuilder);
 
-            if (info.startTimestamp() != null) {
-                spanBuilder.setStartTimestamp(info.startTimestamp());
-            }
-
             if (info.name() != null) {
                 spanBuilder.setAttribute(DURABLE_OPERATION_NAME, info.name());
             }

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -914,11 +914,11 @@ class InvocationOtelPluginTest {
     }
 
     @Test
-    void operationEnd_withoutMatchingStart_usesOperationStartTimestamp() {
+    void operationEnd_withoutMatchingStart_startsWithinCurrentInvocation() {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
-        var operationStart = Instant.parse("2026-01-15T08:30:00Z");
-        var operationEnd = Instant.parse("2026-01-15T09:00:00Z");
+        var operationStart = Instant.EPOCH;
+        var operationEnd = operationStart.plusSeconds(60);
 
         // onOperationEnd without a prior onOperationStart — continuation span
         plugin.onOperationEnd(new OperationEndInfo(
@@ -936,15 +936,19 @@ class InvocationOtelPluginTest {
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
-        var continuationSpan = spanExporter.getFinishedSpanItems().stream()
+        var spans = spanExporter.getFinishedSpanItems();
+        var continuationSpan = spans.stream()
                 .filter(s -> s.getName().contains("wait"))
                 .findFirst()
                 .orElseThrow();
+        var invocationSpan = spans.stream()
+                .filter(s -> s.getName().equals("Invocation"))
+                .findFirst()
+                .orElseThrow();
 
-        assertEquals(
-                operationStart.toEpochMilli(),
-                continuationSpan.getStartEpochNanos() / 1_000_000,
-                "Continuation span should use the operation's startTimestamp");
+        assertEquals(invocationSpan.getSpanId(), continuationSpan.getParentSpanId());
+        assertTrue(continuationSpan.getStartEpochNanos() >= invocationSpan.getStartEpochNanos());
+        assertTrue(continuationSpan.getEndEpochNanos() <= invocationSpan.getEndEpochNanos());
     }
 
     @Test


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Observed in the OpenTelemetry invocation-view conformance run: https://github.com/aws/aws-durable-execution-conformance-tests/actions/runs/31059801062/job/92519884437?pr=69

### Description

Invocation-view continuation spans were backdated to the logical operation start timestamp from a prior Lambda invocation. Because the continuation is parented to the current invocation span, this made it start before its parent and overlap the original STARTED operation span.

Allow continuation spans to use their creation time in the current invocation. The execution-view plugin continues to use the original operation timestamp for its single logical cross-invocation span. The unit test now verifies that a continuation is parented to and temporally contained by the current invocation span.

### Demo/Screenshots

Not applicable.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Updated `InvocationOtelPluginTest` with a regression test covering continuation span parentage and temporal containment.

#### Integration Tests

Ran `mvn -pl otel-plugin -am test`: reactor build succeeded, including all 148 OpenTelemetry plugin tests and 17 invocation plugin integration tests. No new integration test was needed for this isolated span timestamp change.

#### Examples

Not applicable.