### PR TITLE
feat: load plugins dynamically from Lambda layers

### DIFF
--- a/docs/advanced/configuration.md
+++ b/docs/advanced/configuration.md
@@ -39,3 +39,58 @@ public class OrderProcessor extends DurableHandler<Order, OrderResult> {
 | `withCheckpointDelay()`     | How often the SDK checkpoints updates   | `Duration.ofSeconds(0)` (as soon as possible) |
 
 The `withExecutorService()` option configures the thread pool used for running user-defined operations. Internal SDK coordination (checkpoint batching, polling) runs on an SDK-managed thread pool.
+
+### Dynamic plugin loading
+
+Dynamic plugin loading is an experimental, opt-in alternative to registering plugins in application code. Put provider JARs on the application class path, then set `DURABLE_EXECUTION_PLUGINS` to an ordered, comma-separated list of provider names:
+
+```text
+DURABLE_EXECUTION_PLUGINS=otel-invocation,com.example.audit
+```
+
+When the variable is unset or blank, the SDK does not perform provider discovery. During `DurableConfig` construction, the SDK uses `ServiceLoader` and the thread context class loader to find `DurableExecutionPluginProvider` implementations. Only named providers create plugins.
+
+Dynamically loaded plugins run first in the order listed in `DURABLE_EXECUTION_PLUGINS`. Plugins registered through `withPlugins(...)` follow in configuration order. Both sources are additive: if the same plugin type is selected dynamically and registered explicitly, both instances are registered and receive lifecycle hooks. Duplicate configured provider names, duplicate discovered provider names, missing providers, incompatible provider API versions, invalid plugin types, and provider construction failures stop configuration with an `IllegalStateException`.
+
+To distribute a provider in a Lambda layer, package its JAR under `java/lib`:
+
+```text
+my-plugin-layer.zip
+`-- java
+    `-- lib
+        `-- my-durable-plugin.jar
+```
+
+The provider JAR must contain:
+
+```text
+META-INF/services/software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider
+```
+
+The service file contains the provider implementation class name. A minimal provider looks like:
+
+```java
+public final class AuditPluginProvider implements DurableExecutionPluginProvider {
+    @Override
+    public String getName() {
+        return "com.example.audit";
+    }
+
+    @Override
+    public int getApiVersion() {
+        return API_VERSION;
+    }
+
+    @Override
+    public Class<? extends DurableExecutionPlugin> getPluginType() {
+        return AuditPlugin.class;
+    }
+
+    @Override
+    public DurableExecutionPlugin createPlugin() {
+        return new AuditPlugin();
+    }
+}
+```
+
+Provider-specific settings can use namespaced environment variables. If an application shades provider JARs into one artifact, its build must preserve and merge `META-INF/services` entries.

--- a/otel-plugin/README.md
+++ b/otel-plugin/README.md
@@ -11,6 +11,7 @@ OpenTelemetry instrumentation plugin for the AWS Lambda Durable Execution SDK fo
 - **Attempt Spans**: Each user function execution (step attempt, child context run) gets a span, including retries
 - **Log Correlation**: Injects `trace_id`, `span_id`, and `traceSampled` into SLF4J MDC for end-to-end observability
 - **ADOT Java Agent Integration**: `new InvocationOtelPlugin()` uses the ADOT Java agent's global provider with no handler-side OpenTelemetry initialization
+- **Lambda Layer Discovery**: `DURABLE_EXECUTION_PLUGINS` loads either OTel plugin from a JAR under a layer's `java/lib` directory
 
 ## Installation
 
@@ -44,7 +45,7 @@ If you configure your own `SdkTracerProviderBuilder`, add the OpenTelemetry SDK 
 1. Add the ADOT Lambda Layer to your function
 2. Enable X-Ray Active Tracing on the function
 3. Configure environment variables
-4. Register `InvocationOtelPlugin` in your handler's `DurableConfig`
+4. Load `InvocationOtelPlugin` dynamically or register it in your handler's `DurableConfig`
 5. Grant X-Ray write permissions
 
 ### 1. ADOT Lambda Layer
@@ -70,10 +71,12 @@ MyFunction:
       LogFormat: JSON
     Layers:
       - !Sub arn:aws:lambda:${AWS::Region}:615299751070:layer:AWSOpenTelemetryDistroJava:16
+      - <otel-plugin-layer-arn>
     Environment:
       Variables:
         AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
-        OTEL_JAVAAGENT_EXTENSIONS: /var/task/lib/aws-durable-execution-sdk-java-plugin-otel-<version>.jar
+        OTEL_JAVAAGENT_EXTENSIONS: /opt/java/lib/aws-durable-execution-sdk-java-plugin-otel-<version>.jar
+        DURABLE_EXECUTION_PLUGINS: otel-invocation
 ```
 
 **AWS CLI:**
@@ -81,11 +84,11 @@ MyFunction:
 ```bash
 aws lambda update-function-configuration \
   --function-name your-function-name \
-  --layers "arn:aws:lambda:<region>:615299751070:layer:AWSOpenTelemetryDistroJava:16" \
-  --environment "Variables={AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-instrument,OTEL_JAVAAGENT_EXTENSIONS=/var/task/lib/aws-durable-execution-sdk-java-plugin-otel-<version>.jar}"
+  --layers "arn:aws:lambda:<region>:615299751070:layer:AWSOpenTelemetryDistroJava:16" "<otel-plugin-layer-arn>" \
+  --environment "Variables={AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-instrument,OTEL_JAVAAGENT_EXTENSIONS=/opt/java/lib/aws-durable-execution-sdk-java-plugin-otel-<version>.jar,DURABLE_EXECUTION_PLUGINS=otel-invocation}"
 ```
 
-Set `OTEL_JAVAAGENT_EXTENSIONS` to the deployed OTel plugin jar that contains this plugin's `META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider` entry.
+Build the plugin layer ZIP with the OTel plugin JAR at `java/lib/aws-durable-execution-sdk-java-plugin-otel-<version>.jar`. Lambda adds JARs in this directory to the Java class path. Set `OTEL_JAVAAGENT_EXTENSIONS` to the deployed JAR so the ADOT Java agent also loads its `AutoConfigurationCustomizerProvider`, and set `DURABLE_EXECUTION_PLUGINS=otel-invocation` so the Durable Execution SDK loads its `InvocationOtelPluginProvider`.
 
 ### 2. AWS X-Ray Active Tracing
 
@@ -102,7 +105,20 @@ MyFunction:
     Tracing: Active
 ```
 
-### 3. In Your Lambda Handler
+### 3. Plugin Registration
+
+With the layer and `DURABLE_EXECUTION_PLUGINS=otel-invocation` configured above, no OTel plugin dependency or registration code is required in the function artifact. The function can use its existing `DurableConfig`.
+
+The OTel plugin JAR exposes two dynamic provider names:
+
+| Provider name | Plugin | Trace model |
+|---------------|--------|-------------|
+| `otel-invocation` | `InvocationOtelPlugin` | Invocation-rooted |
+| `otel-execution` | `ExecutionOtelPlugin` | Workflow-rooted |
+
+Set `DURABLE_EXECUTION_PLUGINS=otel-execution` to select the Workflow-rooted plugin instead.
+
+Applications that prefer code-based configuration can continue to register the plugin explicitly:
 
 ```java
 import software.amazon.lambda.durable.DurableConfig;

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginProvider.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginProvider.java
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.otel;
+
+import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
+import software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider;
+
+/**
+ * Dynamically loads {@link ExecutionOtelPlugin} when {@code DURABLE_EXECUTION_PLUGINS} contains {@code otel-execution}.
+ *
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public final class ExecutionOtelPluginProvider implements DurableExecutionPluginProvider {
+
+    @Override
+    public String getName() {
+        return "otel-execution";
+    }
+
+    @Override
+    public int getApiVersion() {
+        return API_VERSION;
+    }
+
+    @Override
+    public Class<? extends DurableExecutionPlugin> getPluginType() {
+        return ExecutionOtelPlugin.class;
+    }
+
+    @Override
+    public DurableExecutionPlugin createPlugin() {
+        return new ExecutionOtelPlugin();
+    }
+}

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPluginProvider.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPluginProvider.java
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.otel;
+
+import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
+import software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider;
+
+/**
+ * Dynamically loads {@link InvocationOtelPlugin} when {@code DURABLE_EXECUTION_PLUGINS} contains
+ * {@code otel-invocation}.
+ *
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public final class InvocationOtelPluginProvider implements DurableExecutionPluginProvider {
+
+    @Override
+    public String getName() {
+        return "otel-invocation";
+    }
+
+    @Override
+    public int getApiVersion() {
+        return API_VERSION;
+    }
+
+    @Override
+    public Class<? extends DurableExecutionPlugin> getPluginType() {
+        return InvocationOtelPlugin.class;
+    }
+
+    @Override
+    public DurableExecutionPlugin createPlugin() {
+        return new InvocationOtelPlugin();
+    }
+}

--- a/otel-plugin/src/main/resources/META-INF/services/software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider
+++ b/otel-plugin/src/main/resources/META-INF/services/software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider
@@ -1,0 +1,2 @@
+software.amazon.lambda.durable.otel.InvocationOtelPluginProvider
+software.amazon.lambda.durable.otel.ExecutionOtelPluginProvider

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -15,6 +15,7 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import java.time.Instant;
+import java.util.ServiceLoader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -85,6 +86,19 @@ class ExecutionOtelPluginTest {
         assertTrue(spans.stream().anyMatch(span -> span.getName().equals("Workflow")));
         assertTrue(spans.stream().anyMatch(span -> span.getName().equals("Invocation")));
         assertTrue(spans.stream().anyMatch(span -> span.getName().equals("step")));
+    }
+
+    @Test
+    void executionOtelPluginProvider_isRegisteredAsServiceProvider() {
+        var provider = ServiceLoader.load(DurableExecutionPluginProvider.class).stream()
+                .filter(candidate -> candidate.type().equals(ExecutionOtelPluginProvider.class))
+                .findFirst()
+                .orElseThrow()
+                .get();
+
+        assertEquals("otel-execution", provider.getName());
+        assertEquals(DurableExecutionPluginProvider.API_VERSION, provider.getApiVersion());
+        assertEquals(ExecutionOtelPlugin.class, provider.getPluginType());
     }
 
     // ─── Workflow root span lifecycle ────────────────────────────────────

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -197,6 +197,19 @@ class InvocationOtelPluginTest {
     }
 
     @Test
+    void invocationOtelPluginProvider_isRegisteredAsServiceProvider() {
+        var provider = ServiceLoader.load(DurableExecutionPluginProvider.class).stream()
+                .filter(candidate -> candidate.type().equals(InvocationOtelPluginProvider.class))
+                .findFirst()
+                .orElseThrow()
+                .get();
+
+        assertEquals("otel-invocation", provider.getName());
+        assertEquals(DurableExecutionPluginProvider.API_VERSION, provider.getApiVersion());
+        assertEquals(InvocationOtelPlugin.class, provider.getPluginType());
+    }
+
+    @Test
     void invocationStart_usesCurrentSpanContext_whenExtractorReturnsNull() {
         var traceId = "5759e988bd862e3fe1be46a994272793";
         var parentSpanId = "53995c3f42cd8ad8";

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -27,6 +27,29 @@ class PluginIntegrationTest {
     // ─── Invocation-level hooks ──────────────────────────────────────────
 
     @Test
+    void pluginsFromConfigurationAndEnvironment_receiveLifecycleEvents() {
+        var configuredPlugin = new RecordingPlugin();
+        var dynamicPlugin = new RecordingPlugin();
+        var provider = new RecordingPluginProvider(dynamicPlugin);
+        var plugins =
+                DynamicPluginLoader.loadConfiguredPlugins("recording", List.of(provider), List.of(configuredPlugin));
+        var config = DurableConfig.builder()
+                .withPlugins(plugins.toArray(DurableExecutionPlugin[]::new))
+                .build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> context.step("greet", String.class, stepCtx -> "Hello " + input),
+                config);
+
+        var result = runner.runUntilComplete("World");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertPluginReceivedLifecycleEvents(configuredPlugin);
+        assertPluginReceivedLifecycleEvents(dynamicPlugin);
+    }
+
+    @Test
     void plugin_receivesInvocationStartAndEnd_onSuccessfulExecution() {
         var plugin = new RecordingPlugin();
         var config = DurableConfig.builder().withPlugins(plugin).build();
@@ -782,6 +805,34 @@ class PluginIntegrationTest {
         public void onOperationChange(OperationChangeInfo info) {
             operationChanges.add(info);
         }
+    }
+
+    private record RecordingPluginProvider(RecordingPlugin plugin) implements DurableExecutionPluginProvider {
+        @Override
+        public String getName() {
+            return "recording";
+        }
+
+        @Override
+        public int getApiVersion() {
+            return API_VERSION;
+        }
+
+        @Override
+        public Class<? extends DurableExecutionPlugin> getPluginType() {
+            return RecordingPlugin.class;
+        }
+
+        @Override
+        public DurableExecutionPlugin createPlugin() {
+            return plugin;
+        }
+    }
+
+    private static void assertPluginReceivedLifecycleEvents(RecordingPlugin plugin) {
+        assertEquals(1, plugin.invocationStarts.size());
+        assertTrue(plugin.operationStarts.stream().anyMatch(info -> "greet".equals(info.name())));
+        assertEquals(1, plugin.invocationEnds.size());
     }
 
     /** Plugin that throws on every hook to verify error isolation. */

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
@@ -103,6 +103,7 @@ public final class DurableConfig {
     private final PluginRunner pluginRunner;
 
     private DurableConfig(Builder builder) {
+        var plugins = DynamicPluginLoader.loadConfiguredPlugins(builder.plugins);
         this.durableExecutionClient = Objects.requireNonNullElseGet(
                 builder.durableExecutionClient, DurableConfig::createDefaultDurableExecutionClient);
         this.serDes = Objects.requireNonNullElseGet(builder.serDes, JacksonSerDes::new);
@@ -113,7 +114,7 @@ public final class DurableConfig {
         this.checkpointDelay = Objects.requireNonNullElseGet(builder.checkpointDelay, () -> Duration.ofSeconds(0));
         this.deserializeAfterSerialization = builder.deserializeAfterSerialization;
         this.checkpointEmptyMap = builder.checkpointEmptyMap;
-        this.pluginRunner = builder.plugins.isEmpty() ? PluginRunner.noOp() : new PluginRunner(builder.plugins);
+        this.pluginRunner = plugins.isEmpty() ? PluginRunner.noOp() : new PluginRunner(plugins);
 
         validateConfiguration();
     }
@@ -216,7 +217,7 @@ public final class DurableConfig {
     /**
      * Gets the plugin runner that dispatches lifecycle events to registered plugins.
      *
-     * <p>Returns a no-op runner if no plugins were registered via the builder.
+     * <p>Returns a no-op runner if no plugins were registered via the builder or loaded dynamically.
      *
      * @return PluginRunner instance (never null)
      * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.

--- a/sdk/src/main/java/software/amazon/lambda/durable/DynamicPluginLoader.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DynamicPluginLoader.java
@@ -1,0 +1,183 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
+import software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider;
+
+final class DynamicPluginLoader {
+    static final String PLUGINS_ENVIRONMENT_VARIABLE = "DURABLE_EXECUTION_PLUGINS";
+
+    private DynamicPluginLoader() {}
+
+    static List<DurableExecutionPlugin> loadConfiguredPlugins(List<DurableExecutionPlugin> explicitPlugins) {
+        var configuredNames = System.getenv(PLUGINS_ENVIRONMENT_VARIABLE);
+        if (configuredNames == null || configuredNames.isBlank()) {
+            return List.copyOf(explicitPlugins);
+        }
+
+        var classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = DurableExecutionPluginProvider.class.getClassLoader();
+        }
+        return loadConfiguredPlugins(
+                configuredNames,
+                ServiceLoader.load(DurableExecutionPluginProvider.class, classLoader),
+                explicitPlugins);
+    }
+
+    static List<DurableExecutionPlugin> loadConfiguredPlugins(
+            String configuredNames,
+            Iterable<DurableExecutionPluginProvider> providers,
+            List<DurableExecutionPlugin> explicitPlugins) {
+        if (configuredNames == null || configuredNames.isBlank()) {
+            return List.copyOf(explicitPlugins);
+        }
+
+        var requestedNames = parseProviderNames(configuredNames);
+        var providersByName = indexProviders(providers);
+        var plugins = new ArrayList<DurableExecutionPlugin>();
+        for (var name : requestedNames) {
+            addPlugin(name, getProvider(name, providersByName), plugins);
+        }
+        plugins.addAll(explicitPlugins);
+        return List.copyOf(plugins);
+    }
+
+    private static List<String> parseProviderNames(String configuredNames) {
+        var names = new ArrayList<String>();
+        var uniqueNames = new LinkedHashSet<String>();
+        for (var configuredName : configuredNames.split(",", -1)) {
+            var name = configuredName.trim();
+            if (name.isEmpty()) {
+                throw configurationError("Plugin provider names in " + PLUGINS_ENVIRONMENT_VARIABLE
+                        + " must be non-empty comma-separated values");
+            }
+            if (!uniqueNames.add(name)) {
+                throw configurationError(
+                        "Plugin provider '" + name + "' is listed more than once in " + PLUGINS_ENVIRONMENT_VARIABLE);
+            }
+            names.add(name);
+        }
+        return names;
+    }
+
+    private static Map<String, DurableExecutionPluginProvider> indexProviders(
+            Iterable<DurableExecutionPluginProvider> providers) {
+        var providersByName = new LinkedHashMap<String, DurableExecutionPluginProvider>();
+        try {
+            for (var provider : providers) {
+                if (provider == null) {
+                    throw configurationError("ServiceLoader returned a null DurableExecutionPluginProvider");
+                }
+                var name = getProviderName(provider);
+                var previous = providersByName.putIfAbsent(name, provider);
+                if (previous != null) {
+                    throw configurationError("Multiple DurableExecutionPluginProvider implementations use the name '"
+                            + name + "': " + previous.getClass().getName() + " and "
+                            + provider.getClass().getName());
+                }
+            }
+        } catch (ServiceConfigurationError | LinkageError e) {
+            throw configurationError(
+                    "Failed to discover DurableExecutionPluginProvider implementations. "
+                            + "Verify that plugin JARs and the Durable Execution SDK use compatible versions",
+                    e);
+        }
+        return providersByName;
+    }
+
+    private static String getProviderName(DurableExecutionPluginProvider provider) {
+        String name;
+        try {
+            name = provider.getName();
+        } catch (RuntimeException e) {
+            throw configurationError(
+                    "Plugin provider " + provider.getClass().getName() + " failed to return its name", e);
+        }
+        if (name == null || name.isBlank() || !name.equals(name.trim())) {
+            throw configurationError("Plugin provider " + provider.getClass().getName()
+                    + " returned an invalid name; names must be non-empty and must not have surrounding spaces");
+        }
+        return name;
+    }
+
+    private static DurableExecutionPluginProvider getProvider(
+            String name, Map<String, DurableExecutionPluginProvider> providersByName) {
+        var provider = providersByName.get(name);
+        if (provider == null) {
+            var available = providersByName.isEmpty() ? "none" : String.join(", ", providersByName.keySet());
+            throw configurationError("No DurableExecutionPluginProvider named '" + name
+                    + "' was found on the application class path. Available providers: " + available);
+        }
+        return provider;
+    }
+
+    private static void addPlugin(
+            String name, DurableExecutionPluginProvider provider, List<DurableExecutionPlugin> plugins) {
+        var pluginType = validateProvider(name, provider);
+        var plugin = createPlugin(name, provider);
+        if (!pluginType.isInstance(plugin)) {
+            throw configurationError("Plugin provider '" + name + "' declared type '" + pluginType.getName()
+                    + "' but created '" + plugin.getClass().getName() + "'");
+        }
+        plugins.add(plugin);
+    }
+
+    private static Class<? extends DurableExecutionPlugin> validateProvider(
+            String name, DurableExecutionPluginProvider provider) {
+        int apiVersion;
+        Class<? extends DurableExecutionPlugin> pluginType;
+        try {
+            apiVersion = provider.getApiVersion();
+            pluginType = provider.getPluginType();
+        } catch (RuntimeException | LinkageError e) {
+            throw configurationError(
+                    "Plugin provider '" + name + "' is not compatible with this Durable Execution SDK version", e);
+        }
+        if (apiVersion != DurableExecutionPluginProvider.API_VERSION) {
+            throw configurationError("Plugin provider '" + name + "' uses provider API version " + apiVersion
+                    + ", but this SDK requires version " + DurableExecutionPluginProvider.API_VERSION);
+        }
+        if (pluginType == null
+                || pluginType.isInterface()
+                || Modifier.isAbstract(pluginType.getModifiers())
+                || !DurableExecutionPlugin.class.isAssignableFrom(pluginType)) {
+            throw configurationError(
+                    "Plugin provider '" + name + "' must declare a concrete DurableExecutionPlugin type");
+        }
+        return pluginType;
+    }
+
+    private static DurableExecutionPlugin createPlugin(String name, DurableExecutionPluginProvider provider) {
+        DurableExecutionPlugin plugin;
+        try {
+            plugin = provider.createPlugin();
+        } catch (RuntimeException | LinkageError e) {
+            throw configurationError(
+                    "Plugin provider '" + name + "' failed to create its plugin. "
+                            + "Verify its settings and compatibility with this Durable Execution SDK version",
+                    e);
+        }
+        if (plugin == null) {
+            throw configurationError("Plugin provider '" + name + "' returned a null plugin");
+        }
+        return plugin;
+    }
+
+    private static IllegalStateException configurationError(String message) {
+        return new IllegalStateException("Dynamic plugin configuration failed: " + message);
+    }
+
+    private static IllegalStateException configurationError(String message, Throwable cause) {
+        return new IllegalStateException("Dynamic plugin configuration failed: " + message, cause);
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPluginProvider.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPluginProvider.java
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+/**
+ * Service provider interface for dynamically loading {@link DurableExecutionPlugin} implementations.
+ *
+ * <p>Provider JARs register implementations in
+ * {@code META-INF/services/software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider}. The SDK only creates
+ * plugins from providers explicitly selected through {@code DURABLE_EXECUTION_PLUGINS}.
+ *
+ * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ */
+@Deprecated
+public interface DurableExecutionPluginProvider {
+
+    /** Current version of the dynamic plugin provider contract. */
+    int API_VERSION = 1;
+
+    /**
+     * Returns the stable name used to select this provider.
+     *
+     * @return non-empty provider name
+     */
+    String getName();
+
+    /**
+     * Returns the provider API version this implementation supports.
+     *
+     * @return provider API version
+     */
+    int getApiVersion();
+
+    /**
+     * Returns the concrete plugin type created by this provider.
+     *
+     * @return plugin implementation class
+     */
+    Class<? extends DurableExecutionPlugin> getPluginType();
+
+    /**
+     * Creates the plugin instance.
+     *
+     * @return plugin instance
+     */
+    DurableExecutionPlugin createPlugin();
+}

--- a/sdk/src/test/java/software/amazon/lambda/durable/DynamicPluginLoaderTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/DynamicPluginLoaderTest.java
@@ -1,0 +1,248 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
+import software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider;
+
+class DynamicPluginLoaderTest {
+
+    @Test
+    void unsetConfigurationPreservesExplicitPluginsWithoutDiscoveringProviders() {
+        var explicitPlugin = new FirstPlugin();
+        Iterable<DurableExecutionPluginProvider> providers = () -> {
+            throw new AssertionError("Providers should not be discovered");
+        };
+
+        var plugins = DynamicPluginLoader.loadConfiguredPlugins(null, providers, List.of(explicitPlugin));
+
+        assertEquals(1, plugins.size());
+        assertSame(explicitPlugin, plugins.get(0));
+    }
+
+    @Test
+    void loadsRequestedProvidersBeforeExplicitPluginsInConfiguredOrder() {
+        var creationOrder = new ArrayList<String>();
+        var explicitPlugin = new ExplicitPlugin();
+        var firstProvider = provider("first", FirstPlugin.class, () -> {
+            creationOrder.add("first");
+            return new FirstPlugin();
+        });
+        var secondProvider = provider("second", SecondPlugin.class, () -> {
+            creationOrder.add("second");
+            return new SecondPlugin();
+        });
+
+        var plugins = DynamicPluginLoader.loadConfiguredPlugins(
+                " second, first ", List.of(firstProvider, secondProvider), List.of(explicitPlugin));
+
+        assertInstanceOf(SecondPlugin.class, plugins.get(0));
+        assertInstanceOf(FirstPlugin.class, plugins.get(1));
+        assertSame(explicitPlugin, plugins.get(2));
+        assertEquals(List.of("second", "first"), creationOrder);
+    }
+
+    @Test
+    void doesNotCreateProvidersOutsideTheAllowList() {
+        var unrequestedCreations = new AtomicInteger();
+        var requestedProvider = provider("requested", FirstPlugin.class, FirstPlugin::new);
+        var unrequestedProvider = provider("unrequested", SecondPlugin.class, () -> {
+            unrequestedCreations.incrementAndGet();
+            return new SecondPlugin();
+        });
+
+        var plugins = DynamicPluginLoader.loadConfiguredPlugins(
+                "requested", List.of(requestedProvider, unrequestedProvider), List.of());
+
+        assertEquals(1, plugins.size());
+        assertEquals(0, unrequestedCreations.get());
+    }
+
+    @Test
+    void loadsExplicitAndDynamicPluginsOfTheSameType() {
+        var creations = new AtomicInteger();
+        var explicitPlugin = new FirstPlugin();
+        var dynamicPlugin = new FirstPlugin();
+        var duplicateProvider = provider("first", FirstPlugin.class, () -> {
+            creations.incrementAndGet();
+            return dynamicPlugin;
+        });
+
+        var plugins =
+                DynamicPluginLoader.loadConfiguredPlugins("first", List.of(duplicateProvider), List.of(explicitPlugin));
+
+        assertEquals(2, plugins.size());
+        assertSame(dynamicPlugin, plugins.get(0));
+        assertSame(explicitPlugin, plugins.get(1));
+        assertEquals(1, creations.get());
+    }
+
+    @Test
+    void rejectsEmptyConfiguredProviderName() {
+        var error = assertThrows(
+                IllegalStateException.class,
+                () -> DynamicPluginLoader.loadConfiguredPlugins("first,,second", List.of(), List.of()));
+
+        assertTrue(error.getMessage().contains("must be non-empty"));
+        assertTrue(error.getMessage().contains(DynamicPluginLoader.PLUGINS_ENVIRONMENT_VARIABLE));
+    }
+
+    @Test
+    void rejectsDuplicateConfiguredProviderName() {
+        var error = assertThrows(
+                IllegalStateException.class,
+                () -> DynamicPluginLoader.loadConfiguredPlugins("first,first", List.of(), List.of()));
+
+        assertTrue(error.getMessage().contains("listed more than once"));
+    }
+
+    @Test
+    void rejectsUnknownProviderAndListsAvailableNames() {
+        var availableProvider = provider("available", FirstPlugin.class, FirstPlugin::new);
+
+        var error = assertThrows(
+                IllegalStateException.class,
+                () -> DynamicPluginLoader.loadConfiguredPlugins("missing", List.of(availableProvider), List.of()));
+
+        assertTrue(error.getMessage().contains("No DurableExecutionPluginProvider named 'missing'"));
+        assertTrue(error.getMessage().contains("available"));
+    }
+
+    @Test
+    void rejectsDuplicateDiscoveredProviderNames() {
+        var firstProvider = provider("duplicate", FirstPlugin.class, FirstPlugin::new);
+        var secondProvider = provider("duplicate", SecondPlugin.class, SecondPlugin::new);
+
+        var error = assertThrows(
+                IllegalStateException.class,
+                () -> DynamicPluginLoader.loadConfiguredPlugins(
+                        "duplicate", List.of(firstProvider, secondProvider), List.of()));
+
+        assertTrue(error.getMessage().contains("Multiple DurableExecutionPluginProvider implementations"));
+        assertTrue(error.getMessage().contains("duplicate"));
+    }
+
+    @Test
+    void rejectsIncompatibleProviderApiVersion() {
+        var provider = new TestProvider("first", 2, FirstPlugin.class, FirstPlugin::new);
+
+        var error = assertThrows(
+                IllegalStateException.class,
+                () -> DynamicPluginLoader.loadConfiguredPlugins("first", List.of(provider), List.of()));
+
+        assertTrue(error.getMessage().contains("uses provider API version 2"));
+        assertTrue(error.getMessage().contains("requires version " + DurableExecutionPluginProvider.API_VERSION));
+    }
+
+    @Test
+    void rejectsInvalidDeclaredPluginType() {
+        var provider = provider("invalid", DurableExecutionPlugin.class, FirstPlugin::new);
+
+        var error = assertThrows(
+                IllegalStateException.class,
+                () -> DynamicPluginLoader.loadConfiguredPlugins("invalid", List.of(provider), List.of()));
+
+        assertTrue(error.getMessage().contains("must declare a concrete DurableExecutionPlugin type"));
+    }
+
+    @Test
+    void rejectsPluginThatDoesNotMatchDeclaredType() {
+        var provider = provider("first", FirstPlugin.class, SecondPlugin::new);
+
+        var error = assertThrows(
+                IllegalStateException.class,
+                () -> DynamicPluginLoader.loadConfiguredPlugins("first", List.of(provider), List.of()));
+
+        assertTrue(error.getMessage().contains("declared type"));
+        assertTrue(error.getMessage().contains(SecondPlugin.class.getName()));
+    }
+
+    @Test
+    void wrapsProviderDiscoveryFailure() {
+        Iterable<DurableExecutionPluginProvider> providers = () -> new Iterator<>() {
+            @Override
+            public boolean hasNext() {
+                throw new LinkageError("incompatible");
+            }
+
+            @Override
+            public DurableExecutionPluginProvider next() {
+                throw new AssertionError("next should not be called");
+            }
+        };
+
+        var error = assertThrows(
+                IllegalStateException.class,
+                () -> DynamicPluginLoader.loadConfiguredPlugins("first", providers, List.of()));
+
+        assertTrue(error.getMessage().contains("Failed to discover"));
+        assertInstanceOf(LinkageError.class, error.getCause());
+    }
+
+    @Test
+    void wrapsPluginCreationFailure() {
+        var provider = provider("first", FirstPlugin.class, () -> {
+            throw new IllegalArgumentException("bad settings");
+        });
+
+        var error = assertThrows(
+                IllegalStateException.class,
+                () -> DynamicPluginLoader.loadConfiguredPlugins("first", List.of(provider), List.of()));
+
+        assertTrue(error.getMessage().contains("failed to create its plugin"));
+        assertInstanceOf(IllegalArgumentException.class, error.getCause());
+    }
+
+    private static TestProvider provider(
+            String name,
+            Class<? extends DurableExecutionPlugin> pluginType,
+            Supplier<DurableExecutionPlugin> pluginSupplier) {
+        return new TestProvider(name, DurableExecutionPluginProvider.API_VERSION, pluginType, pluginSupplier);
+    }
+
+    private record TestProvider(
+            String name,
+            int apiVersion,
+            Class<? extends DurableExecutionPlugin> pluginType,
+            Supplier<DurableExecutionPlugin> pluginSupplier)
+            implements DurableExecutionPluginProvider {
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public int getApiVersion() {
+            return apiVersion;
+        }
+
+        @Override
+        public Class<? extends DurableExecutionPlugin> getPluginType() {
+            return pluginType;
+        }
+
+        @Override
+        public DurableExecutionPlugin createPlugin() {
+            return pluginSupplier.get();
+        }
+    }
+
+    private static final class ExplicitPlugin implements DurableExecutionPlugin {}
+
+    private static final class FirstPlugin implements DurableExecutionPlugin {}
+
+    private static final class SecondPlugin implements DurableExecutionPlugin {}
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Closes #605

### Description

- Add a versioned `DurableExecutionPluginProvider` SPI discovered with `ServiceLoader` when `DURABLE_EXECUTION_PLUGINS` is set.
- Load environment-selected plugins first in configured order, followed by plugins registered through `DurableConfig.withPlugins(...)`; both sources remain additive.
- Add `otel-invocation` and `otel-execution` providers for `InvocationOtelPlugin` and `ExecutionOtelPlugin`.
- Validate provider names, duplicates, API compatibility, plugin types, and creation failures with actionable configuration errors.
- Document Lambda layer packaging, provider authoring, selector names, and OTel layer configuration.

### Demo/Screenshots

Not applicable; this is SDK configuration and plugin discovery behavior.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Yes. Added loader coverage for ordering, additive duplicate types, allow-list behavior, malformed configuration, discovery failures, compatibility validation, and plugin creation failures. Added provider tests for both OTel plugins.

#### Integration Tests

Yes. Added lifecycle coverage confirming dynamically loaded and explicitly configured plugins both receive events.

Also ran `mvn clean install` successfully across all reactor modules.

#### Examples

No new example was required. The configuration guide and OTel plugin README now include Lambda layer and environment-variable examples.