### PR TITLE
ci: grant id-token: write for Slack notify workflow

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -17,8 +17,10 @@ jobs:
     permissions:
       contents: read
       models: read
+      id-token: write
     uses: aws/aws-durable-execution-ci/.github/workflows/notify.yml@ac55d9f4b027e193aba9fa5a69c70bfa1bdc38ed
     secrets:
+      BEDROCK_ROLE_ARN: ${{ secrets.BEDROCK_ROLE_ARN }}
       SLACK_WEBHOOK_URL_PR: ${{ secrets.SLACK_WEBHOOK_URL_PR }}
       SLACK_WEBHOOK_URL_ISSUE: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}
       SLACK_WEBHOOK_URL_DISCUSSION: ${{ secrets.SLACK_WEBHOOK_URL_DISCUSSION }}


### PR DESCRIPTION
Fixes aws/aws-durable-execution-ci#30.

The reusable `notify.yml` in aws-durable-execution-ci changed its
`summarize` job at ac55d9f to assume `BEDROCK_ROLE_ARN` via OIDC,
requiring `id-token: write`. Consumer `notify.yml` files still grant
only `contents: read` + `models: read`, and GitHub caps a reusable
workflow's token at the caller's grant — aborting the run at startup
and dropping all Slack notifications.

Changes (identical across all four consumer repos):
- Add `id-token: write` permission
- Explicitly forward `BEDROCK_ROLE_ARN` (enables AI-generated summaries
  when the org secret is configured) alongside the existing Slack webhooks
