### PR TITLE
feat(plugin): surface execution input and result on invocation hooks

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -122,6 +122,78 @@ class PluginIntegrationTest {
         assertNotNull(plugin.invocationEnds.get(0).executionError());
     }
 
+    @Test
+    void plugin_invocationHooks_carryExecutionInputAndResult_onSuccess() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> context.step("greet", String.class, stepCtx -> "Hello " + input),
+                config);
+
+        var result = runner.runUntilComplete("World");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+
+        // The deserialized handler input reaches the start hook ...
+        assertEquals("World", plugin.invocationStarts.get(0).executionInput());
+        // ... and the end hook, alongside the value the handler returned.
+        var end = plugin.invocationEnds.get(0);
+        assertEquals("World", end.executionInput());
+        assertEquals("Hello World", end.executionResult());
+    }
+
+    @Test
+    void plugin_invocationEnd_omitsExecutionResult_onFailure() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> context.step(
+                        "failing",
+                        String.class,
+                        stepCtx -> {
+                            throw new RuntimeException("boom");
+                        },
+                        StepConfig.builder()
+                                .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                                .build()),
+                config);
+
+        var result = runner.run("input");
+
+        assertEquals(ExecutionStatus.FAILED, result.getStatus());
+
+        var end = plugin.invocationEnds.get(0);
+        assertEquals("input", end.executionInput());
+        assertNull(end.executionResult(), "a failed execution produced no result");
+    }
+
+    @Test
+    void plugin_invocationEnd_omitsExecutionResult_onSuspension() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    context.wait("pause", Duration.ofMinutes(5));
+                    return "complete";
+                },
+                config);
+
+        var result = runner.run("input");
+
+        assertEquals(ExecutionStatus.PENDING, result.getStatus());
+
+        var end = plugin.invocationEnds.get(0);
+        assertEquals(InvocationStatus.PENDING, end.invocationStatus());
+        assertEquals("input", end.executionInput());
+        assertNull(end.executionResult(), "a suspended invocation has not produced a result yet");
+    }
+
     // ─── Operation-level hooks ───────────────────────────────────────────
 
     @Test

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -8,7 +8,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
@@ -19,6 +22,8 @@ import software.amazon.lambda.durable.model.ExecutionStatus;
 import software.amazon.lambda.durable.model.WaitForConditionResult;
 import software.amazon.lambda.durable.plugin.*;
 import software.amazon.lambda.durable.retry.RetryStrategies;
+import software.amazon.lambda.durable.serde.JacksonSerDes;
+import software.amazon.lambda.durable.serde.SerDes;
 import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
 
 /** Integration tests verifying plugin hooks fire correctly during durable execution lifecycle. */
@@ -192,6 +197,56 @@ class PluginIntegrationTest {
         assertEquals(InvocationStatus.PENDING, end.invocationStatus());
         assertEquals("input", end.executionInput());
         assertNull(end.executionResult(), "a suspended invocation has not produced a result yet");
+    }
+
+    @Test
+    void plugin_executionInput_isDeserializedOnce_andSharedWithHandler() {
+        var serDes = new CountingSerDes();
+        var plugin = new RecordingPlugin();
+        var config =
+                DurableConfig.builder().withPlugins(plugin).withSerDes(serDes).build();
+        var handlerInput = new AtomicReference<Object>();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    handlerInput.set(input);
+                    return context.step("greet", String.class, stepCtx -> "Hello " + input);
+                },
+                config);
+
+        var result = runner.runUntilComplete("World");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        // The handler input is deserialized once and that same instance reaches the hooks — a second
+        // deserialization would double the cost and re-run side effects in a stateful SerDes.
+        assertEquals(1, serDes.inputDeserializations("World"));
+        assertSame(handlerInput.get(), plugin.invocationStarts.get(0).executionInput());
+        assertSame(handlerInput.get(), plugin.invocationEnds.get(0).executionInput());
+    }
+
+    /** SerDes that counts how many times each payload is deserialized. */
+    static class CountingSerDes implements SerDes {
+        private final JacksonSerDes delegate = new JacksonSerDes();
+        private final Map<String, AtomicInteger> deserializations = new ConcurrentHashMap<>();
+
+        @Override
+        public String serialize(Object value) {
+            return delegate.serialize(value);
+        }
+
+        @Override
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            deserializations
+                    .computeIfAbsent(data, ignored -> new AtomicInteger())
+                    .incrementAndGet();
+            return delegate.deserialize(data, typeToken);
+        }
+
+        int inputDeserializations(String value) {
+            var counter = deserializations.get(delegate.serialize(value));
+            return counter == null ? 0 : counter.get();
+        }
     }
 
     // ─── Operation-level hooks ───────────────────────────────────────────

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -4,6 +4,7 @@ package software.amazon.lambda.durable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,6 +26,7 @@ import software.amazon.lambda.durable.retry.RetryStrategies;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
 import software.amazon.lambda.durable.serde.SerDes;
 import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
