### PR TITLE
fix: prevent invalid PENDING suspension after checkpoint completion

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -89,6 +89,8 @@ jobs:
             --resolve-image-repos --resolve-s3 --parameter-overrides \
             'ParameterKey=Architecture,ParameterValue=x86_64 ParameterKey=JavaVersion,ParameterValue=java${{ matrix.java }} ParameterKey=FunctionNamePrefix,ParameterValue=Java${{ matrix.java }}- ParameterKey=RoleArn,ParameterValue=${{ secrets.TEST_LAMBDA_EXECUTION_ROLE_ARN }}'
         working-directory: ./examples
+      - name: Record E2E log start time
+        run: echo "E2E_LOG_START_TIME_MS=$(date +%s%3N)" >> "$GITHUB_ENV"
       - name: Cloud Based Integration Tests
         run: |
           mvn clean test -B \
@@ -102,6 +104,45 @@ jobs:
             -Djunit.jupiter.execution.parallel.config.strategy=fixed \
             -Djunit.jupiter.execution.parallel.config.fixed.parallelism=${{ env.E2E_TEST_PARALLELISM }}
         working-directory: ./examples
+      - name: Check checkpoint invariant logs
+        env:
+          E2E_STACK_NAME: Java${{ matrix.java }}-JavaSDKCloudBasedIntegrationTestStack
+        run: |
+          set -euo pipefail
+
+          # Allow the final Lambda invocation logs to reach CloudWatch before checking every
+          # managed function log group created by the E2E stack.
+          sleep 10
+
+          log_groups=$(aws cloudformation list-stack-resources \
+            --stack-name "$E2E_STACK_NAME" \
+            --query "StackResourceSummaries[?ResourceType=='AWS::Logs::LogGroup'].PhysicalResourceId" \
+            --output text)
+
+          if [[ -z "$log_groups" ]]; then
+            echo "::error::No managed Lambda log groups found for $E2E_STACK_NAME"
+            exit 1
+          fi
+
+          invariant_violated=false
+          for log_group in $log_groups; do
+            messages=$(aws logs filter-log-events \
+              --log-group-name "$log_group" \
+              --start-time "$E2E_LOG_START_TIME_MS" \
+              --filter-pattern '"Checkpoint invariant violation"' \
+              --query "events[].message" \
+              --output text)
+
+            if [[ -n "$messages" ]]; then
+              invariant_violated=true
+              echo "::error title=Checkpoint invariant violation::Found in $log_group"
+              echo "$messages"
+            fi
+          done
+
+          if [[ "$invariant_violated" == true ]]; then
+            exit 1
+          fi
       - name: Publish test case summary
         if: always()
         env:

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/CheckpointManager.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/CheckpointManager.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +41,8 @@ class CheckpointManager {
     private final Map<String, List<CompletableFuture<Operation>>> pollingFutures = new ConcurrentHashMap<>();
     private final ApiRequestDelayedBatcher<OperationUpdate> checkpointApiRequestDelayedBatcher;
     private final DurableConfig config;
+    private final BooleanSupplier tryStartCheckpointProcessing;
+    private final Runnable finishCheckpointProcessing;
     private String checkpointToken;
 
     CheckpointManager(
@@ -47,10 +50,22 @@ class CheckpointManager {
             String durableExecutionArn,
             String checkpointToken,
             Consumer<List<Operation>> callback) {
+        this(config, durableExecutionArn, checkpointToken, callback, () -> true, () -> {});
+    }
+
+    CheckpointManager(
+            DurableConfig config,
+            String durableExecutionArn,
+            String checkpointToken,
+            Consumer<List<Operation>> callback,
+            BooleanSupplier tryStartCheckpointProcessing,
+            Runnable finishCheckpointProcessing) {
         this.config = config;
         this.durableExecutionArn = durableExecutionArn;
         this.callback = callback;
         this.checkpointToken = checkpointToken;
+        this.tryStartCheckpointProcessing = tryStartCheckpointProcessing;
+        this.finishCheckpointProcessing = finishCheckpointProcessing;
         this.checkpointApiRequestDelayedBatcher = new ApiRequestDelayedBatcher<>(
                 MAX_ITEM_COUNT, MAX_BATCH_SIZE_BYTES, CheckpointManager::estimateSize, this::checkpointBatch);
     }
@@ -191,6 +206,13 @@ class CheckpointManager {
                 return;
             }
 
+            // Starting the backend request is coordinated with the last-thread suspension decision. Once suspension
+            // wins that race, no later poll/checkpoint may advance backend state behind the PENDING response.
+            if (!tryStartCheckpointProcessing.getAsBoolean()) {
+                logger.debug("Skipping checkpoint API call because execution has already completed");
+                return;
+            }
+
             var startTime = System.nanoTime();
             logger.debug("Calling durable checkpoint API with {} updates: {}", updates.size(), request);
             try {
@@ -228,6 +250,8 @@ class CheckpointManager {
                 }
             } catch (AwsServiceException e) {
                 throw DurableApiErrorClassifier.classifyException(e);
+            } finally {
+                finishCheckpointProcessing.run();
             }
         }
     }

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/CheckpointManager.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/CheckpointManager.java
@@ -209,6 +209,12 @@ class CheckpointManager {
             // Starting the backend request is coordinated with the last-thread suspension decision. Once suspension
             // wins that race, no later poll/checkpoint may advance backend state behind the PENDING response.
             if (!tryStartCheckpointProcessing.getAsBoolean()) {
+                if (!request.isEmpty()) {
+                    logger.error(
+                            "Checkpoint invariant violation: skipping {} operation updates because execution has already"
+                                    + " completed",
+                            request.size());
+                }
                 logger.debug("Skipping checkpoint API call because execution has already completed");
                 return;
             }

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
@@ -139,7 +139,7 @@ public class ExecutionManager implements SafeCloseable {
 
     // ===== Checkpoint Completion Handler =====
     /** Called by CheckpointManager when a checkpoint completes. Updates operationStorage and notify operations . */
-    private void onCheckpointComplete(List<Operation> newOperations) {
+    void onCheckpointComplete(List<Operation> newOperations) {
         var updatedOperations = new ArrayList<Operation>();
         newOperations.forEach(op -> {
             // Detect a status change against the previously stored operation
@@ -147,13 +147,14 @@ public class ExecutionManager implements SafeCloseable {
             if (previous == null || previous.status() != op.status()) {
                 updatedOperations.add(op);
             }
-            // Update operation storage
-            operationStorage.put(op.id(), op);
-            // call registered operation's onCheckpointComplete method for completed operations
-            registeredOperations.computeIfPresent(op.id(), (id, operation) -> {
-                operation.onCheckpointComplete(op);
-                return operation;
-            });
+            // Publish the updated state and notify its waiter atomically. Otherwise, a waiter can observe the terminal
+            // state before its completion future is completed and attempt to suspend with no pending operations.
+            var registeredOperation = registeredOperations.get(op.id());
+            if (registeredOperation == null) {
+                operationStorage.put(op.id(), op);
+            } else {
+                registeredOperation.processCheckpointUpdate(op, () -> operationStorage.put(op.id(), op));
+            }
         });
 
         // Fire onOperationChange when a checkpoint response changed one or more operations

--- a/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/execution/ExecutionManager.java
@@ -69,6 +69,8 @@ public class ExecutionManager implements SafeCloseable {
     private final Set<String> activeThreads = Collections.synchronizedSet(new HashSet<>());
     private static final ThreadLocal<ThreadContext> currentThreadContext = new ThreadLocal<>();
     private final CompletableFuture<Void> executionExceptionFuture = new CompletableFuture<>();
+    // Guarded by activeThreads so starting a checkpoint request is atomic with the last-thread suspension decision.
+    private int checkpointRequestsInFlight;
 
     // ===== Checkpoint Batching =====
     private final CheckpointManager checkpointManager;
@@ -83,8 +85,13 @@ public class ExecutionManager implements SafeCloseable {
                 input.updatedOperationIds() != null ? Set.copyOf(input.updatedOperationIds()) : Collections.emptySet();
 
         // Create checkpoint batcher for internal coordination
-        this.checkpointManager =
-                new CheckpointManager(config, durableExecutionArn, input.checkpointToken(), this::onCheckpointComplete);
+        this.checkpointManager = new CheckpointManager(
+                config,
+                durableExecutionArn,
+                input.checkpointToken(),
+                this::onCheckpointComplete,
+                this::tryStartCheckpointProcessing,
+                this::finishCheckpointProcessing);
 
         this.operationStorage = checkpointManager.fetchAllPages(input.initialExecutionState()).stream()
                 .collect(Collectors.toConcurrentMap(Operation::id, op -> op));
@@ -149,12 +156,14 @@ public class ExecutionManager implements SafeCloseable {
             }
             // Publish the updated state and notify its waiter atomically. Otherwise, a waiter can observe the terminal
             // state before its completion future is completed and attempt to suspend with no pending operations.
-            var registeredOperation = registeredOperations.get(op.id());
-            if (registeredOperation == null) {
-                operationStorage.put(op.id(), op);
-            } else {
-                registeredOperation.processCheckpointUpdate(op, () -> operationStorage.put(op.id(), op));
-            }
+            registeredOperations.compute(op.id(), (id, registeredOperation) -> {
+                if (registeredOperation == null) {
+                    operationStorage.put(op.id(), op);
+                } else {
+                    registeredOperation.processCheckpointUpdate(op, () -> operationStorage.put(op.id(), op));
+                }
+                return registeredOperation;
+            });
         });
 
         // Fire onOperationChange when a checkpoint response changed one or more operations
@@ -250,14 +259,14 @@ public class ExecutionManager implements SafeCloseable {
      * @param threadId the thread ID to deregister
      */
     public void deregisterActiveThread(String threadId) {
-        // Skip if already suspended
-        if (executionExceptionFuture.isDone()) {
-            return;
-        }
-
         // Add synchronized block to avoid remove then check race condition and make sure that
         // the suspendExecution is called only once
         synchronized (activeThreads) {
+            // Skip if already suspended
+            if (executionExceptionFuture.isDone()) {
+                return;
+            }
+
             boolean removed = activeThreads.remove(threadId);
             if (removed) {
                 logger.trace("Deregistered thread '{}' Active threads: {}", threadId, activeThreads.size());
@@ -265,12 +274,40 @@ public class ExecutionManager implements SafeCloseable {
                 logger.warn("Thread '{}' not active, cannot deregister", threadId);
             }
 
-            if (activeThreads.isEmpty()) {
+            if (shouldSuspendExecution()) {
                 logger.info("No active threads remaining - suspending execution");
                 preSuspendCheck();
                 suspendExecution();
             }
         }
+    }
+
+    boolean tryStartCheckpointProcessing() {
+        synchronized (activeThreads) {
+            if (executionExceptionFuture.isDone()) {
+                return false;
+            }
+            checkpointRequestsInFlight++;
+            return true;
+        }
+    }
+
+    void finishCheckpointProcessing() {
+        synchronized (activeThreads) {
+            if (checkpointRequestsInFlight == 0) {
+                throw new IllegalStateException("No checkpoint request is in flight");
+            }
+            checkpointRequestsInFlight--;
+            if (shouldSuspendExecution()) {
+                logger.info("Checkpoint processing completed with no active threads - suspending execution");
+                preSuspendCheck();
+                signalSuspension();
+            }
+        }
+    }
+
+    private boolean shouldSuspendExecution() {
+        return activeThreads.isEmpty() && checkpointRequestsInFlight == 0 && !executionExceptionFuture.isDone();
     }
 
     private void preSuspendCheck() {
@@ -377,10 +414,14 @@ public class ExecutionManager implements SafeCloseable {
 
     /** Suspends the execution by completing the execution exception future with a {@link SuspendExecutionException}. */
     public void suspendExecution() {
+        throw signalSuspension();
+    }
+
+    private SuspendExecutionException signalSuspension() {
         var ex = new SuspendExecutionException();
         stopAllOperations(ex);
         executionExceptionFuture.completeExceptionally(ex);
-        throw ex;
+        return ex;
     }
 
     /**

--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/BaseDurableOperation.java
@@ -234,7 +234,7 @@ public abstract class BaseDurableOperation {
         // is between `isOperationCompleted` and `thenRun`.
         // If this operation is a branch/iteration of a ConcurrencyOperation (map or parallel), the branches/iterations
         // must be completed sequentially to avoid race conditions.
-        synchronized (parentOperation == null ? completionFuture : parentOperation.completionFuture) {
+        synchronized (completionLock()) {
             if (!isOperationCompleted()) {
                 // Add a completion stage to completionFuture so that when the completionFuture is completed,
                 // it will register the current Context thread synchronously to make sure it is always registered
@@ -393,6 +393,19 @@ public abstract class BaseDurableOperation {
         }
     }
 
+    /**
+     * Publishes a checkpoint update and notifies this operation under the same lock used by operation waiters.
+     *
+     * @param operation the updated operation state
+     * @param publishUpdate publishes the operation to execution state
+     */
+    public final void processCheckpointUpdate(Operation operation, Runnable publishUpdate) {
+        synchronized (completionLock()) {
+            publishUpdate.run();
+            onCheckpointComplete(operation);
+        }
+    }
+
     /** Marks the operation as already completed (in replay). */
     protected void markAlreadyCompleted() {
         // When the operation is already completed in a replay, we complete completionFuture immediately
@@ -404,13 +417,17 @@ public abstract class BaseDurableOperation {
     private void markCompletionFutureCompleted() {
         // It's important that we synchronize access to the future, otherwise the processing could happen
         // on someone else's thread and cause a race condition.
-        synchronized (parentOperation == null ? completionFuture : parentOperation.completionFuture) {
+        synchronized (completionLock()) {
             // Completing the future here will also run any other completion stages that have been attached
             // to the future. In our case, other contexts may have attached a function to reactivate themselves,
             // so they will definitely have a chance to reactivate before we finish completing and deactivating
             // whatever operations were just checkpointed.
             completionFuture.complete(this);
         }
+    }
+
+    private CompletableFuture<BaseDurableOperation> completionLock() {
+        return parentOperation == null ? completionFuture : parentOperation.completionFuture;
     }
 
     /**

--- a/sdk/src/test/java/software/amazon/lambda/durable/execution/CheckpointManagerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/execution/CheckpointManagerTest.java
@@ -76,6 +76,23 @@ class CheckpointManagerTest {
     }
 
     @Test
+    void checkpoint_skipsApiCallWhenExecutionAlreadyCompleted() throws Exception {
+        var finishCheckpointProcessing = mock(Runnable.class);
+        var guardedBatcher = new CheckpointManager(
+                config, "arn:test", "token-1", callbackOperations::addAll, () -> false, finishCheckpointProcessing);
+        var update = OperationUpdate.builder()
+                .id("op-1")
+                .type(OperationType.STEP)
+                .action(OperationAction.START)
+                .build();
+
+        guardedBatcher.checkpoint(update).get(200, TimeUnit.MILLISECONDS);
+
+        verifyNoInteractions(client);
+        verify(finishCheckpointProcessing, never()).run();
+    }
+
+    @Test
     void pollForUpdate_completesWhenOperationReturned() throws Exception {
         var operation = Operation.builder()
                 .id("op-1")

--- a/sdk/src/test/java/software/amazon/lambda/durable/execution/DurableExecutionTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/execution/DurableExecutionTest.java
@@ -12,7 +12,11 @@ import static software.amazon.lambda.durable.TypeToken.get;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
@@ -23,10 +27,13 @@ import software.amazon.awssdk.services.lambda.model.OperationType;
 import software.amazon.awssdk.services.lambda.model.StepDetails;
 import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.TestUtils;
+import software.amazon.lambda.durable.context.DurableContextImpl;
 import software.amazon.lambda.durable.exception.UnrecoverableDurableExecutionException;
 import software.amazon.lambda.durable.model.DurableExecutionInput;
 import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
+import software.amazon.lambda.durable.operation.BaseDurableOperation;
 
 class DurableExecutionTest {
 
@@ -106,6 +113,86 @@ class DurableExecutionTest {
 
         assertEquals(ExecutionStatus.PENDING, output.status());
         assertNull(output.result());
+    }
+
+    @Test
+    void waiterFirstTerminalCheckpointReturnsSuccessfulOutput() {
+        var pendingStep = Operation.builder()
+                .id("step")
+                .name("step")
+                .type(OperationType.STEP)
+                .subType(OperationSubType.STEP.getValue())
+                .status(OperationStatus.PENDING)
+                .build();
+        var input = new DurableExecutionInput(
+                EXECUTION_ARN,
+                "token1",
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(List.of(executionOp(), pendingStep))
+                        .build());
+        var checkpointAttempted = new CountDownLatch(1);
+        var checkpointFuture = new AtomicReference<CompletableFuture<Void>>();
+
+        var output = DurableExecutor.execute(
+                input,
+                null,
+                get(String.class),
+                (userInput, ctx) -> {
+                    var durableContext = (DurableContextImpl) ctx;
+                    var manager = durableContext.getExecutionManager();
+
+                    class TestOperation extends BaseDurableOperation {
+                        TestOperation() {
+                            super(OperationIdentifier.of("step", "step", OperationSubType.STEP), durableContext, null);
+                        }
+
+                        @Override
+                        protected void start() {}
+
+                        @Override
+                        protected void replay(Operation existing) {}
+
+                        Operation awaitCompletion() {
+                            return waitForOperationCompletion();
+                        }
+
+                        @Override
+                        protected void deregisterActiveThread(String threadId) {
+                            checkpointFuture.set(CompletableFuture.runAsync(() -> {
+                                checkpointAttempted.countDown();
+                                try {
+                                    manager.onCheckpointComplete(List.of(Operation.builder()
+                                            .id("step")
+                                            .name("step")
+                                            .type(OperationType.STEP)
+                                            .subType(OperationSubType.STEP.getValue())
+                                            .status(OperationStatus.SUCCEEDED)
+                                            .build()));
+                                } finally {
+                                    manager.finishCheckpointProcessing();
+                                }
+                            }));
+                            try {
+                                assertTrue(checkpointAttempted.await(5, TimeUnit.SECONDS));
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                throw new AssertionError(e);
+                            }
+                            super.deregisterActiveThread(threadId);
+                        }
+                    }
+
+                    var operation = new TestOperation();
+                    operation.execute();
+                    assertTrue(manager.tryStartCheckpointProcessing());
+                    var completed = operation.awaitCompletion();
+                    checkpointFuture.get().join();
+                    return completed.statusAsString();
+                },
+                configWithMockClient());
+
+        assertEquals(ExecutionStatus.SUCCEEDED, output.status());
+        assertTrue(output.result().contains(OperationStatus.SUCCEEDED.toString()));
     }
 
     @Test
@@ -350,5 +437,17 @@ class DurableExecutionTest {
         // Verify both executions completed successfully and used the same executor
         assertTrue(output1.result().contains("Result 1: test-input-1"));
         assertTrue(output2.result().contains("Result 2: test-input-2"));
+    }
+
+    private Operation executionOp() {
+        return Operation.builder()
+                .id(EXECUTION_OP_ID)
+                .type(OperationType.EXECUTION)
+                .status(OperationStatus.STARTED)
+                .startTimestamp(EXECUTION_START_TIME)
+                .executionDetails(ExecutionDetails.builder()
+                        .inputPayload("\"test-input\"")
+                        .build())
+                .build();
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/execution/ExecutionManagerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/execution/ExecutionManagerTest.java
@@ -8,6 +8,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.GetDurableExecutionStateResponse;
@@ -17,7 +21,11 @@ import software.amazon.awssdk.services.lambda.model.OperationType;
 import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.TestUtils;
 import software.amazon.lambda.durable.client.DurableExecutionClient;
+import software.amazon.lambda.durable.context.DurableContextImpl;
 import software.amazon.lambda.durable.model.DurableExecutionInput;
+import software.amazon.lambda.durable.model.OperationIdentifier;
+import software.amazon.lambda.durable.model.OperationSubType;
+import software.amazon.lambda.durable.operation.BaseDurableOperation;
 
 class ExecutionManagerTest {
     private static final String EXECUTION_OP_ID = "01234567-0123-0123-0123-012345678901";
@@ -198,5 +206,49 @@ class ExecutionManagerTest {
         assertTrue(manager.isOperationUpdatedSinceLastInvocation("2"));
         assertTrue(manager.isOperationUpdatedSinceLastInvocation("3"));
         assertFalse(manager.isOperationUpdatedSinceLastInvocation("4"));
+    }
+
+    @Test
+    void checkpointStateIsNotPublishedBeforeOperationCompletion() throws Exception {
+        var manager = createManager(List.of(executionOp(), stepOp("step", OperationStatus.PENDING)));
+        var durableContext = mock(DurableContextImpl.class);
+        when(durableContext.getExecutionManager()).thenReturn(manager);
+
+        class TestOperation extends BaseDurableOperation {
+            TestOperation() {
+                super(OperationIdentifier.of("step", "step", OperationSubType.STEP), durableContext, null);
+            }
+
+            @Override
+            protected void start() {}
+
+            @Override
+            protected void replay(Operation existing) {}
+
+            CompletableFuture<BaseDurableOperation> completionLock() {
+                return completionFuture;
+            }
+        }
+
+        var operation = new TestOperation();
+        var checkpointStarted = new CountDownLatch(1);
+        CompletableFuture<Void> checkpoint;
+        synchronized (operation.completionLock()) {
+            checkpoint = CompletableFuture.runAsync(() -> {
+                checkpointStarted.countDown();
+                manager.onCheckpointComplete(List.of(stepOp("step", OperationStatus.SUCCEEDED)));
+            });
+            assertTrue(checkpointStarted.await(5, TimeUnit.SECONDS));
+            assertThrows(TimeoutException.class, () -> checkpoint.get(500, TimeUnit.MILLISECONDS));
+            assertEquals(
+                    OperationStatus.PENDING,
+                    manager.getOperationAndUpdateReplayState("step").status());
+        }
+
+        checkpoint.get(5, TimeUnit.SECONDS);
+        assertTrue(operation.getCompletionFuture().isDone());
+        assertEquals(
+                OperationStatus.SUCCEEDED,
+                manager.getOperationAndUpdateReplayState("step").status());
     }
 }

--- a/sdk/src/test/java/software/amazon/lambda/durable/execution/ExecutionManagerTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/execution/ExecutionManagerTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.GetDurableExecutionStateResponse;
@@ -250,5 +251,68 @@ class ExecutionManagerTest {
         assertEquals(
                 OperationStatus.SUCCEEDED,
                 manager.getOperationAndUpdateReplayState("step").status());
+    }
+
+    @Test
+    void deferredSuspensionOccursWhenCheckpointFinishesWithoutReactivatingThread() {
+        var manager = createManager(List.of(executionOp(), stepOp("step", OperationStatus.PENDING)));
+        manager.registerActiveThread("root");
+        assertTrue(manager.tryStartCheckpointProcessing());
+
+        manager.deregisterActiveThread("root");
+        assertFalse(manager.isExecutionCompletedExceptionally());
+
+        manager.finishCheckpointProcessing();
+        assertTrue(manager.isExecutionCompletedExceptionally());
+    }
+
+    @Test
+    void checkpointDeliveryIsAtomicWithOperationRegistration() throws Exception {
+        var manager = createManager(List.of(executionOp(), stepOp("step", OperationStatus.PENDING)));
+        var durableContext = mock(DurableContextImpl.class);
+        when(durableContext.getExecutionManager()).thenReturn(manager);
+        var publicationReached = new CountDownLatch(1);
+        var allowPublication = new CountDownLatch(1);
+        var idCalls = new AtomicInteger();
+        var terminalOperation = mock(Operation.class);
+        when(terminalOperation.id()).thenAnswer(invocation -> {
+            if (idCalls.incrementAndGet() == 3) {
+                publicationReached.countDown();
+                assertTrue(allowPublication.await(5, TimeUnit.SECONDS));
+            }
+            return "step";
+        });
+        when(terminalOperation.name()).thenReturn("step");
+        when(terminalOperation.type()).thenReturn(OperationType.STEP);
+        when(terminalOperation.subType()).thenReturn(OperationSubType.STEP.getValue());
+        when(terminalOperation.status()).thenReturn(OperationStatus.SUCCEEDED);
+
+        class TestOperation extends BaseDurableOperation {
+            TestOperation() {
+                super(OperationIdentifier.of("step", "step", OperationSubType.STEP), durableContext, null);
+            }
+
+            @Override
+            protected void start() {}
+
+            @Override
+            protected void replay(Operation existing) {
+                markAlreadyCompleted();
+            }
+        }
+
+        var checkpoint = CompletableFuture.runAsync(() -> manager.onCheckpointComplete(List.of(terminalOperation)));
+        assertTrue(publicationReached.await(5, TimeUnit.SECONDS));
+        var registration = CompletableFuture.supplyAsync(TestOperation::new);
+        try {
+            assertThrows(TimeoutException.class, () -> registration.get(500, TimeUnit.MILLISECONDS));
+        } finally {
+            allowPublication.countDown();
+        }
+
+        checkpoint.get(5, TimeUnit.SECONDS);
+        var operation = registration.get(5, TimeUnit.SECONDS);
+        operation.execute();
+        assertTrue(operation.getCompletionFuture().isDone());
     }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Closes #370

### Description

This fixes a race between checkpoint completion and a context thread waiting for the same operation.

Before this change, ExecutionManager processed a checkpoint response in two separate steps:

1. It published the new operation state to operationStorage.
2. It called onCheckpointComplete on the registered operation, which completed its completion future and reactivated any waiting context thread.

A context thread could run between those steps. In the failing interleaving:

1. The checkpoint thread published a terminal state such as SUCCEEDED to operationStorage.
2. Before the checkpoint thread completed the operation future, the context thread entered waitForOperationCompletion and still observed that future as incomplete.
3. The context thread attached its reactivation callback and deregistered itself so the invocation could suspend.
4. If it was the last active thread, suspension began. However, the suspension check now saw only the already-published terminal operation state, so there were no pending operations left.
5. The invocation returned PENDING even though its checkpoint state contained no pending operation, which the durable service rejected with Cannot return PENDING status with no pending operations.

The fix publishes the checkpoint state and notifies the registered operation while holding the same completion lock used by waitForOperationCompletion. This makes the state transition and completion signal atomic from the waiter perspective:

- If the waiter acquires the lock first, operationStorage remains pending until the waiter has safely deregistered, so suspension has a valid pending operation.
- If the checkpoint thread acquires the lock first, it publishes the terminal state, completes the operation future, and synchronously runs the waiter reactivation callback before the waiter can inspect the future or deregister.

The same lock selection is retained for map and parallel children, which use the parent operation completion lock to serialize branch completion. A deterministic regression test holds that lock while a terminal checkpoint is processed and verifies that the terminal state cannot become visible before operation completion.

### Demo/Screenshots

Not applicable.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Yes. Added a deterministic ExecutionManager regression test for the checkpoint publication/completion race.

Commands run:

    mvn -pl sdk -Dtest=ExecutionManagerTest test
    mvn -pl sdk test

The SDK suite passed 1,150 tests.

#### Integration Tests

No new integration test was required because the failing interleaving is covered deterministically at the unit boundary. The complete repository reactor, including sdk-integration-tests, passed with:

    mvn test

#### Examples

No new example was required. Existing example tests passed as part of the full reactor; cloud-only tests remained disabled by default.