### PR TITLE
feat: promote plugin APIs to stable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,12 +67,12 @@ sdk/                    # Core SDK module
 │   ├── serde/                   # JSON serialization
 │   ├── client/                  # AWS Lambda Durable Functions client integration
 │   ├── logging/                 # DurableLogger and logger configuration
-│   ├── plugin/                  # Preview lifecycle plugin API
+│   ├── plugin/                  # Lifecycle plugin API
 │   └── exception/               # Domain exceptions
 
 sdk-testing/            # LocalDurableTestRunner, CloudDurableTestRunner, test helpers
 sdk-integration-tests/  # Integration tests using sdk-testing
-otel-plugin/            # Preview OpenTelemetry plugin implementation
+otel-plugin/            # OpenTelemetry plugin implementation
 examples/               # Customer-facing examples with local and cloud tests
 coverage-report/        # Aggregated JaCoCo coverage report module
 docs/                   # User docs, design notes, ADRs, migration guide
@@ -277,7 +277,7 @@ Do NOT add conformance tests — conformance tests live in a separate repository
 | `MapOperation` | Applies a function across items concurrently via child contexts |
 | `ParallelOperation` | Runs named child-context branches concurrently |
 | `ConcurrencyOperation` | Shared base for map/parallel concurrency limiting and completion evaluation |
-| `DurableExecutionPlugin` | Preview lifecycle hook interface |
+| `DurableExecutionPlugin` | Lifecycle hook interface |
 | `InvocationOtelPlugin` | OpenTelemetry plugin implementation in `otel-plugin` |
 
 ### Serialization

--- a/conformance-tests/src/main/java/plugin/ConformanceLoggingPlugin.java
+++ b/conformance-tests/src/main/java/plugin/ConformanceLoggingPlugin.java
@@ -18,7 +18,6 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * filtered to step-type operations to match the requirement vocabulary. All lines are emitted from the real SDK plugin
  * hooks; nothing is hand-rolled.
  */
