### PR TITLE
feat(plugin): add user function outcome enum

### DIFF
--- a/conformance-tests/src/main/java/plugin/ConformanceLoggingPlugin.java
+++ b/conformance-tests/src/main/java/plugin/ConformanceLoggingPlugin.java
@@ -83,7 +83,7 @@ public class ConformanceLoggingPlugin implements DurableExecutionPlugin {
     @Override
     public void onUserFunctionEnd(UserFunctionEndInfo info) {
         if (isStep(info.type()) && info.attempt() != null) {
-            String outcome = info.succeeded() ? "SUCCEEDED" : "FAILED";
+            String outcome = info.outcome().name();
             System.out.println(String.format(
                     "{\"plugin\": \"%s\", \"hook\": \"attempt-end\", \"n\": %d, \"outcome\": \"%s\", \"op\": \"%s\"%s}",
                     prefix, info.attempt(), outcome, info.id(), arnField()));

--- a/conformance-tests/src/main/java/plugin/PluginFaultyAndHealthy.java
+++ b/conformance-tests/src/main/java/plugin/PluginFaultyAndHealthy.java
@@ -141,7 +141,7 @@ public class PluginFaultyAndHealthy extends DurableHandler<String, String> {
             System.out.println(String.format(
                     "{\"plugin\": \"CONFPLUGIN-HEALTHY\", \"hook\": \"attempt-end\", \"op\": \"%s\", "
                             + "\"outcome\": \"%s\"%s}",
-                    info.id(), info.succeeded() ? "SUCCEEDED" : "FAILED", PluginSupport.arnField(executionArn)));
+                    info.id(), info.outcome().name(), PluginSupport.arnField(executionArn)));
         }
 
         @Override

--- a/conformance-tests/src/main/java/plugin/PluginParallelBranchHooks.java
+++ b/conformance-tests/src/main/java/plugin/PluginParallelBranchHooks.java
@@ -65,7 +65,7 @@ public class PluginParallelBranchHooks extends DurableHandler<Object, List<Strin
             if (!PluginSupport.isBranch(info.subType())) {
                 return;
             }
-            String outcome = info.succeeded() ? "SUCCEEDED" : "FAILED";
+            String outcome = info.outcome().name();
             System.out.println(String.format(
                     "{\"plugin\": \"CONFPLUGIN\", \"hook\": \"fn-end\", \"op\": \"%s\", \"parent\": \"%s\", "
                             + "\"outcome\": \"%s\"%s}",

--- a/conformance-tests/src/main/java/plugin/PluginRetryExhaustion.java
+++ b/conformance-tests/src/main/java/plugin/PluginRetryExhaustion.java
@@ -67,7 +67,7 @@ public class PluginRetryExhaustion extends DurableHandler<Object, String> {
             if (!PluginSupport.isStep(info.type()) || info.attempt() == null) {
                 return;
             }
-            String outcome = info.succeeded() ? "SUCCEEDED" : "FAILED";
+            String outcome = info.outcome().name();
             System.out.println(String.format(
                     "{\"plugin\": \"CONFPLUGIN\", \"hook\": \"attempt-end\", \"n\": %d, \"outcome\": \"%s\", "
                             + "\"op\": \"%s\"%s}",

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/general/PluginExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/general/PluginExample.java
@@ -91,9 +91,9 @@ public class PluginExample extends DurableHandler<GreetingRequest, String> {
         @Override
         public void onUserFunctionEnd(UserFunctionEndInfo info) {
             System.out.printf(
-                    "[PLUGIN] onUserFunctionEnd: name=%s, succeeded=%s, error=%s%n",
+                    "[PLUGIN] onUserFunctionEnd: name=%s, outcome=%s, error=%s%n",
                     info.name(),
-                    info.succeeded(),
+                    info.outcome(),
                     info.error() != null ? info.error().getMessage() : null);
         }
     }

--- a/examples/src/main/java/software/amazon/lambda/durable/examples/general/PluginExample.java
+++ b/examples/src/main/java/software/amazon/lambda/durable/examples/general/PluginExample.java
@@ -20,11 +20,11 @@ import software.amazon.lambda.durable.plugin.*;
  * [PLUGIN] onInvocationStart: requestId=..., durableExecutionArn=..., firstInvocation=true
  * [PLUGIN] onOperationStart: name=create-greeting, type=STEP
  * [PLUGIN] onUserFunctionStart: name=create-greeting, attempt=1
- * [PLUGIN] onUserFunctionEnd: name=create-greeting, succeeded=true
+ * [PLUGIN] onUserFunctionEnd: name=create-greeting, outcome=SUCCEEDED
  * [PLUGIN] onOperationEnd: name=create-greeting
  * [PLUGIN] onOperationStart: name=transform, type=STEP
  * [PLUGIN] onUserFunctionStart: name=transform, attempt=1
- * [PLUGIN] onUserFunctionEnd: name=transform, succeeded=true
+ * [PLUGIN] onUserFunctionEnd: name=transform, outcome=SUCCEEDED
  * [PLUGIN] onOperationEnd: name=transform
  * [PLUGIN] onInvocationEnd: status=SUCCEEDED
  * </pre>

--- a/otel-plugin/README.md
+++ b/otel-plugin/README.md
@@ -211,7 +211,7 @@ Operation and attempt spans link to the Workflow span. `ExecutionOtelPlugin` rev
 | `durable.operation.type` | Parent operation type |
 | `durable.operation.name` | Parent operation name |
 | `durable.attempt.number` | 1-based attempt number |
-| `durable.attempt.outcome` | SUCCEEDED or FAILED |
+| `durable.attempt.outcome` | SUCCEEDED (span status `OK`), FAILED (`ERROR`), or INCOMPLETE (`UNSET`) |
 
 ## Log Correlation (MDC)
 

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/ExecutionOtelPlugin.java
@@ -495,14 +495,19 @@ public class ExecutionOtelPlugin implements DurableExecutionPlugin {
         var span = attemptSpans.remove(key);
         if (span == null) return;
 
-        var outcome = info.succeeded() ? "SUCCEEDED" : "FAILED";
-        span.setAttribute(DURABLE_ATTEMPT_OUTCOME, outcome);
+        span.setAttribute(DURABLE_ATTEMPT_OUTCOME, info.outcome().name());
 
-        if (!info.succeeded() && info.error() != null) {
-            span.setStatus(StatusCode.ERROR, info.error().getMessage());
-            span.recordException(info.error());
-        } else if (info.succeeded()) {
-            span.setStatus(StatusCode.OK);
+        switch (info.outcome()) {
+            case SUCCEEDED -> span.setStatus(StatusCode.OK);
+            case FAILED -> {
+                if (info.error() != null) {
+                    span.setStatus(StatusCode.ERROR, info.error().getMessage());
+                    span.recordException(info.error());
+                }
+            }
+            case INCOMPLETE -> {
+                // An incomplete user function is expected when the durable execution suspends.
+            }
         }
 
         endSpan(span, info.endTimestamp());

--- a/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
+++ b/otel-plugin/src/main/java/software/amazon/lambda/durable/otel/InvocationOtelPlugin.java
@@ -523,14 +523,19 @@ public class InvocationOtelPlugin implements DurableExecutionPlugin {
         var span = attemptSpans.remove(key);
         if (span == null) return;
 
-        var outcome = info.succeeded() ? "SUCCEEDED" : "FAILED";
-        span.setAttribute(DURABLE_ATTEMPT_OUTCOME, outcome);
+        span.setAttribute(DURABLE_ATTEMPT_OUTCOME, info.outcome().name());
 
-        if (!info.succeeded() && info.error() != null) {
-            span.setStatus(StatusCode.ERROR, info.error().getMessage());
-            span.recordException(info.error());
-        } else if (info.succeeded()) {
-            span.setStatus(StatusCode.OK);
+        switch (info.outcome()) {
+            case SUCCEEDED -> span.setStatus(StatusCode.OK);
+            case FAILED -> {
+                if (info.error() != null) {
+                    span.setStatus(StatusCode.ERROR, info.error().getMessage());
+                    span.recordException(info.error());
+                }
+            }
+            case INCOMPLETE -> {
+                // An incomplete user function is expected when the durable execution suspends.
+            }
         }
 
         if (info.endTimestamp() != null) {

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -23,6 +23,7 @@ import java.util.ServiceLoader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.lambda.durable.execution.SuspendExecutionException;
 import software.amazon.lambda.durable.plugin.*;
 
 class ExecutionOtelPluginTest {
@@ -599,6 +600,31 @@ class ExecutionOtelPluginTest {
                 .findFirst()
                 .orElseThrow();
         assertEquals(StatusCode.OK, attemptSpan.getStatus().getStatusCode());
+    }
+
+    @Test
+    void userFunctionIncomplete_leavesAttemptSpanUnset() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", ARN, true, Instant.now()));
+        plugin.onUserFunctionStart(
+                new UserFunctionStartInfo("op-1", "waiting", "STEP", "Step", null, Instant.now(), false, 1));
+        plugin.onUserFunctionEnd(new UserFunctionEndInfo(
+                "op-1",
+                "waiting",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.INCOMPLETE,
+                new SuspendExecutionException()));
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.PENDING, null));
+
+        var attemptSpan = spanByName(spanExporter.getFinishedSpanItems(), "waiting attempt 1");
+        assertEquals(StatusCode.UNSET, attemptSpan.getStatus().getStatusCode());
+        assertEquals("INCOMPLETE", attemptSpan.getAttributes().get(AttributeKey.stringKey("durable.attempt.outcome")));
+        assertTrue(attemptSpan.getEvents().isEmpty());
     }
 
     @Test

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/ExecutionOtelPluginTest.java
@@ -460,7 +460,17 @@ class ExecutionOtelPluginTest {
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "compute", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "compute", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "compute",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-1",
                 "compute",
@@ -501,7 +511,17 @@ class ExecutionOtelPluginTest {
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "process-order", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "process-order", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "process-order",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var attemptSpan = spanExporter.getFinishedSpanItems().stream()
@@ -575,7 +595,7 @@ class ExecutionOtelPluginTest {
                 Instant.now(),
                 false,
                 1,
-                false,
+                UserFunctionOutcome.FAILED,
                 new RuntimeException("step failed")));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.FAILED, null));
 
@@ -592,7 +612,17 @@ class ExecutionOtelPluginTest {
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "compute", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "compute", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "compute",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", ARN, true, InvocationStatus.SUCCEEDED, null));
 
         var attemptSpan = spanExporter.getFinishedSpanItems().stream()

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -452,7 +452,17 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "process-order", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "process-order", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "process-order",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var attemptSpan = spanExporter.getFinishedSpanItems().stream()
@@ -502,7 +512,17 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "process-order", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "process-order", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "process-order",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
         var attemptSpan = spanExporter.getFinishedSpanItems().stream()
@@ -609,7 +629,17 @@ class InvocationOtelPluginTest {
                 new UserFunctionStartInfo("op-1", "compute", "STEP", "Step", null, Instant.now(), false, 1));
 
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "compute", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "compute",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -641,7 +671,7 @@ class InvocationOtelPluginTest {
                 Instant.now(),
                 false,
                 1,
-                false,
+                UserFunctionOutcome.FAILED,
                 new RuntimeException("step failed")));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.FAILED, null));
@@ -660,7 +690,17 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "compute", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "compute", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "compute",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.SUCCEEDED, null));
 
@@ -835,7 +875,17 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "step-a",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-1",
                 "step-a",
@@ -856,7 +906,17 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-2", "step-b", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-2", "step-b", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-2",
+                "step-b",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-2",
                 "step-b",
@@ -993,7 +1053,17 @@ class InvocationOtelPluginTest {
         sampledPlugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "step", "STEP", "Step", null, Instant.now(), false, 1));
         sampledPlugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "step",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         sampledPlugin.onOperationEnd(new OperationEndInfo(
                 "op-1",
                 "step",
@@ -1061,7 +1131,17 @@ class InvocationOtelPluginTest {
         xrayPlugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), false, 1));
         xrayPlugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "step-a",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         xrayPlugin.onOperationEnd(new OperationEndInfo(
                 "op-1",
                 "step-a",
@@ -1486,7 +1566,17 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "step-A", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "step-A", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "step-A",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-1",
                 "step-A",
@@ -1540,7 +1630,17 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-3", "step-B", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-3", "step-B", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-3",
+                "step-B",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-3",
                 "step-B",
@@ -1607,7 +1707,7 @@ class InvocationOtelPluginTest {
                 Instant.now(),
                 false,
                 1,
-                false,
+                UserFunctionOutcome.FAILED,
                 new RuntimeException("payment failed")));
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", arn, true, InvocationStatus.PENDING, null));
 
@@ -1641,7 +1741,17 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "process-payment", "STEP", "Step", null, Instant.now(), false, 2));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "process-payment", "STEP", "Step", null, Instant.now(), Instant.now(), false, 2, true, null));
+                "op-1",
+                "process-payment",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                2,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-1",
                 "process-payment",