+import software.amazon.lambda.durable.util.ExceptionHelper;
 
 /** Integration tests verifying plugin hooks fire correctly during durable execution lifecycle. */
 class PluginIntegrationTest {
@@ -246,6 +248,45 @@ class PluginIntegrationTest {
         int inputDeserializations(String value) {
             var counter = deserializations.get(delegate.serialize(value));
             return counter == null ? 0 : counter.get();
+        }
+    }
+
+    @Test
+    void plugin_hooksStayPaired_whenSerDesSneakyThrowsCheckedException() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder()
+                .withPlugins(plugin)
+                .withSerDes(new SneakyThrowingSerDes())
+                .build();
+
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> "unreachable", config);
+
+        var result = runner.run("input");
+
+        assertEquals(ExecutionStatus.FAILED, result.getStatus());
+        // SerDes.deserialize declares no checked exceptions, so an implementation can sneaky-throw one. The start
+        // hook must still fire, otherwise a plugin keying state on it sees an end with no start.
+        assertEquals(1, plugin.invocationStarts.size(), "onInvocationStart must fire before the failure surfaces");
+        assertNull(plugin.invocationStarts.get(0).executionInput(), "input could not be deserialized");
+        assertEquals(1, plugin.invocationEnds.size());
+        assertEquals(InvocationStatus.FAILED, plugin.invocationEnds.get(0).invocationStatus());
+    }
+
+    /**
+     * SerDes that sneaky-throws a checked exception from deserialize, as DurableInputOutputSerDes does on IO errors.
+     */
+    static class SneakyThrowingSerDes implements SerDes {
+        private final JacksonSerDes delegate = new JacksonSerDes();
+
+        @Override
+        public String serialize(Object value) {
+            return delegate.serialize(value);
+        }
+
+        @Override
+        public <T> T deserialize(String data, TypeToken<T> typeToken) {
+            ExceptionHelper.sneakyThrow(new IOException("sneaky checked failure"));
+            return null;
         }
     }
 

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/DurableExecutor.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/DurableExecutor.java
@@ -71,13 +71,15 @@ public class DurableExecutor {
                         // deserialization would double the cost, hand plugins a different object than the handler, and
                         // re-run any side effects in a stateful custom SerDes. A failure is captured rather than thrown
                         // so onInvocationStart still fires before it surfaces, keeping the start/end hooks paired.
+                        // SerDes is a public extension point whose deserialize declares no checked exceptions, so an
+                        // implementation may sneaky-throw one; capture every Throwable and rethrow it unchanged.
                         I userInput = null;
-                        RuntimeException inputFailure = null;
+                        Throwable inputFailure = null;
                         try {
                             userInput = extractUserInput(
                                     executionManager.getExecutionOperation(), config.getSerDes(), inputType);
-                        } catch (RuntimeException e) {
-                            inputFailure = e;
+                        } catch (Throwable t) {
+                            inputFailure = t;
                         }
                         pluginExecutionInput.set(userInput);
 
@@ -91,7 +93,7 @@ public class DurableExecutor {
                                 executionManager.getExecutionOperation().startTimestamp(),
                                 userInput));
                         if (inputFailure != null) {
-                            throw inputFailure;
+                            ExceptionHelper.sneakyThrow(inputFailure);
                         }
 
                         var context = DurableContextImpl.createRootContext(executionManager, config, lambdaContext);

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/DurableExecutor.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/DurableExecutor.java
@@ -67,20 +67,33 @@ public class DurableExecutor {
                     () -> {
                         executionManager.setCurrentThreadContext(new ThreadContext(null, ThreadType.CONTEXT));
 
+                        // Deserialize once and share the value with the plugin hooks and the handler below. A second
+                        // deserialization would double the cost, hand plugins a different object than the handler, and
+                        // re-run any side effects in a stateful custom SerDes. A failure is captured rather than thrown
+                        // so onInvocationStart still fires before it surfaces, keeping the start/end hooks paired.
+                        I userInput = null;
+                        RuntimeException inputFailure = null;
+                        try {
+                            userInput = extractUserInput(
+                                    executionManager.getExecutionOperation(), config.getSerDes(), inputType);
+                        } catch (RuntimeException e) {
+                            inputFailure = e;
+                        }
+                        pluginExecutionInput.set(userInput);
+
                         // onInvocationStart runs on the user thread so plugins can
                         // inject ThreadLocal objects, update MDC, etc.
                         // executionStartTime comes from the initial EXECUTION operation in the first backend event.
-                        pluginExecutionInput.set(extractUserInputForPlugins(
-                                pluginRunner, executionManager.getExecutionOperation(), config.getSerDes(), inputType));
                         pluginRunner.onInvocationStart(new InvocationInfo(
                                 requestId,
                                 executionArn,
                                 isFirstInvocation,
                                 executionManager.getExecutionOperation().startTimestamp(),
-                                pluginExecutionInput.get()));
+                                userInput));
+                        if (inputFailure != null) {
+                            throw inputFailure;
+                        }
 
