### PR TITLE
test(otel): add virtual context conformance handler

### DIFF
--- a/conformance-tests-otel/src/main/java/software/amazon/lambda/durable/conformance/otel/Otel20VirtualContext.java
+++ b/conformance-tests-otel/src/main/java/software/amazon/lambda/durable/conformance/otel/Otel20VirtualContext.java
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.conformance.otel;
+
+import java.util.Map;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.config.RunInChildContextConfig;
+
+/** Virtual child-context scenario for OTel requirement otel-invocation-20. */
+public final class Otel20VirtualContext extends OtelConformanceHandler<String> {
+
+  @Override
+  public String handleRequest(Map<String, Object> event, DurableContext context) {
+    requireScenario(event, "virtual-context");
+    return context.runInChildContext(
+        "otel-virtual-context",
+        String.class,
+        child -> "virtual-complete",
+        RunInChildContextConfig.builder().isVirtual(true).build());
+  }
+}

--- a/conformance-tests-otel/template.yaml
+++ b/conformance-tests-otel/template.yaml
@@ -305,6 +305,17 @@ Resources:
       CodeUri: .
       Handler: software.amazon.lambda.durable.conformance.otel.Otel19ExecutionFailure
       Role: !Ref LambdaExecutionRoleArn
+
+  Otel20VirtualContext:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription:
+        - otel-invocation-20
+    Properties:
+      CodeUri: .
+      Handler: software.amazon.lambda.durable.conformance.otel.Otel20VirtualContext
+      Role: !Ref LambdaExecutionRoleArn
+
   OtelExecution1Success:
     Type: AWS::Serverless::Function
     TestingMetadata:
@@ -572,6 +583,19 @@ Resources:
     Properties:
       CodeUri: .
       Handler: software.amazon.lambda.durable.conformance.otel.Otel19ExecutionFailure
+      Role: !Ref LambdaExecutionRoleArn
+      Environment:
+        Variables:
+          OTEL_PLUGIN_MODE: execution
+
+  OtelExecution20VirtualContext:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription:
+        - otel-execution-20
+    Properties:
+      CodeUri: .
+      Handler: software.amazon.lambda.durable.conformance.otel.Otel20VirtualContext
       Role: !Ref LambdaExecutionRoleArn
       Environment:
         Variables:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Related conformance requirement: https://github.com/aws/aws-durable-execution-conformance-tests/pull/96

Merge order: merge the shared conformance requirement PR first, then this Java SDK handler PR.

### Description

Adds the Java SDK-owned `Otel20VirtualContext` handler for the new virtual child-context OTel scenario. The SAM template maps the handler to both `otel-invocation-20` and `otel-execution-20`, selecting execution-view telemetry through `OTEL_PLUGIN_MODE`.

### Demo/Screenshots

Not applicable; this change adds deployed conformance-test handlers.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

No new unit test was added because this is a standalone conformance handler and template mapping with no new SDK behavior. The handler was compiled as part of the module package build.

#### Integration Tests

The paired end-to-end requirements are added in aws/aws-durable-execution-conformance-tests#96 and will run through the OTel conformance workflow. Locally, the standalone module packaged successfully with `JAVA_SDK_VERSION=2.1.1-SNAPSHOT`.

#### Examples

Added `Otel20VirtualContext` and invocation/execution SAM mappings.