@@ -1743,7 +1853,17 @@ class InvocationOtelPluginTest {
         plugin.onUserFunctionStart(
                 new UserFunctionStartInfo("op-1", "step-a", "STEP", "Step", null, Instant.now(), false, 1));
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "step-a", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "step-a",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
         plugin.onOperationEnd(new OperationEndInfo(
                 "op-1",
                 "step-a",

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/InvocationOtelPluginTest.java
@@ -672,6 +672,36 @@ class InvocationOtelPluginTest {
     }
 
     @Test
+    void userFunctionEnd_withIncomplete_leavesAttemptSpanUnset() {
+        plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
+
+        plugin.onUserFunctionStart(
+                new UserFunctionStartInfo("op-1", "waiting", "STEP", "Step", null, Instant.now(), false, 1));
+        plugin.onUserFunctionEnd(new UserFunctionEndInfo(
+                "op-1",
+                "waiting",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.INCOMPLETE,
+                new SuspendExecutionException()));
+
+        plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.PENDING, null));
+
+        var attemptSpan = spanExporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().equals("waiting attempt 1"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(StatusCode.UNSET, attemptSpan.getStatus().getStatusCode());
+        assertEquals("INCOMPLETE", attemptSpan.getAttributes().get(AttributeKey.stringKey("durable.attempt.outcome")));
+        assertTrue(attemptSpan.getEvents().isEmpty());
+    }
+
+    @Test
     void operationEnd_withSuccess_setsOkOnOperationSpan() {
         plugin.onInvocationStart(new InvocationInfo("req-1", "arn:exec1", true, Instant.now()));
 
@@ -1350,7 +1380,7 @@ class InvocationOtelPluginTest {
                 Instant.now(),
                 false,
                 null,
-                false,
+                UserFunctionOutcome.INCOMPLETE,
                 new SuspendExecutionException()));
 
         plugin.onInvocationEnd(new InvocationEndInfo("req-1", "arn:exec1", true, InvocationStatus.PENDING, null));

--- a/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
+++ b/otel-plugin/src/test/java/software/amazon/lambda/durable/otel/MdcSpanEnricherTest.java
@@ -74,7 +74,17 @@ class MdcSpanEnricherTest {
         assertNotNull(MDC.get(MdcSpanEnricher.MDC_TRACE_SAMPLED));
 
         plugin.onUserFunctionEnd(new UserFunctionEndInfo(
-                "op-1", "step", "STEP", "Step", null, Instant.now(), Instant.now(), false, 1, true, null));
+                "op-1",
+                "step",
+                "STEP",
+                "Step",
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null));
 
         // After onUserFunctionEnd: span_id is cleared, but trace_id remains for handler-level logs between steps
         assertNotNull(MDC.get(MdcSpanEnricher.MDC_TRACE_ID), "trace_id should persist between steps");

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -908,6 +909,30 @@ class PluginIntegrationTest {
         assertTrue(
                 childEnd.error() instanceof SuspendExecutionException,
                 "Suspension should surface the SuspendExecutionException, not a user error");
+    }
+
+    @Test
+    void plugin_userFunctionEnd_unwrapsCompletionExceptionForSuspension() {
+        var plugin = new RecordingPlugin();
+        var config = DurableConfig.builder().withPlugins(plugin).build();
+        var suspension = new SuspendExecutionException();
+
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> context.step("wrapped-suspension", String.class, step -> {
+                    throw new CompletionException(suspension);
+                }),
+                config);
+
+        var result = runner.run("input");
+        assertEquals(ExecutionStatus.PENDING, result.getStatus());
+
+        var stepEnd = plugin.userFunctionEnds.stream()
+                .filter(info -> "wrapped-suspension".equals(info.name()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("onUserFunctionEnd should fire for the suspended step"));
+        assertEquals(UserFunctionOutcome.INCOMPLETE, stepEnd.outcome());
+        assertSame(suspension, stepEnd.error(), "The event should expose the unwrapped suspension");
     }
 
     @Test

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PluginIntegrationTest.java
@@ -648,17 +648,19 @@ class PluginIntegrationTest {
                 plugin.userFunctionStarts.stream().anyMatch(info -> "compute".equals(info.name())),
                 "Should have onUserFunctionStart for 'compute'");
         assertTrue(
-                plugin.userFunctionEnds.stream().anyMatch(info -> "compute".equals(info.name()) && info.succeeded()),
+                plugin.userFunctionEnds.stream()
+                        .anyMatch(info ->
+                                "compute".equals(info.name()) && info.outcome() == UserFunctionOutcome.SUCCEEDED),
                 "Should have successful onUserFunctionEnd for 'compute'");
     }
 
     @Test
