### PR TITLE
fix(otel): parent ExecutionOtelPlugin invocation to ambient span

### DIFF
--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -41,8 +41,8 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  *   <li><b>Workflow span</b> — one <em>logical</em> root span per durable execution. Its span ID is derived
  *       deterministically from the execution ARN, so every invocation of the same execution produces the same ID. It is
  *       ended (and therefore exported) exactly once, on the terminal invocation.
- *   <li><b>Invocation span</b> — one per Lambda invocation, a child of the Workflow span. Created and ended every
- *       invocation.
+ *   <li><b>Invocation span</b> — one per Lambda invocation, a child of the ambient Lambda span when available and a
+ *       root otherwise. Created and ended every invocation.
  *   <li><b>Operation span</b> — parented to its parent operation span (or the Workflow span) and carrying a
  *       <em>link</em> to the current Invocation span for correlation. Deterministic ID keyed by operation ID, so a
  *       suspended-then-resumed operation stitches into a single logical span across invocations.
@@ -51,8 +51,8 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * </ul>
  *
  * <p>Contrast with {@link InvocationOtelPlugin} (the invocation-rooted variant, equivalent to the reference
- * {@code InvocationOtelPlugin}): there the invocation span is the root and there is no Workflow span. Here the workflow
- * span is the root, operations hang off the Workflow span, and each operation/attempt links to the invocation that ran
+ * {@code InvocationOtelPlugin}): there operations hang off the per-invocation span and link to the Workflow span. Here
+ * operations hang off the independent Workflow root span, while each operation/attempt links to the invocation that ran
  * it. Both plugins share {@link DeterministicIdGenerator}, {@link ContextExtractor}, {@link SpanAttributes}, and
  * {@link MdcSpanEnricher}.
  *
@@ -193,8 +193,7 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         // Set execution ARN for deterministic span/trace ID generation
         idGenerator.setDurableExecutionArn(info.durableExecutionArn());
 