-@SuppressWarnings("deprecation")
 public class ConformanceLoggingPlugin implements DurableExecutionPlugin {
 
     private final String prefix;

--- a/conformance-tests/src/main/java/plugin/FaultyConformancePlugin.java
+++ b/conformance-tests/src/main/java/plugin/FaultyConformancePlugin.java
@@ -17,7 +17,6 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * thrown exception must be swallowed by the SDK so the execution result and history are identical to running without
  * the plugin. Operation- and attempt-level hooks are filtered to step-type operations.
  */
-@SuppressWarnings("deprecation")
 public class FaultyConformancePlugin implements DurableExecutionPlugin {
 
     private static boolean isStep(String type) {

--- a/conformance-tests/src/main/java/plugin/PluginAttemptHooksRetry.java
+++ b/conformance-tests/src/main/java/plugin/PluginAttemptHooksRetry.java
@@ -17,7 +17,6 @@ import software.amazon.lambda.durable.retry.RetryDecision;
  * {@code attempt-start n=<n>} / {@code attempt-end n=<n> outcome=<SUCCEEDED|FAILED>} from the user-function hooks,
  * which run on the same thread as the step body so their order is deterministic.
  */
-@SuppressWarnings("deprecation")
 public class PluginAttemptHooksRetry extends DurableHandler<Object, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginErrorIsolation.java
+++ b/conformance-tests/src/main/java/plugin/PluginErrorIsolation.java
@@ -13,7 +13,6 @@ import software.amazon.lambda.durable.DurableHandler;
  * throws. The SDK must catch and ignore every plugin exception so the execution result and history are identical to
  * running without the plugin.
  */
-@SuppressWarnings("deprecation")
 public class PluginErrorIsolation extends DurableHandler<String, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginExternalUpdateOnInvoke.java
+++ b/conformance-tests/src/main/java/plugin/PluginExternalUpdateOnInvoke.java
@@ -19,7 +19,6 @@ import software.amazon.lambda.durable.plugin.OperationEndInfo;
  * invocation-start hook and emits the "updated-on-invoke" record only for wait-type operations observed with
  * {@code isReplay() == true}; on the first invocation the wait has only started (never ends), so nothing is emitted.
  */
-@SuppressWarnings("deprecation")
 public class PluginExternalUpdateOnInvoke extends DurableHandler<Object, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginFaultyAndHealthy.java
+++ b/conformance-tests/src/main/java/plugin/PluginFaultyAndHealthy.java
@@ -24,7 +24,6 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * plugin. Attempt boundaries are the real user-function hooks ({@code onUserFunctionStart}/{@code onUserFunctionEnd},
  * filtered to step attempts); the healthy attempt-end reports the SDK's real success/failure outcome.
  */
-@SuppressWarnings("deprecation")
 public class PluginFaultyAndHealthy extends DurableHandler<String, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginFirstInvocationFlag.java
+++ b/conformance-tests/src/main/java/plugin/PluginFirstInvocationFlag.java
@@ -14,7 +14,6 @@ import software.amazon.lambda.durable.DurableHandler;
  * {@code first=true} (then suspends), and the replay invocation reports {@code first=false} and finalizes with
  * {@code status=SUCCEEDED}.
  */
-@SuppressWarnings("deprecation")
 public class PluginFirstInvocationFlag extends DurableHandler<Object, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginInvocationLifecycle.java
+++ b/conformance-tests/src/main/java/plugin/PluginInvocationLifecycle.java
@@ -13,7 +13,6 @@ import software.amazon.lambda.durable.DurableHandler;
  * {@code first=true} before the handler runs and its invocation-end hook logs {@code status=SUCCEEDED} after the result
  * is finalized. The step body logs its running line via the context logger.
  */
-@SuppressWarnings("deprecation")
 public class PluginInvocationLifecycle extends DurableHandler<String, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginMultiplePlugins.java
+++ b/conformance-tests/src/main/java/plugin/PluginMultiplePlugins.java
@@ -16,7 +16,6 @@ import software.amazon.lambda.durable.plugin.InvocationInfo;
  * logs with prefix {@code CONFPLUGIN-A}, plugin B with prefix {@code CONFPLUGIN-B}, emitting exactly the lines the
  * requirement documents: {@code <prefix> invocation-start} and {@code <prefix> invocation-end status=<status>}.
  */
-@SuppressWarnings("deprecation")
 public class PluginMultiplePlugins extends DurableHandler<String, String> {
 
     /** Minimal plugin emitting exactly the 10-5 documented invocation lines. */

--- a/conformance-tests/src/main/java/plugin/PluginNestedParentLinkage.java
+++ b/conformance-tests/src/main/java/plugin/PluginNestedParentLinkage.java
@@ -16,7 +16,6 @@ import software.amazon.lambda.durable.plugin.OperationEndInfo;
  * a terminal status, with the operation id, its parent id (the literal string {@code NONE} when absent), and status.
  * The inner step ends with the child context as its parent; the child context ends with no parent.
  */
-@SuppressWarnings("deprecation")
 public class PluginNestedParentLinkage extends DurableHandler<String, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginOperationChange.java
+++ b/conformance-tests/src/main/java/plugin/PluginOperationChange.java
@@ -17,7 +17,6 @@ import software.amazon.lambda.durable.plugin.OperationChangeItemInfo;
  * operation in the change's updated-operations delta, logs the operation id, its post-change status, and whether that
  * id is also present in the change info's full operation map.
  */
-@SuppressWarnings("deprecation")
 public class PluginOperationChange extends DurableHandler<String, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginOperationLifecycle.java
+++ b/conformance-tests/src/main/java/plugin/PluginOperationLifecycle.java
@@ -13,7 +13,6 @@ import software.amazon.lambda.durable.DurableHandler;
  * operations, logs {@code operation-start} when the step's STARTED checkpoint is observed and {@code operation-end
  * status=SUCCEEDED} when the step reaches its terminal status.
  */
-@SuppressWarnings("deprecation")
 public class PluginOperationLifecycle extends DurableHandler<String, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginParallelBranchHooks.java
+++ b/conformance-tests/src/main/java/plugin/PluginParallelBranchHooks.java
@@ -23,7 +23,6 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * and fn-end (with outcome) from the real user-function hooks, carrying the branch operation id and the parallel parent
  * id. These hooks run on the branch's own thread, so start-before-end order per branch is deterministic.
  */
-@SuppressWarnings("deprecation")
 public class PluginParallelBranchHooks extends DurableHandler<Object, List<String>> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginReplayFlags.java
+++ b/conformance-tests/src/main/java/plugin/PluginReplayFlags.java
@@ -22,7 +22,6 @@ import software.amazon.lambda.durable.retry.RetryStrategies;
  * delay). The plugin, filtering to step-type operations, logs operation-start with the SDK's is-replayed indicator
  * ({@code OperationInfo#isReplay()}) and operation-end with the terminal status.
  */
-@SuppressWarnings("deprecation")
 public class PluginReplayFlags extends DurableHandler<Object, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginRetryExhaustion.java
+++ b/conformance-tests/src/main/java/plugin/PluginRetryExhaustion.java
@@ -23,7 +23,6 @@ import software.amazon.lambda.durable.retry.RetryStrategies;
  * and attempt-end (with outcome) from the real user-function hooks (which carry the 1-based attempt number) and
  * operation-end when the step reaches its terminal FAILED status.
  */
-@SuppressWarnings("deprecation")
 public class PluginRetryExhaustion extends DurableHandler<Object, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginSuspensionInvocationEnd.java
+++ b/conformance-tests/src/main/java/plugin/PluginSuspensionInvocationEnd.java
@@ -19,7 +19,6 @@ import software.amazon.lambda.durable.plugin.InvocationStatus;
  * The suspending first invocation reports a non-terminal status (PENDING → terminal=false); the resuming invocation
  * reports terminal SUCCEEDED (terminal=true).
  */
-@SuppressWarnings("deprecation")
 public class PluginSuspensionInvocationEnd extends DurableHandler<Object, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginTerminalFailure.java
+++ b/conformance-tests/src/main/java/plugin/PluginTerminalFailure.java
@@ -15,7 +15,6 @@ import software.amazon.lambda.durable.retry.RetryStrategies;
  * {@code invocation-start first=true}; the step throws, no retry is attempted, and the plugin's invocation-end hook
  * fires with {@code status=FAILED}.
  */
-@SuppressWarnings("deprecation")
 public class PluginTerminalFailure extends DurableHandler<Object, String> {
 
     @Override

--- a/conformance-tests/src/main/java/plugin/PluginWaitOperationHooks.java
+++ b/conformance-tests/src/main/java/plugin/PluginWaitOperationHooks.java
@@ -19,7 +19,6 @@ import software.amazon.lambda.durable.plugin.OperationInfo;
  * STARTED checkpoint is observed and operation-end with the terminal status. The type token is normalized to upper-case
  * (WAIT).
  */
-@SuppressWarnings("deprecation")
 public class PluginWaitOperationHooks extends DurableHandler<Object, String> {
 
     @Override

--- a/docs/advanced/configuration.md
+++ b/docs/advanced/configuration.md
@@ -42,7 +42,7 @@ The `withExecutorService()` option configures the thread pool used for running u
 
 ### Dynamic plugin loading
 
-Dynamic plugin loading is an experimental, opt-in alternative to registering plugins in application code. Put provider JARs on the application class path, then set `DURABLE_EXECUTION_PLUGINS` to an ordered, comma-separated list of provider names:
+Dynamic plugin loading is an opt-in alternative to registering plugins in application code. Put provider JARs on the application class path, then set `DURABLE_EXECUTION_PLUGINS` to an ordered, comma-separated list of provider names:
 
 ```text
 DURABLE_EXECUTION_PLUGINS=otel-invocation,com.example.audit

--- a/otel-plugin/README.md
+++ b/otel-plugin/README.md
@@ -1,7 +1,5 @@
 # AWS Durable Execution SDK - OpenTelemetry Plugin
 
-> **Experimental Feature:** This plugin is currently experimental. Functionality may change without notice between releases. It is not recommended for production workloads at this time.
-
 OpenTelemetry instrumentation plugin for the AWS Lambda Durable Execution SDK for Java. Emits distributed traces that correlate across multiple Lambda invocations of a single durable execution, producing deterministic span and trace IDs so that spans from different invocations are stitched into a single coherent trace.
 
 ## Features

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ContextExtractor.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ContextExtractor.java
@@ -10,9 +10,7 @@ package software.amazon.lambda.durable.otel;
  *
  * <p>Called once per invocation in {@code onInvocationStart} to establish the parent trace context.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 @FunctionalInterface
 public interface ContextExtractor {
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ContextExtractor.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ContextExtractor.java
@@ -9,7 +9,6 @@ package software.amazon.lambda.durable.otel;
  * {@link ExtractedContext} containing the trace ID and optional parent span ID.
  *
  * <p>Called once per invocation in {@code onInvocationStart} to establish the parent trace context.
- *
  */
 @FunctionalInterface
 public interface ContextExtractor {

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * <p>Span IDs for operations are deterministic (derived from execution ARN + operation ID), ensuring the same operation
  * produces the same span across invocations. When no pending operation ID is set, falls back to random generation.
- *
  */
 public class DeterministicIdGenerator implements IdGenerator {
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/DeterministicIdGenerator.java
@@ -24,9 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * <p>Span IDs for operations are deterministic (derived from execution ARN + operation ID), ensuring the same operation
  * produces the same span across invocations. When no pending operation ID is set, falls back to random generation.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public class DeterministicIdGenerator implements IdGenerator {
 
     private static final IdGenerator RANDOM = IdGenerator.random();

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -75,9 +75,7 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * <p>Thread-safe: uses {@link ConcurrentHashMap} for span/scope storage since the SDK runs user code on multiple
  * threads.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public class ExecutionOtelPlugin implements DurableExecutionPlugin {
 
     private static final Logger logger = LoggerFactory.getLogger(ExecutionOtelPlugin.class);

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -74,7 +74,6 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  *
  * <p>Thread-safe: uses {@link ConcurrentHashMap} for span/scope storage since the SDK runs user code on multiple
  * threads.
- *
  */
 public class ExecutionOtelPlugin implements DurableExecutionPlugin {
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginProvider.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginProvider.java
@@ -7,7 +7,6 @@ import software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider;
 
 /**
  * Dynamically loads {@link ExecutionOtelPlugin} when {@code DURABLE_EXECUTION_PLUGINS} contains {@code otel-execution}.
- *
  */
 public final class ExecutionOtelPluginProvider implements DurableExecutionPluginProvider {
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginProvider.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginProvider.java
@@ -8,9 +8,7 @@ import software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider;
 /**
  * Dynamically loads {@link ExecutionOtelPlugin} when {@code DURABLE_EXECUTION_PLUGINS} contains {@code otel-execution}.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public final class ExecutionOtelPluginProvider implements DurableExecutionPluginProvider {
 
     @Override

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExtractedContext.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExtractedContext.java
@@ -11,7 +11,5 @@ package software.amazon.lambda.durable.otel;
  *
  * @param traceId 32-character lowercase hex trace ID (OTel format, no dashes)
  * @param parentSpanId 16-character lowercase hex parent span ID (may be null if no parent available)
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public record ExtractedContext(String traceId, String parentSpanId) {}

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -88,9 +88,7 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  * <p>Thread-safe: uses {@link ConcurrentHashMap} for span/scope storage since the SDK runs user code on multiple
  * threads.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public class InvocationOtelPlugin implements DurableExecutionPlugin {
 
     private static final Logger logger = LoggerFactory.getLogger(InvocationOtelPlugin.class);

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -87,7 +87,6 @@ import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
  *
  * <p>Thread-safe: uses {@link ConcurrentHashMap} for span/scope storage since the SDK runs user code on multiple
  * threads.
- *
  */
 public class InvocationOtelPlugin implements DurableExecutionPlugin {
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPluginProvider.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPluginProvider.java
@@ -9,9 +9,7 @@ import software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider;
  * Dynamically loads {@link InvocationOtelPlugin} when {@code DURABLE_EXECUTION_PLUGINS} contains
  * {@code otel-invocation}.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public final class InvocationOtelPluginProvider implements DurableExecutionPluginProvider {
 
     @Override

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPluginProvider.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPluginProvider.java
@@ -8,7 +8,6 @@ import software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider;
 /**
  * Dynamically loads {@link InvocationOtelPlugin} when {@code DURABLE_EXECUTION_PLUGINS} contains
  * {@code otel-invocation}.
- *
  */
 public final class InvocationOtelPluginProvider implements DurableExecutionPluginProvider {
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
@@ -23,9 +23,7 @@ import org.slf4j.MDC;
  * {@code onUserFunctionEnd}. Or use the convenience plugin {@link InvocationOtelPlugin} which handles this
  * automatically when MDC enrichment is enabled.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public final class MdcSpanEnricher {
 
     // MDC key names are aligned with the JS and Python SDK OTel plugins

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/MdcSpanEnricher.java
@@ -22,7 +22,6 @@ import org.slf4j.MDC;
  * <p>Usage: Call {@link #inject()} in {@code onUserFunctionStart} (after span is active) and {@link #clear()} in
  * {@code onUserFunctionEnd}. Or use the convenience plugin {@link InvocationOtelPlugin} which handles this
  * automatically when MDC enrichment is enabled.
- *
  */
 public final class MdcSpanEnricher {
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginAutoConfigurationCustomizerProvider.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginAutoConfigurationCustomizerProvider.java
@@ -8,9 +8,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvide
 /**
  * Installs the durable-execution ID generator when the OpenTelemetry Java agent auto-configures the SDK.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public final class OtelPluginAutoConfigurationCustomizerProvider implements AutoConfigurationCustomizerProvider {
 
     private static final DeterministicIdGenerator ID_GENERATOR = new DeterministicIdGenerator();

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginAutoConfigurationCustomizerProvider.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginAutoConfigurationCustomizerProvider.java
@@ -5,10 +5,7 @@ package software.amazon.lambda.durable.otel;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 
-/**
- * Installs the durable-execution ID generator when the OpenTelemetry Java agent auto-configures the SDK.
- *
- */
+/** Installs the durable-execution ID generator when the OpenTelemetry Java agent auto-configures the SDK. */
 public final class OtelPluginAutoConfigurationCustomizerProvider implements AutoConfigurationCustomizerProvider {
 
     private static final DeterministicIdGenerator ID_GENERATOR = new DeterministicIdGenerator();

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginConfig.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginConfig.java
@@ -28,7 +28,6 @@ import java.util.Map;
  * <p>Defaults: {@code contextExtractor = new XRayContextExtractor()}, {@code enableMdc = true}, {@code workflowSpanName
  * = "Workflow"}, {@code instrumentationName = "aws-durable-execution-sdk-java"}, {@code providerSource =
  * ProviderSource.GLOBAL}. A {@code null} passed to any builder setter falls back to the corresponding default.
- *
  */
 public final class OtelPluginConfig {
 
@@ -108,10 +107,7 @@ public final class OtelPluginConfig {
         return otlpHeaders;
     }
 
-    /**
-     * Builder for {@link OtelPluginConfig}.
-     *
-     */
+    /** Builder for {@link OtelPluginConfig}. */
     public static final class Builder {
 
         private ContextExtractor contextExtractor;

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginConfig.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginConfig.java
@@ -29,9 +29,7 @@ import java.util.Map;
  * = "Workflow"}, {@code instrumentationName = "aws-durable-execution-sdk-java"}, {@code providerSource =
  * ProviderSource.GLOBAL}. A {@code null} passed to any builder setter falls back to the corresponding default.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public final class OtelPluginConfig {
 
     static final String DEFAULT_INSTRUMENTATION_NAME = "aws-durable-execution-sdk-java";
@@ -113,9 +111,7 @@ public final class OtelPluginConfig {
     /**
      * Builder for {@link OtelPluginConfig}.
      *
-     * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
      */
-    @Deprecated
     public static final class Builder {
 
         private ContextExtractor contextExtractor;

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginSupport.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginSupport.java
@@ -18,10 +18,7 @@ import java.nio.file.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Shared utilities for OTel plugin default constructor support (ADOT Java agent SPI path).
- *
- */
+/** Shared utilities for OTel plugin default constructor support (ADOT Java agent SPI path). */
 final class OtelPluginSupport {
 
     private static final Logger logger = LoggerFactory.getLogger(OtelPluginSupport.class);
@@ -87,7 +84,6 @@ final class OtelPluginSupport {
     /**
      * The tracer provider, tracer, and ID generator resolved for a config-only plugin constructor, plus the
      * {@link ProviderSource} that produced them.
-     *
      */
     record ProviderSetup(
             ProviderSource source,

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginSupport.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/OtelPluginSupport.java
@@ -21,9 +21,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Shared utilities for OTel plugin default constructor support (ADOT Java agent SPI path).
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 final class OtelPluginSupport {
 
     private static final Logger logger = LoggerFactory.getLogger(OtelPluginSupport.class);
@@ -90,9 +88,7 @@ final class OtelPluginSupport {
      * The tracer provider, tracer, and ID generator resolved for a config-only plugin constructor, plus the
      * {@link ProviderSource} that produced them.
      *
-     * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
      */
-    @Deprecated
     record ProviderSetup(
             ProviderSource source,
             SdkTracerProvider sdkTracerProvider,

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ProviderSource.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ProviderSource.java
@@ -21,9 +21,7 @@ package software.amazon.lambda.durable.otel;
  * it for the config-only constructors; the {@code (SdkTracerProviderBuilder, OtelPluginConfig)} constructors always
  * report {@link #EXPLICIT}.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public enum ProviderSource {
     /** Caller-supplied {@code SdkTracerProviderBuilder}; plugin-owned. */
     EXPLICIT,

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ProviderSource.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ProviderSource.java
@@ -20,7 +20,6 @@ package software.amazon.lambda.durable.otel;
  * <p>This is the single knob that selects a plugin's tracer provider. {@link OtelPluginConfig#providerSource()} carries
  * it for the config-only constructors; the {@code (SdkTracerProviderBuilder, OtelPluginConfig)} constructors always
  * report {@link #EXPLICIT}.
- *
  */
 public enum ProviderSource {
     /** Caller-supplied {@code SdkTracerProviderBuilder}; plugin-owned. */

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/SpanAttributes.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/SpanAttributes.java
@@ -7,9 +7,7 @@ import io.opentelemetry.api.common.AttributeKey;
 /**
  * OTel span attribute keys for durable execution spans.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 final class SpanAttributes {
 
     private SpanAttributes() {}

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/SpanAttributes.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/SpanAttributes.java
@@ -4,10 +4,7 @@ package software.amazon.lambda.durable.otel;
 
 import io.opentelemetry.api.common.AttributeKey;
 
-/**
- * OTel span attribute keys for durable execution spans.
- *
- */
+/** OTel span attribute keys for durable execution spans. */
 final class SpanAttributes {
 
     private SpanAttributes() {}

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/XRayContextExtractor.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/XRayContextExtractor.java
@@ -18,9 +18,7 @@ import org.slf4j.LoggerFactory;
  * <p>The Root field is converted to OTel format by stripping "1-" and removing dashes:
  * {@code 5759e988bd862e3fe1be46a994272793}
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public class XRayContextExtractor implements ContextExtractor {
 
     private static final Logger logger = LoggerFactory.getLogger(XRayContextExtractor.class);

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/XRayContextExtractor.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/XRayContextExtractor.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The Root field is converted to OTel format by stripping "1-" and removing dashes:
  * {@code 5759e988bd862e3fe1be46a994272793}
- *
  */
 public class XRayContextExtractor implements ContextExtractor {
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/DurableConfig.java
@@ -220,9 +220,7 @@ public final class DurableConfig {
      * <p>Returns a no-op runner if no plugins were registered via the builder or loaded dynamically.
      *
      * @return PluginRunner instance (never null)
-     * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
      */
-    @Deprecated
     public PluginRunner getPluginRunner() {
         return pluginRunner;
     }
@@ -471,9 +469,7 @@ public final class DurableConfig {
          * @param plugins the plugins to register
          * @return This builder
          * @throws NullPointerException if any plugin is null
-         * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
          */
-        @Deprecated
         public Builder withPlugins(DurableExecutionPlugin... plugins) {
             Objects.requireNonNull(plugins, "Plugins array cannot be null");
             var newPlugins = new ArrayList<DurableExecutionPlugin>(plugins.length);

--- a/sdk/src/main/java/software/amazon/lambda/durable/annotations/Experimental.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/annotations/Experimental.java
@@ -20,11 +20,5 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({
-    ElementType.TYPE,
-    ElementType.METHOD,
-    ElementType.FIELD,
-    ElementType.PARAMETER,
-    ElementType.RECORD_COMPONENT
-})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
 public @interface Experimental {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/annotations/Experimental.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/annotations/Experimental.java
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a public API as <b>experimental</b>.
+ *
+ * <p>Experimental APIs may be changed or removed in future releases <b>without a major-version bump</b> and without
+ * prior notice. They are provided for early evaluation and feedback. Do not depend on experimental APIs in production
+ * code until they are promoted to stable.
+ *
+ * @apiNote <b>Experimental.</b> This API is experimental and may be changed or removed in future releases without a
+ *     major-version bump.
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({
+    ElementType.TYPE,
+    ElementType.METHOD,
+    ElementType.FIELD,
+    ElementType.PARAMETER,
+    ElementType.RECORD_COMPONENT
+})
+public @interface Experimental {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPlugin.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPlugin.java
@@ -13,9 +13,7 @@ package software.amazon.lambda.durable.plugin;
  * <p>Plugin errors are isolated — exceptions thrown by plugin methods are caught and logged but never disrupt SDK
  * execution.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public interface DurableExecutionPlugin {
 
     // ─── Invocation-level hooks ──────────────────────────────────────────

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPlugin.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPlugin.java
@@ -12,7 +12,6 @@ package software.amazon.lambda.durable.plugin;
  *
  * <p>Plugin errors are isolated — exceptions thrown by plugin methods are caught and logged but never disrupt SDK
  * execution.
- *
  */
 public interface DurableExecutionPlugin {
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPluginProvider.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPluginProvider.java
@@ -8,7 +8,6 @@ package software.amazon.lambda.durable.plugin;
  * <p>Provider JARs register implementations in
  * {@code META-INF/services/software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider}. The SDK only creates
  * plugins from providers explicitly selected through {@code DURABLE_EXECUTION_PLUGINS}.
- *
  */
 public interface DurableExecutionPluginProvider {
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPluginProvider.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPluginProvider.java
@@ -9,9 +9,7 @@ package software.amazon.lambda.durable.plugin;
  * {@code META-INF/services/software.amazon.lambda.durable.plugin.DurableExecutionPluginProvider}. The SDK only creates
  * plugins from providers explicitly selected through {@code DURABLE_EXECUTION_PLUGINS}.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public interface DurableExecutionPluginProvider {
 
     /** Current version of the dynamic plugin provider contract. */

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationEndInfo.java
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.plugin;
 
+import software.amazon.lambda.durable.annotations.Experimental;
+
 /**
  * Information provided at the end of a Lambda invocation.
  *
@@ -9,13 +11,11 @@ package software.amazon.lambda.durable.plugin;
  * @param durableExecutionArn the durable execution ARN
  * @param isFirstInvocation true if this is the first invocation of the execution
  * @param invocationStatus the invocation outcome (SUCCEEDED, FAILED, or PENDING)
- * @param executionError non-null if the execution failed
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ * @param executionError non-null if the execution failed; this component is experimental
  */
-@Deprecated
 public record InvocationEndInfo(
         String requestId,
         String durableExecutionArn,
         boolean isFirstInvocation,
         InvocationStatus invocationStatus,
-        Throwable executionError) {}
+        @Experimental Throwable executionError) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
@@ -12,8 +12,6 @@ import java.time.Instant;
  * @param isFirstInvocation true if this is the first invocation of the execution (not a replay invocation)
  * @param executionStartTime the start timestamp of the durable execution, taken from the initial EXECUTION operation in
  *     the first event delivered by the backend. Stable across all invocations of the same execution.
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public record InvocationInfo(
         String requestId, String durableExecutionArn, boolean isFirstInvocation, Instant executionStartTime) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationStatus.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationStatus.java
@@ -5,9 +5,7 @@ package software.amazon.lambda.durable.plugin;
 /**
  * Status of a Lambda invocation at the end of its execution.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public enum InvocationStatus {
     /** Execution completed successfully in this invocation. */
     SUCCEEDED,

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationStatus.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationStatus.java
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.plugin;
 
-/**
- * Status of a Lambda invocation at the end of its execution.
- *
- */
+/** Status of a Lambda invocation at the end of its execution. */
 public enum InvocationStatus {
     /** Execution completed successfully in this invocation. */
     SUCCEEDED,

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationChangeInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationChangeInfo.java
@@ -13,9 +13,7 @@ import java.util.Map;
  * @param durableExecutionArn the durable execution ARN
  * @param updatedOperations operations whose status changed in this checkpoint response, keyed by operation ID
  * @param operations a snapshot of all known operations after the update, keyed by operation ID
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public record OperationChangeInfo(
         String requestId,
         String durableExecutionArn,

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationChangeItemInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationChangeItemInfo.java
@@ -4,6 +4,7 @@ package software.amazon.lambda.durable.plugin;
 
 import java.time.Instant;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
+import software.amazon.lambda.durable.annotations.Experimental;
 
 /**
  * Operation-level information for a single operation within an {@link OperationChangeInfo}.
@@ -15,11 +16,9 @@ import software.amazon.awssdk.services.lambda.model.OperationStatus;
  * @param parentId parent operation ID (null for root-level operations)
  * @param startTimestamp when the operation started
  * @param endTimestamp when the operation ended
- * @param error non-null if the operation failed
+ * @param error non-null if the operation failed; this component is experimental
  * @param status operation status
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public record OperationChangeItemInfo(
         String id,
         String name,
@@ -28,5 +27,5 @@ public record OperationChangeItemInfo(
         String parentId,
         Instant startTimestamp,
         Instant endTimestamp,
-        Throwable error,
+        @Experimental Throwable error,
         OperationStatus status) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationEndInfo.java
@@ -3,6 +3,7 @@
 package software.amazon.lambda.durable.plugin;
 
 import java.time.Instant;
+import software.amazon.lambda.durable.annotations.Experimental;
 
 /**
  * Extended operation information for operation end events.
@@ -17,10 +18,8 @@ import java.time.Instant;
  * @param status the operation's terminal status (e.g., SUCCEEDED, FAILED, TIMED_OUT) — may be null for virtual ops
  * @param attempt the total number of attempts for retriable operations (STEP, WAIT_FOR_CONDITION) — null for others
  * @param isReplay true if this operation already existed in the execution state (completed in a prior invocation)
- * @param error non-null if the operation failed
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ * @param error non-null if the operation failed; this component is experimental
  */
-@Deprecated
 public record OperationEndInfo(
         String id,
         String name,
@@ -32,4 +31,4 @@ public record OperationEndInfo(
         String status,
         Integer attempt,
         boolean isReplay,
-        Throwable error) {}
+        @Experimental Throwable error) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/OperationInfo.java
@@ -20,9 +20,7 @@ import java.time.Instant;
  * @param status current operation status (may be null before the first checkpoint)
  * @param isReplay true if this operation already exists in the execution state from a prior invocation. Plugins can use
  *     this to avoid generating duplicate span IDs.
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public record OperationInfo(
         String id,
         String name,

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
@@ -9,10 +9,7 @@ import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.operation.BaseDurableOperation;
 
-/**
- * Utility methods for converting SDK internal types to plugin info records.
- *
- */
+/** Utility methods for converting SDK internal types to plugin info records. */
 public final class PluginInfoConverter {
 
     private PluginInfoConverter() {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
@@ -12,9 +12,7 @@ import software.amazon.lambda.durable.operation.BaseDurableOperation;
 /**
  * Utility methods for converting SDK internal types to plugin info records.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public final class PluginInfoConverter {
 
     private PluginInfoConverter() {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginRunner.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginRunner.java
@@ -16,9 +16,7 @@ import org.slf4j.LoggerFactory;
  * <p>{@code onInvocationEnd} is awaited (the SDK blocks until it returns) to allow plugins to flush data before Lambda
  * freezes.
  *
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public class PluginRunner {
 
     private static final Logger logger = LoggerFactory.getLogger(PluginRunner.class);

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginRunner.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginRunner.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
  *
  * <p>{@code onInvocationEnd} is awaited (the SDK blocks until it returns) to allow plugins to flush data before Lambda
  * freezes.
- *
  */
 public class PluginRunner {
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionEndInfo.java
@@ -3,6 +3,7 @@
 package software.amazon.lambda.durable.plugin;
 
 import java.time.Instant;
+import software.amazon.lambda.durable.annotations.Experimental;
 
 /**
  * Information provided when a user function finishes executing.
@@ -19,10 +20,8 @@ import java.time.Instant;
  * @param isReplayingChildren true if child operations within this context are being replayed from checkpoints
  * @param attempt 1-based attempt number for steps/waitForCondition, null for context operations
  * @param succeeded true if the user function completed without error
- * @param error non-null if the user function failed
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
+ * @param error non-null if the user function failed; this component is experimental
  */
-@Deprecated
 public record UserFunctionEndInfo(
         String id,
         String name,
@@ -34,4 +33,4 @@ public record UserFunctionEndInfo(
         boolean isReplayingChildren,
         Integer attempt,
         boolean succeeded,
-        Throwable error) {}
+        @Experimental Throwable error) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionStartInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionStartInfo.java
@@ -18,9 +18,7 @@ import java.time.Instant;
  * @param startTimestamp when the user function started
  * @param isReplayingChildren true if child operations within this context are being replayed from checkpoints
  * @param attempt 1-based attempt number for steps/waitForCondition, null for context operations
- * @deprecated This is a preview API that is experimental and may be changed or removed in future releases.
  */
-@Deprecated
 public record UserFunctionStartInfo(
         String id,
         String name,

--- a/sdk/src/test/java/software/amazon/lambda/durable/annotations/ExperimentalTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/annotations/ExperimentalTest.java
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.annotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ExperimentalTest {
+
+    @Test
+    void supportsPublicApisAndRecordComponents() {
+        var targets = Set.of(Experimental.class.getAnnotation(Target.class).value());
+
+        assertTrue(targets.contains(ElementType.TYPE));
+        assertTrue(targets.contains(ElementType.METHOD));
+        assertTrue(targets.contains(ElementType.FIELD));
+        assertTrue(targets.contains(ElementType.PARAMETER));
+        assertTrue(targets.contains(ElementType.RECORD_COMPONENT));
+    }
+
+    @Test
+    void isDocumentedAndRetainedInClassFiles() {
+        assertTrue(Experimental.class.isAnnotationPresent(Documented.class));
+        assertEquals(
+                RetentionPolicy.CLASS,
+                Experimental.class.getAnnotation(Retention.class).value());
+    }
+}

--- a/sdk/src/test/java/software/amazon/lambda/durable/annotations/ExperimentalTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/annotations/ExperimentalTest.java
@@ -29,6 +29,8 @@ class ExperimentalTest {
     @Test
     void isDocumentedAndRetainedInClassFiles() {
         assertTrue(Experimental.class.isAnnotationPresent(Documented.class));
-        assertEquals(RetentionPolicy.CLASS, Experimental.class.getAnnotation(Retention.class).value());
+        assertEquals(
+                RetentionPolicy.CLASS,
+                Experimental.class.getAnnotation(Retention.class).value());
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/annotations/ExperimentalTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/annotations/ExperimentalTest.java
@@ -29,8 +29,6 @@ class ExperimentalTest {
     @Test
     void isDocumentedAndRetainedInClassFiles() {
         assertTrue(Experimental.class.isAnnotationPresent(Documented.class));
-        assertEquals(
-                RetentionPolicy.CLASS,
-                Experimental.class.getAnnotation(Retention.class).value());
+        assertEquals(RetentionPolicy.CLASS, Experimental.class.getAnnotation(Retention.class).value());
     }
 }


### PR DESCRIPTION
## Summary
- remove preview deprecation markers from the durable plugin API and OpenTelemetry plugin
- update documentation and remove obsolete deprecation suppressions
- add an `Experimental` annotation and apply it to plugin error payload components

## Testing
- `git diff --check`
- static scans confirm no preview/deprecation markers remain on the promoted APIs
- Maven tests and Spotless were not run because Java and Maven are unavailable in the workspace environment