-    void plugin_userFunctionEnd_succeeded_false_whenStepFails() {
+    void plugin_userFunctionEnd_reportsFailed_whenStepFails() {
         var plugin = new RecordingPlugin();
         var config = DurableConfig.builder().withPlugins(plugin).build();
 
         // When a step's user function throws, the exception propagates through the user-function hook
-        // boundary, so onUserFunctionEnd reports succeeded=false with the error. Retry/checkpoint
+        // boundary, so onUserFunctionEnd reports FAILED with the error. Retry/checkpoint
         // handling happens outside that boundary.
         var runner = LocalDurableTestRunner.create(
                 String.class,
@@ -688,7 +690,7 @@ class PluginIntegrationTest {
                 .filter(info -> "fail-step".equals(info.name()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("Should have user function end for 'fail-step'"));
-        assertFalse(failStepEnd.succeeded(), "Failed step should report succeeded=false");
+        assertEquals(UserFunctionOutcome.FAILED, failStepEnd.outcome());
         assertNotNull(failStepEnd.error());
         assertTrue(failStepEnd.error().getMessage().contains("step failed"));
     }
@@ -860,7 +862,7 @@ class PluginIntegrationTest {
                 .filter(info -> info.attempt() == 1)
                 .findFirst()
                 .orElseThrow();
-        assertFalse(firstAttempt.succeeded());
+        assertEquals(UserFunctionOutcome.FAILED, firstAttempt.outcome());
         assertNotNull(firstAttempt.error());
 
         // Retry attempt succeeded.
@@ -868,7 +870,7 @@ class PluginIntegrationTest {
                 .filter(info -> info.attempt() == 2)
                 .findFirst()
                 .orElseThrow();
-        assertTrue(secondAttempt.succeeded());
+        assertEquals(UserFunctionOutcome.SUCCEEDED, secondAttempt.outcome());
         assertNull(secondAttempt.error());
 
         // The operation end reports the terminal attempt number = total attempts that ran. The step
@@ -881,12 +883,12 @@ class PluginIntegrationTest {
     }
 
     @Test
-    void plugin_userFunctionEnd_reportsSuspension_asNotSucceeded() {
+    void plugin_userFunctionEnd_reportsSuspension_asIncomplete() {
         var plugin = new RecordingPlugin();
         var config = DurableConfig.builder().withPlugins(plugin).build();
 
         // A child context whose body suspends (on a wait) throws SuspendExecutionException through the
-        // user-function boundary, so onUserFunctionEnd fires with succeeded=false and the suspend exception.
+        // user-function boundary, so onUserFunctionEnd fires with INCOMPLETE and the suspend exception.
         var runner = LocalDurableTestRunner.create(
                 String.class,
                 (input, context) -> context.runInChildContext("child", TypeToken.get(String.class), child -> {
@@ -902,7 +904,7 @@ class PluginIntegrationTest {
                 .filter(info -> "child".equals(info.name()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("onUserFunctionEnd should fire for the suspended child context"));
-        assertFalse(childEnd.succeeded(), "A suspended user function must not report succeeded=true");
+        assertEquals(UserFunctionOutcome.INCOMPLETE, childEnd.outcome());
         assertTrue(
                 childEnd.error() instanceof SuspendExecutionException,
                 "Suspension should surface the SuspendExecutionException, not a user error");

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -359,7 +359,7 @@ public abstract class BaseDurableOperation {
                     PluginInfoConverter.toUserFunctionEndInfo(startInfo, UserFunctionOutcome.SUCCEEDED, null));
             return result;
         } catch (Throwable e) {
-var error = ExceptionHelper.unwrapCompletableFuture(e);
+            var error = ExceptionHelper.unwrapCompletableFuture(e);
             if (error == null) {
                 error = e;
             }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -29,6 +29,7 @@ import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
 import software.amazon.lambda.durable.plugin.PluginInfoConverter;
 import software.amazon.lambda.durable.plugin.PluginRunner;
+import software.amazon.lambda.durable.plugin.UserFunctionOutcome;
 import software.amazon.lambda.durable.util.ExceptionHelper;
 
 /**
@@ -354,10 +355,14 @@ public abstract class BaseDurableOperation {
         pluginRunner.onUserFunctionStart(startInfo);
         try {
             T result = userFunction.get();
-            pluginRunner.onUserFunctionEnd(PluginInfoConverter.toUserFunctionEndInfo(startInfo, true, null));
+            pluginRunner.onUserFunctionEnd(
+                    PluginInfoConverter.toUserFunctionEndInfo(startInfo, UserFunctionOutcome.SUCCEEDED, null));
             return result;
         } catch (Throwable e) {
-            pluginRunner.onUserFunctionEnd(PluginInfoConverter.toUserFunctionEndInfo(startInfo, false, e));
+            var outcome = e instanceof SuspendExecutionException
+                    ? UserFunctionOutcome.INCOMPLETE
+                    : UserFunctionOutcome.FAILED;
+            pluginRunner.onUserFunctionEnd(PluginInfoConverter.toUserFunctionEndInfo(startInfo, outcome, e));
             ExceptionHelper.sneakyThrow(e);
             return null; // unreachable — sneakyThrow always throws
         }

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -359,7 +359,10 @@ public abstract class BaseDurableOperation {
                     PluginInfoConverter.toUserFunctionEndInfo(startInfo, UserFunctionOutcome.SUCCEEDED, null));
             return result;
         } catch (Throwable e) {
-            var error = ExceptionHelper.unwrapCompletableFuture(e);
+var error = ExceptionHelper.unwrapCompletableFuture(e);
+            if (error == null) {
+                error = e;
+            }
             var outcome = error instanceof SuspendExecutionException
                     ? UserFunctionOutcome.INCOMPLETE
                     : UserFunctionOutcome.FAILED;

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -359,10 +359,11 @@ public abstract class BaseDurableOperation {
                     PluginInfoConverter.toUserFunctionEndInfo(startInfo, UserFunctionOutcome.SUCCEEDED, null));
             return result;
         } catch (Throwable e) {
-            var outcome = e instanceof SuspendExecutionException
+            var error = ExceptionHelper.unwrapCompletableFuture(e);
+            var outcome = error instanceof SuspendExecutionException
                     ? UserFunctionOutcome.INCOMPLETE
                     : UserFunctionOutcome.FAILED;
-            pluginRunner.onUserFunctionEnd(PluginInfoConverter.toUserFunctionEndInfo(startInfo, outcome, e));
+            pluginRunner.onUserFunctionEnd(PluginInfoConverter.toUserFunctionEndInfo(startInfo, outcome, error));
             ExceptionHelper.sneakyThrow(e);
             return null; // unreachable — sneakyThrow always throws
         }

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPlugin.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/DurableExecutionPlugin.java
@@ -79,11 +79,10 @@ public interface DurableExecutionPlugin {
      *
      * <p>This hook fires on the same thread as user code, so plugins can close OTel scopes here.
      *
-     * <p>It fires for every terminal outcome of the user function: normal return, a thrown failure, and suspension.
-     * {@link UserFunctionEndInfo#succeeded()} is {@code true} only on normal return; it is {@code false} for both a
-     * genuine failure and a suspension. On suspension the {@link UserFunctionEndInfo#error()} is the SDK's internal
-     * {@code SuspendExecutionException}, which is not a user error — plugins that count failures should treat a
-     * suspension as a neutral outcome (for example by checking the error type) rather than a failure.
+     * <p>It fires for every outcome of the user function: normal return, a thrown failure, and suspension. Check
+     * {@link UserFunctionEndInfo#outcome()} to distinguish them. A suspended function reports
+     * {@link UserFunctionOutcome#INCOMPLETE}; its {@link UserFunctionEndInfo#error()} is the SDK's internal
+     * {@code SuspendExecutionException}, not a user error.
      */
     default void onUserFunctionEnd(UserFunctionEndInfo info) {}
 }

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
@@ -146,17 +146,6 @@ public final class PluginInfoConverter {
     }
 
     /**
-     * Creates user-function-end information from the former boolean outcome.
-     *
-     * @deprecated Use {@link #toUserFunctionEndInfo(UserFunctionStartInfo, UserFunctionOutcome, Throwable)}.
-     */
-    public static UserFunctionEndInfo toUserFunctionEndInfo(
-            UserFunctionStartInfo startInfo, boolean succeeded, Throwable error) {
-        return toUserFunctionEndInfo(
-                startInfo, succeeded ? UserFunctionOutcome.SUCCEEDED : UserFunctionOutcome.FAILED, error);
-    }
-
-    /**
      * Creates an {@link OperationChangeInfo} from the durable operations whose status changed in a checkpoint response
      * and a snapshot of all operations tracked for the execution.
      *

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
@@ -150,7 +150,6 @@ public final class PluginInfoConverter {
      *
      * @deprecated Use {@link #toUserFunctionEndInfo(UserFunctionStartInfo, UserFunctionOutcome, Throwable)}.
      */
-    @Deprecated(forRemoval = false)
     public static UserFunctionEndInfo toUserFunctionEndInfo(
             UserFunctionStartInfo startInfo, boolean succeeded, Throwable error) {
         return toUserFunctionEndInfo(

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/PluginInfoConverter.java
@@ -125,12 +125,12 @@ public final class PluginInfoConverter {
      * Creates a {@link UserFunctionEndInfo} from a start info and outcome.
      *
      * @param startInfo the start info from when the function began
-     * @param succeeded true if the function completed without error
-     * @param error the error if the function failed (may be null)
+     * @param outcome the user function outcome
+     * @param error the error if the function failed or exited incompletely (may be null)
      * @return a UserFunctionEndInfo record
      */
     public static UserFunctionEndInfo toUserFunctionEndInfo(
-            UserFunctionStartInfo startInfo, boolean succeeded, Throwable error) {
+            UserFunctionStartInfo startInfo, UserFunctionOutcome outcome, Throwable error) {
         return new UserFunctionEndInfo(
                 startInfo.id(),
                 startInfo.name(),
@@ -141,8 +141,20 @@ public final class PluginInfoConverter {
                 Instant.now(),
                 startInfo.isReplayingChildren(),
                 startInfo.attempt(),
-                succeeded,
+                outcome,
                 error);
+    }
+
+    /**
+     * Creates user-function-end information from the former boolean outcome.
+     *
+     * @deprecated Use {@link #toUserFunctionEndInfo(UserFunctionStartInfo, UserFunctionOutcome, Throwable)}.
+     */
+    @Deprecated(forRemoval = false)
+    public static UserFunctionEndInfo toUserFunctionEndInfo(
+            UserFunctionStartInfo startInfo, boolean succeeded, Throwable error) {
+        return toUserFunctionEndInfo(
+                startInfo, succeeded ? UserFunctionOutcome.SUCCEEDED : UserFunctionOutcome.FAILED, error);
     }
 
     /**

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionEndInfo.java
@@ -33,47 +33,4 @@ public record UserFunctionEndInfo(
         boolean isReplayingChildren,
         Integer attempt,
         UserFunctionOutcome outcome,
-        @Experimental Throwable error) {
-
-    /**
-     * Creates user-function-end information from the former boolean outcome.
-     *
-     * @deprecated Use {@link #UserFunctionEndInfo(String, String, String, String, String, Instant, Instant, boolean,
-     *     Integer, UserFunctionOutcome, Throwable)} so incomplete executions are distinguishable from failures.
-     */
-    public UserFunctionEndInfo(
-            String id,
-            String name,
-            String type,
-            String subType,
-            String parentId,
-            Instant startTimestamp,
-            Instant endTimestamp,
-            boolean isReplayingChildren,
-            Integer attempt,
-            boolean succeeded,
-            Throwable error) {
-        this(
-                id,
-                name,
-                type,
-                subType,
-                parentId,
-                startTimestamp,
-                endTimestamp,
-                isReplayingChildren,
-                attempt,
-                succeeded ? UserFunctionOutcome.SUCCEEDED : UserFunctionOutcome.FAILED,
-                error);
-    }
-
-    /**
-     * Returns whether the user function completed successfully.
-     *
-     * @deprecated Use {@link #outcome()} to distinguish failures from incomplete executions.
-     */
-    @Deprecated(forRemoval = false)
-    public boolean succeeded() {
-        return outcome == UserFunctionOutcome.SUCCEEDED;
-    }
-}
+        @Experimental Throwable error) {}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionEndInfo.java
@@ -41,7 +41,6 @@ public record UserFunctionEndInfo(
      * @deprecated Use {@link #UserFunctionEndInfo(String, String, String, String, String, Instant, Instant, boolean,
      *     Integer, UserFunctionOutcome, Throwable)} so incomplete executions are distinguishable from failures.
      */
-    @Deprecated(forRemoval = false)
     public UserFunctionEndInfo(
             String id,
             String name,

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionEndInfo.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionEndInfo.java
@@ -19,8 +19,8 @@ import software.amazon.lambda.durable.annotations.Experimental;
  * @param endTimestamp when the user function ended
  * @param isReplayingChildren true if child operations within this context are being replayed from checkpoints
  * @param attempt 1-based attempt number for steps/waitForCondition, null for context operations
- * @param succeeded true if the user function completed without error
- * @param error non-null if the user function failed; this component is experimental
+ * @param outcome the user function outcome
+ * @param error non-null if the user function failed or exited incompletely; this component is experimental
  */
 public record UserFunctionEndInfo(
         String id,
@@ -32,5 +32,49 @@ public record UserFunctionEndInfo(
         Instant endTimestamp,
         boolean isReplayingChildren,
         Integer attempt,
-        boolean succeeded,
-        @Experimental Throwable error) {}
+        UserFunctionOutcome outcome,
+        @Experimental Throwable error) {
+
+    /**
+     * Creates user-function-end information from the former boolean outcome.
+     *
+     * @deprecated Use {@link #UserFunctionEndInfo(String, String, String, String, String, Instant, Instant, boolean,
+     *     Integer, UserFunctionOutcome, Throwable)} so incomplete executions are distinguishable from failures.
+     */
+    @Deprecated(forRemoval = false)
+    public UserFunctionEndInfo(
+            String id,
+            String name,
+            String type,
+            String subType,
+            String parentId,
+            Instant startTimestamp,
+            Instant endTimestamp,
+            boolean isReplayingChildren,
+            Integer attempt,
+            boolean succeeded,
+            Throwable error) {
+        this(
+                id,
+                name,
+                type,
+                subType,
+                parentId,
+                startTimestamp,
+                endTimestamp,
+                isReplayingChildren,
+                attempt,
+                succeeded ? UserFunctionOutcome.SUCCEEDED : UserFunctionOutcome.FAILED,
+                error);
+    }
+
+    /**
+     * Returns whether the user function completed successfully.
+     *
+     * @deprecated Use {@link #outcome()} to distinguish failures from incomplete executions.
+     */
+    @Deprecated(forRemoval = false)
+    public boolean succeeded() {
+        return outcome == UserFunctionOutcome.SUCCEEDED;
+    }
+}

--- a/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionOutcome.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/plugin/UserFunctionOutcome.java
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.plugin;
+
+/** Outcome of a user-provided function when its execution ends. */
+public enum UserFunctionOutcome {
+    /** The user function returned normally. */
+    SUCCEEDED,
+    /** The user function threw an error. */
+    FAILED,
+    /** The user function exited before completing, for example when the durable execution suspended. */
+    INCOMPLETE
+}

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginInfoConverterTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginInfoConverterTest.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.lambda.model.Operation;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.awssdk.services.lambda.model.OperationType;
 import software.amazon.awssdk.services.lambda.model.StepDetails;
+import software.amazon.lambda.durable.execution.SuspendExecutionException;
 import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
 
@@ -259,7 +260,7 @@ class PluginInfoConverterTest {
     void toUserFunctionEndInfo_succeeded() {
         var startInfo = PluginInfoConverter.toUserFunctionStartInfo(STEP_IDENTIFIER, PARENT_ID, false, 1);
 
-        var endInfo = PluginInfoConverter.toUserFunctionEndInfo(startInfo, true, null);
+        var endInfo = PluginInfoConverter.toUserFunctionEndInfo(startInfo, UserFunctionOutcome.SUCCEEDED, null);
 
         assertEquals(OPERATION_ID, endInfo.id());
         assertEquals(OPERATION_NAME, endInfo.name());
@@ -267,7 +268,7 @@ class PluginInfoConverterTest {
         assertNotNull(endInfo.endTimestamp());
         assertFalse(endInfo.isReplayingChildren());
         assertEquals(1, endInfo.attempt());
-        assertTrue(endInfo.succeeded());
+        assertEquals(UserFunctionOutcome.SUCCEEDED, endInfo.outcome());
         assertNull(endInfo.error());
     }
 
@@ -276,10 +277,21 @@ class PluginInfoConverterTest {
         var error = new RuntimeException("step failed");
         var startInfo = PluginInfoConverter.toUserFunctionStartInfo(STEP_IDENTIFIER, null, false, 2);
 
-        var endInfo = PluginInfoConverter.toUserFunctionEndInfo(startInfo, false, error);
+        var endInfo = PluginInfoConverter.toUserFunctionEndInfo(startInfo, UserFunctionOutcome.FAILED, error);
 
-        assertFalse(endInfo.succeeded());
+        assertEquals(UserFunctionOutcome.FAILED, endInfo.outcome());
         assertEquals(error, endInfo.error());
         assertEquals(2, endInfo.attempt());
+    }
+
+    @Test
+    void toUserFunctionEndInfo_incomplete() {
+        var error = new SuspendExecutionException();
+        var startInfo = PluginInfoConverter.toUserFunctionStartInfo(MAP_IDENTIFIER, null, false, null);
+
+        var endInfo = PluginInfoConverter.toUserFunctionEndInfo(startInfo, UserFunctionOutcome.INCOMPLETE, error);
+
+        assertEquals(UserFunctionOutcome.INCOMPLETE, endInfo.outcome());
+        assertSame(error, endInfo.error());
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/plugin/PluginRunnerTest.java
@@ -243,7 +243,17 @@ class PluginRunnerTest {
 
     private static UserFunctionEndInfo attemptEndInfo() {
         return new UserFunctionEndInfo(
-                "op-1", "test-step", "STEP", null, null, Instant.now(), Instant.now(), false, 1, true, null);
+                "op-1",
+                "test-step",
+                "STEP",
+                null,
+                null,
+                Instant.now(),
+                Instant.now(),
+                false,
+                1,
+                UserFunctionOutcome.SUCCEEDED,
+                null);
     }
 
     // ─── Test plugin implementations ─────────────────────────────────────


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Closes #636

### Description

Replace the boolean user-function completion flag with `UserFunctionOutcome`, which has `SUCCEEDED`, `FAILED`, and `INCOMPLETE` values.

User functions now report `INCOMPLETE` when durable execution suspends. Normal returns report `SUCCEEDED`, and thrown failures report `FAILED`. Deprecated boolean constructor and accessor adapters preserve compatibility for existing plugin implementations.

The OTel plugins treat incomplete functions as a neutral outcome: the attempt span remains `UNSET`, records the `INCOMPLETE` attribute, and does not record the internal suspension exception. Conformance handlers and the plugin example now consume the enum directly.

### Demo/Screenshots

Not applicable. This change updates the Java plugin API and lifecycle event behavior.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

`mvn clean install`

Result: 1,803 tests passed with 0 failures and 0 errors. The 31 skipped tests are existing cloud-only example tests.

#### Unit Tests

Yes. Added converter coverage for all three outcomes and OTel tests that verify incomplete attempts remain neutral and do not record the suspension exception.

#### Integration Tests

Yes. Updated plugin integration tests to verify successful, failed, retried, and suspended user-function outcomes. Suspension, including a `CompletionException`-wrapped suspension, now asserts `INCOMPLETE` and exposes the unwrapped error.

#### Examples

Updated the existing plugin example to log `outcome`. No new example was needed.