-                        var userInput = extractUserInput(
-                                executionManager.getExecutionOperation(), config.getSerDes(), inputType);
                         var context = DurableContextImpl.createRootContext(executionManager, config, lambdaContext);
                         DurableContextImpl.setCurrentContext(context);
                         // use a try-with-resources to clear logger properties
@@ -182,26 +195,6 @@ public class DurableExecutor {
             Object executionResult) {
         pluginRunner.onInvocationEnd(new InvocationEndInfo(
                 requestId, executionArn, isFirstInvocation, status, error, executionInput, executionResult));
-    }
-
-    /**
-     * Deserializes the execution input for the plugin hooks, or returns null when it is not needed or not available.
-     *
-     * <p>Skipped entirely when no plugins are registered, so plugin-less executions pay nothing. A deserialization
-     * failure yields null rather than propagating: the authoritative extraction below still surfaces the error at its
-     * original point, so the plugin hooks must not change when the invocation fails.
-     */
-    private static <I> Object extractUserInputForPlugins(
-            PluginRunner pluginRunner, Operation executionOp, SerDes serDes, TypeToken<I> inputType) {
-        if (pluginRunner.isEmpty()) {
-            return null;
-        }
-        try {
-            return extractUserInput(executionOp, serDes, inputType);
-        } catch (RuntimeException e) {
-            logger.debug("Could not deserialize execution input for plugins: {}", e.getMessage());
-            return null;
-        }
     }
 
     private static String handleLargePayload(ExecutionManager executionManager, String outputPayload) {

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/DurableExecutor.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/DurableExecutor.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +61,8 @@ public class DurableExecutor {
             var executionArn = input.durableExecutionArn();
 
             executionManager.registerActiveThread(null);
+            // Captured for onInvocationEnd, which runs outside the handler thread below.
+            var pluginExecutionInput = new AtomicReference<>();
             var handlerFuture = CompletableFuture.supplyAsync(
                     () -> {
                         executionManager.setCurrentThreadContext(new ThreadContext(null, ThreadType.CONTEXT));
@@ -67,11 +70,14 @@ public class DurableExecutor {
                         // onInvocationStart runs on the user thread so plugins can
                         // inject ThreadLocal objects, update MDC, etc.
                         // executionStartTime comes from the initial EXECUTION operation in the first backend event.
+                        pluginExecutionInput.set(extractUserInputForPlugins(
+                                pluginRunner, executionManager.getExecutionOperation(), config.getSerDes(), inputType));
                         pluginRunner.onInvocationStart(new InvocationInfo(
                                 requestId,
                                 executionArn,
                                 isFirstInvocation,
-                                executionManager.getExecutionOperation().startTimestamp()));
+                                executionManager.getExecutionOperation().startTimestamp(),
+                                pluginExecutionInput.get()));
 
                         var userInput = extractUserInput(
                                 executionManager.getExecutionOperation(), config.getSerDes(), inputType);
@@ -103,6 +109,8 @@ public class DurableExecutor {
                                             executionArn,
                                             isFirstInvocation,
                                             InvocationStatus.PENDING,
+                                            null,
+                                            pluginExecutionInput.get(),
                                             null);
                                     return DurableExecutionOutput.pending();
                                 }
@@ -119,7 +127,9 @@ public class DurableExecutor {
                                             executionArn,
                                             isFirstInvocation,
                                             InvocationStatus.RETRYING,
-                                            cause);
+                                            cause,
+                                            pluginExecutionInput.get(),
+                                            null);
                                     throw unrecoverableDurableExecutionException;
                                 }
 
