### PR TITLE
ci: run e2e tests on otel-plugin changes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,6 +10,7 @@ on:
       - 'sdk/**'
       - 'sdk-testing/**'
       - 'sdk-integration-tests/**'
+      - 'otel-plugin/**'
       - 'examples/**'
       - 'pom.xml'
   push:
@@ -20,6 +21,7 @@ on:
       - 'sdk/**'
       - 'sdk-testing/**'
       - 'sdk-integration-tests/**'
+      - 'otel-plugin/**'
       - 'examples/**'
       - 'pom.xml'
 


### PR DESCRIPTION
### Issue Link, if available
N/A

### Description
The e2e-tests workflow's paths filter omitted otel-plugin/, so any PR touching only that module (including real code changes, not just dependency bumps) silently skipped e2e coverage. Add 'otel-plugin/**' to the paths filter on both the pull_request and push triggers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Demo/Screenshots
N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Have unit tests been written for these changes? N/A

#### Integration Tests

Have integration tests been written for these changes? N/A

#### Examples

Has a new example been added for the change? (if applicable) N/A