-        // Extract trace context from environment (X-Ray header). Only the trace ID is used — the Workflow span is a
-        // true root, so the X-Ray parent span ID is intentionally not used for parenting (unlike InvocationOtelPlugin).
+        // Extract trace context from the environment (X-Ray header), falling back to the ambient OTel span.
         var extractedContext = contextExtractor.extract();
         if (extractedContext == null) {
             extractedContext = extractCurrentSpanContext();
@@ -216,10 +215,22 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         idGenerator.setNextSpanId(idGenerator.generateWorkflowSpanId());
         workflowSpan = workflowSpanBuilder.startSpan();
 
-        // Invocation span — child of the Workflow span, INTERNAL kind, random span ID (new every invocation).
+        Context parentContext;
+        if (extractedContext != null && extractedContext.parentSpanId() != null) {
+            var parentSpanContext = SpanContext.createFromRemoteParent(
+                    extractedContext.traceId(),
+                    extractedContext.parentSpanId(),
+                    TraceFlags.getSampled(),
+                    TraceState.getDefault());
+            parentContext = Context.root().with(Span.wrap(parentSpanContext));
+        } else {
+            parentContext = Context.root();
+        }
+
+        // Invocation span — child of the ambient Lambda span when available, otherwise a root.
         var spanBuilder = tracer.spanBuilder("Invocation")
                 .setSpanKind(SpanKind.INTERNAL)
-                .setParent(Context.root().with(workflowSpan))
+                .setParent(parentContext)
                 .setAttribute(DURABLE_EXECUTION_ARN, info.durableExecutionArn())
                 .setAttribute(DURABLE_FIRST_INVOCATION, info.isFirstInvocation());
 

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -7,8 +7,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
@@ -225,7 +229,7 @@ class ExecutionOtelPluginTest {
     }
 
     @Test
-    void workflowSpan_isRoot_invocationSpanIsChild() {
+    void workflowAndInvocationSpans_areIndependentRoots_withoutAmbientContext() {
         plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
@@ -233,14 +237,27 @@ class ExecutionOtelPluginTest {
         var workflowSpan = spanByName(spans, "Workflow");
         var invocationSpan = spanByName(spans, "Invocation");
 
-        assertFalse(
-                invocationSpan.getParentSpanContext().getSpanId().equals("0000000000000000"),
-                "Invocation span must have a parent");
-        assertEquals(
-                workflowSpan.getSpanId(),
-                invocationSpan.getParentSpanId(),
-                "Invocation span must be a child of the Workflow root span");
+        assertFalse(workflowSpan.getParentSpanContext().isValid(), "Workflow span must be a root");
+        assertFalse(invocationSpan.getParentSpanContext().isValid(), "Invocation span must be a root");
+        assertEquals(workflowSpan.getTraceId(), invocationSpan.getTraceId());
         assertEquals(SpanKind.INTERNAL, invocationSpan.getKind());
+    }
+
+    @Test
+    void invocationStart_usesCurrentSpanContext_whenExtractorReturnsNull() {
+        var traceId = "5759e988bd862e3fe1be46a994272793";
+        var parentSpanId = "53995c3f42cd8ad8";
+        var parentSpanContext =
+                SpanContext.create(traceId, parentSpanId, TraceFlags.getSampled(), TraceState.getDefault());
+
+        try (var ignored = Span.wrap(parentSpanContext).makeCurrent()) {
+            plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
+        }
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var invocationSpan = spanByName(spanExporter.getFinishedSpanItems(), "Invocation");
+        assertEquals(traceId, invocationSpan.getTraceId());
+        assertEquals(parentSpanId, invocationSpan.getParentSpanId());
     }
 
     @Test
@@ -766,6 +783,30 @@ class ExecutionOtelPluginTest {
         assertTrue(
                 spans.stream().allMatch(s -> s.getTraceId().equals(xrayTraceId)),
                 "All spans must share the extracted X-Ray trace ID");
+    }
+
+    @Test
+    void xrayExtraction_withParentSpanId_invocationSpanHasCorrectParent() {
+        var xrayTraceId = "5759e988bd862e3fe1be46a994272793";
+        var parentSpanId = "53995c3f42cd8ad8";
+        var exporter = InMemorySpanExporter.create();
+        var xrayPlugin = new ExecutionOtelPlugin(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)),
+                OtelPluginConfig.builder()
+                        .contextExtractor(() -> new ExtractedContext(xrayTraceId, parentSpanId))
+                        .enableMdc(false)
+                        .workflowSpanName("Workflow")
+                        .build());
+
+        xrayPlugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
+        xrayPlugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
+
+        var spans = exporter.getFinishedSpanItems();
+        var workflowSpan = spanByName(spans, "Workflow");
+        var invocationSpan = spanByName(spans, "Invocation");
+        assertFalse(workflowSpan.getParentSpanContext().isValid(), "Workflow span must remain an independent root");
+        assertEquals(xrayTraceId, invocationSpan.getTraceId());
+        assertEquals(parentSpanId, invocationSpan.getParentSpanId());
     }
 
     // ─── Helpers ─────────────────────────────────────────────────────────


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

- ADOT/X-Ray conformance failure: https://github.com/aws/aws-durable-execution-conformance-tests/actions/runs/31229807262/job/93031279877?pr=44

### Description

`ExecutionOtelPlugin` extracted the Lambda trace context but discarded its parent span ID and explicitly parented the `Invocation` span to the deterministic `Workflow` span. This prevented the invocation from appearing beneath the Lambda ambient span in ADOT/X-Ray traces.

This change:

- Reconstructs the extracted remote parent context and uses it as the `Invocation` span parent.
- Uses the existing `Span.current()` fallback when the configured context extractor returns no context.
- Leaves the deterministic `Workflow` span as an independent root.
- Preserves operation parenting under `Workflow` and the existing links to `Invocation`.

### Demo/Screenshots

Not applicable.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Yes. Added coverage for:

- Extracted X-Ray parent span IDs.
- Ambient `Span.current()` fallback.
- Independent `Workflow` and `Invocation` roots when no ambient context exists.

Ran:

- `mvn spotless:apply`
- `mvn -pl otel-plugin test` (165 tests passed)
- `git diff --check`

#### Integration Tests

No new integration test was required. The existing OpenTelemetry plugin integration tests ran as part of the module test suite.

#### Examples

No example changes are needed for this internal span-parenting correction.