@@ -131,7 +141,9 @@ public class DurableExecutor {
                                         executionArn,
                                         isFirstInvocation,
                                         InvocationStatus.FAILED,
-                                        cause);
+                                        cause,
+                                        pluginExecutionInput.get(),
+                                        null);
                                 return DurableExecutionOutput.failure(buildErrorObject(cause, config.getSerDes()));
                             }
                             // user handler complete successfully
@@ -145,7 +157,9 @@ public class DurableExecutor {
                                     executionArn,
                                     isFirstInvocation,
                                     InvocationStatus.SUCCEEDED,
-                                    null);
+                                    null,
+                                    pluginExecutionInput.get(),
+                                    result);
                             return output;
                         })
                         .join();
@@ -163,8 +177,31 @@ public class DurableExecutor {
             String executionArn,
             boolean isFirstInvocation,
             InvocationStatus status,
-            Throwable error) {
-        pluginRunner.onInvocationEnd(new InvocationEndInfo(requestId, executionArn, isFirstInvocation, status, error));
+            Throwable error,
+            Object executionInput,
+            Object executionResult) {
+        pluginRunner.onInvocationEnd(new InvocationEndInfo(
+                requestId, executionArn, isFirstInvocation, status, error, executionInput, executionResult));
+    }
+
+    /**
+     * Deserializes the execution input for the plugin hooks, or returns null when it is not needed or not available.
+     *
+     * <p>Skipped entirely when no plugins are registered, so plugin-less executions pay nothing. A deserialization
+     * failure yields null rather than propagating: the authoritative extraction below still surfaces the error at its
+     * original point, so the plugin hooks must not change when the invocation fails.
+     */
+    private static <I> Object extractUserInputForPlugins(
+            PluginRunner pluginRunner, Operation executionOp, SerDes serDes, TypeToken<I> inputType) {
+        if (pluginRunner.isEmpty()) {
+            return null;
+        }
+        try {
+            return extractUserInput(executionOp, serDes, inputType);
+        } catch (RuntimeException e) {
+            logger.debug("Could not deserialize execution input for plugins: {}", e.getMessage());
+            return null;
+        }
     }
 
     private static String handleLargePayload(ExecutionManager executionManager, String outputPayload) {

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationEndInfo.java
@@ -12,10 +12,39 @@ import software.amazon.lambda.durable.annotations.Experimental;
  * @param isFirstInvocation true if this is the first invocation of the execution
  * @param invocationStatus the invocation outcome (SUCCEEDED, FAILED, or PENDING)
  * @param executionError non-null if the execution failed; this component is experimental
+ * @param executionInput the deserialized execution input passed to the user handler, or null when no plugins are
+ *     registered or the input could not be deserialized. This is a preview API that is experimental and may be changed
+ *     or removed in future releases.
+ * @param executionResult the value the user handler returned, or null unless the invocation completed the execution
+ *     successfully. This is a preview API that is experimental and may be changed or removed in future releases.
  */
 public record InvocationEndInfo(
         String requestId,
         String durableExecutionArn,
         boolean isFirstInvocation,
         InvocationStatus invocationStatus,
-        @Experimental Throwable executionError) {}
+        @Experimental Throwable executionError,
+        @Deprecated Object executionInput,
+        @Deprecated Object executionResult) {
+
+    /**
+     * Creates invocation-end information without the execution input or result.
+     *
+     * <p>Retained so callers written before {@code executionInput} and {@code executionResult} were added keep
+     * compiling; both resolve to null.
+     *
+     * @param requestId the Lambda request ID for this invocation
+     * @param durableExecutionArn the durable execution ARN
+     * @param isFirstInvocation true if this is the first invocation of the execution
+     * @param invocationStatus the invocation outcome
+     * @param executionError non-null if the execution failed
+     */
+    public InvocationEndInfo(
+            String requestId,
+            String durableExecutionArn,
+            boolean isFirstInvocation,
+            InvocationStatus invocationStatus,
+            Throwable executionError) {
+        this(requestId, durableExecutionArn, isFirstInvocation, invocationStatus, executionError, null, null);
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationEndInfo.java
@@ -13,10 +13,9 @@ import software.amazon.lambda.durable.annotations.Experimental;
  * @param invocationStatus the invocation outcome (SUCCEEDED, FAILED, or PENDING)
  * @param executionError non-null if the execution failed; this component is experimental
  * @param executionInput the deserialized execution input passed to the user handler, or null when no plugins are
- *     registered or the input could not be deserialized. This is a preview API that is experimental and may be changed
- *     or removed in future releases.
+ *     registered or the input could not be deserialized; this component is experimental
  * @param executionResult the value the user handler returned, or null unless the invocation completed the execution
- *     successfully. This is a preview API that is experimental and may be changed or removed in future releases.
+ *     successfully; this component is experimental
  */
 public record InvocationEndInfo(
         String requestId,
@@ -24,8 +23,8 @@ public record InvocationEndInfo(
         boolean isFirstInvocation,
         InvocationStatus invocationStatus,
         @Experimental Throwable executionError,
-        @Deprecated Object executionInput,
-        @Deprecated Object executionResult) {
+        @Experimental Object executionInput,
+        @Experimental Object executionResult) {
 
     /**
      * Creates invocation-end information without the execution input or result.

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationEndInfo.java
@@ -46,4 +46,18 @@ public record InvocationEndInfo(
             Throwable executionError) {
         this(requestId, durableExecutionArn, isFirstInvocation, invocationStatus, executionError, null, null);
     }
+
+    /**
+     * Returns a representation that omits {@code executionInput} and {@code executionResult}.
+     *
+     * <p>The generated representation would render both payloads, so plugins that log this object whole would start
+     * emitting customer inputs and results, potentially including secrets or personal data. Read the components
+     * explicitly to record them.
+     */
+    @Override
+    public String toString() {
+        return "InvocationEndInfo[requestId=" + requestId + ", durableExecutionArn=" + durableExecutionArn
+                + ", isFirstInvocation=" + isFirstInvocation + ", invocationStatus=" + invocationStatus
+                + ", executionError=" + executionError + "]";
+    }
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
@@ -3,6 +3,7 @@
 package software.amazon.lambda.durable.plugin;
 
 import java.time.Instant;
+import software.amazon.lambda.durable.annotations.Experimental;
 
 /**
  * Invocation-level information available to plugin hooks.
@@ -13,15 +14,14 @@ import java.time.Instant;
  * @param executionStartTime the start timestamp of the durable execution, taken from the initial EXECUTION operation in
  *     the first event delivered by the backend. Stable across all invocations of the same execution.
  * @param executionInput the deserialized execution input passed to the user handler, or null when no plugins are
- *     registered or the input could not be deserialized. This is a preview API that is experimental and may be changed
- *     or removed in future releases.
+ *     registered or the input could not be deserialized; this component is experimental
  */
 public record InvocationInfo(
         String requestId,
         String durableExecutionArn,
         boolean isFirstInvocation,
         Instant executionStartTime,
-        @Deprecated Object executionInput) {
+        @Experimental Object executionInput) {
 
     /**
      * Creates invocation information without an execution input.

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
@@ -12,6 +12,30 @@ import java.time.Instant;
  * @param isFirstInvocation true if this is the first invocation of the execution (not a replay invocation)
  * @param executionStartTime the start timestamp of the durable execution, taken from the initial EXECUTION operation in
  *     the first event delivered by the backend. Stable across all invocations of the same execution.
+ * @param executionInput the deserialized execution input passed to the user handler, or null when no plugins are
+ *     registered or the input could not be deserialized. This is a preview API that is experimental and may be changed
+ *     or removed in future releases.
  */
 public record InvocationInfo(
-        String requestId, String durableExecutionArn, boolean isFirstInvocation, Instant executionStartTime) {}
+        String requestId,
+        String durableExecutionArn,
+        boolean isFirstInvocation,
+        Instant executionStartTime,
+        @Deprecated Object executionInput) {
+
+    /**
+     * Creates invocation information without an execution input.
+     *
+     * <p>Retained so callers written before {@code executionInput} was added keep compiling; {@code executionInput}
+     * resolves to null.
+     *
+     * @param requestId the Lambda request ID for this invocation
+     * @param durableExecutionArn the durable execution ARN
+     * @param isFirstInvocation true if this is the first invocation of the execution
+     * @param executionStartTime the start timestamp of the durable execution
+     */
+    public InvocationInfo(
+            String requestId, String durableExecutionArn, boolean isFirstInvocation, Instant executionStartTime) {
+        this(requestId, durableExecutionArn, isFirstInvocation, executionStartTime, null);
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/InvocationInfo.java
@@ -38,4 +38,17 @@ public record InvocationInfo(
             String requestId, String durableExecutionArn, boolean isFirstInvocation, Instant executionStartTime) {
         this(requestId, durableExecutionArn, isFirstInvocation, executionStartTime, null);
     }
+
+    /**
+     * Returns a representation that omits {@code executionInput}.
+     *
+     * <p>The generated representation would render the execution input, so plugins that log this object whole would
+     * start emitting customer payloads, potentially including secrets or personal data. Read the component explicitly
+     * to record it.
+     */
+    @Override
+    public String toString() {
+        return "InvocationInfo[requestId=" + requestId + ", durableExecutionArn=" + durableExecutionArn
+                + ", isFirstInvocation=" + isFirstInvocation + ", executionStartTime=" + executionStartTime + "]";
+    }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
@@ -133,6 +133,41 @@ class PluginRunnerTest {
         assertEquals(List.of("p1:onInvocationStart"), calls);
     }
 
+    // ─── Execution input / result components ─────────────────────────────
+
+    @Test
+    void invocationInfo_compatibilityConstructor_leavesExecutionInputNull() {
+        var info = new InvocationInfo("req-123", "arn:test", false, Instant.now());
+
+        assertNull(info.executionInput());
+    }
+
+    @Test
+    void invocationInfo_carriesExecutionInput() {
+        var input = Map.of("name", "World");
+
+        var info = new InvocationInfo("req-123", "arn:test", true, Instant.now(), input);
+
+        assertEquals(input, info.executionInput());
+    }
+
+    @Test
+    void invocationEndInfo_compatibilityConstructor_leavesExecutionInputAndResultNull() {
+        var info = new InvocationEndInfo("req-123", "arn:test", false, InvocationStatus.SUCCEEDED, null);
+
+        assertNull(info.executionInput());
+        assertNull(info.executionResult());
+    }
+
+    @Test
+    void invocationEndInfo_carriesExecutionInputAndResult() {
+        var info = new InvocationEndInfo(
+                "req-123", "arn:test", false, InvocationStatus.SUCCEEDED, null, "World", "Hello World");
+
+        assertEquals("World", info.executionInput());
+        assertEquals("Hello World", info.executionResult());
+    }
+
     // ─── Helper methods ──────────────────────────────────────────────────
 
     private static InvocationInfo invocationInfo() {

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
@@ -168,6 +168,30 @@ class PluginRunnerTest {
         assertEquals("Hello World", info.executionResult());
     }
 
+    @Test
+    void invocationInfo_toString_omitsExecutionInput() {
+        var info = new InvocationInfo("req-123", "arn:test", true, Instant.now(), "s3cret-input");
+
+        var rendered = info.toString();
+
+        assertFalse(rendered.contains("s3cret-input"), "execution input must not leak into logs");
+        assertTrue(rendered.contains("req-123"));
+        assertTrue(rendered.contains("arn:test"));
+    }
+
+    @Test
+    void invocationEndInfo_toString_omitsExecutionInputAndResult() {
+        var info = new InvocationEndInfo(
+                "req-123", "arn:test", false, InvocationStatus.SUCCEEDED, null, "s3cret-input", "s3cret-result");
+
+        var rendered = info.toString();
+
+        assertFalse(rendered.contains("s3cret-input"), "execution input must not leak into logs");
+        assertFalse(rendered.contains("s3cret-result"), "execution result must not leak into logs");
+        assertTrue(rendered.contains("req-123"));
+        assertTrue(rendered.contains("SUCCEEDED"));
+    }
+
     // ─── Helper methods ──────────────────────────────────────────────────
 
     private static InvocationInfo invocationInfo() {


### PR DESCRIPTION
## Summary

Widens the plugin invocation hooks so instrumentation plugins can record execution
input/output:

- `InvocationInfo.executionInput` — the **deserialized** handler input
- `InvocationEndInfo.executionInput` — the same value, so end-only plugins need not cache it
- `InvocationEndInfo.executionResult` — the value the handler returned, populated only when the
  invocation completed the execution successfully (null on FAILED / PENDING / RETRYING)

## Motivation

The JS SDK already exposes this to plugins (`InvocationBaseInfo.executionInput`,
`InvocationEndInfo.executionResult`), and the Python SDK added the equivalent in
aws-durable-execution-sdk-python#616. Java is the only SDK where a plugin cannot see execution
I/O at all, which blocks the Workflow Insight plugin from emitting the `input`/`output` fields
its record schema defines — it currently omits them rather than fabricating them. This is the
one remaining hook-surface gap of the two found by cross-SDK conformance validation (the other,
per-operation `result`, is #596).

## Compatibility

Both records keep a **constructor at their previous arity**, delegating with nulls:

```java
new InvocationInfo(requestId, arn, isFirstInvocation, executionStartTime);              // still compiles
new InvocationEndInfo(requestId, arn, isFirstInvocation, status, executionError);       // still compiles
```

So existing callers — including `otel-plugin`'s tests, which construct these directly — compile
unchanged; nothing outside `sdk/` needed edits. Adding a record component alone would have been a
source-breaking change to an API that #620 just promoted to stable.

## Cost and failure behavior

- The plugin-facing deserialization is **skipped entirely when no plugins are registered**
  (`PluginRunner.isEmpty()`), so plugin-less executions pay nothing.
- If the input cannot be deserialized, the hook value is null rather than propagating; the
  authoritative extraction still surfaces the error at its original point. This keeps hook
  ordering intact — plugins continue to receive `onInvocationStart` before any input-extraction
  failure, so a plugin keying state on start never sees an end without a start.

## Preview marking

The new components are marked `@Experimental`, matching the convention #620 established when it
replaced the preview-API `@Deprecated` markers — the same idiom already used by
`@Experimental Throwable executionError` in this record.

## Testing

- `PluginRunnerTest` — 13 pass, including 4 new: the compatibility constructors leave the new
  components null, and the canonical constructors carry input/result
- `PluginIntegrationTest` — 28 pass, including 3 new end-to-end through the real executor:
  input reaches both hooks and the result appears on success; result is null on failure and on
  suspension (PENDING)
- Full reactor: `sdk` 397 tests, `otel-plugin` 165 tests, all green; `mvn spotless:check` clean
