### PR TITLE
ci: run conformance tests on push to main

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -8,6 +8,8 @@ name: Conformance Tests
 # shipping its template + handlers under conformance-tests/.
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
Adds a `push` trigger to the Conformance Tests workflow so the full-integration conformance run also executes after commits land on `main`, not only on pull requests.

## Change
```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
    paths: ...
```

- New: conformance runs on every push to `main` (post-merge coverage).
- Unchanged: the existing `pull_request` path filters (`sdk/**`, `pom.xml`, `conformance-tests/**`, the workflow file) still gate PR runs exactly as before. The `push` trigger intentionally has no path filter so any commit landing on `main` gets a conformance run.

## Validation
YAML parses cleanly (`python3 -c 'yaml.safe_load(...)'` -> OK).