### PR TITLE
docs: clarify one-based step attempts

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/retry/RetryIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/retry/RetryIntegrationTest.java
@@ -4,6 +4,9 @@ package software.amazon.lambda.durable.retry;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -102,5 +105,35 @@ class RetryIntegrationTest {
         assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
         assertEquals("success: test-input", result.getResult(String.class));
         assertEquals(1, callCount.get());
+    }
+
+    @Test
+    void testStepContextAttemptNumbers_ShouldBeOneBased() {
+        var attempts = new CopyOnWriteArrayList<Integer>();
+        var handler = new DurableHandler<String, String>() {
+            @Override
+            public String handleRequest(String input, DurableContext context) {
+                return context.step(
+                        "retry-step",
+                        String.class,
+                        stepContext -> {
+                            attempts.add(stepContext.getAttempt());
+                            if (stepContext.getAttempt() == 1) {
+                                throw new RuntimeException("Retry once");
+                            }
+                            return "success";
+                        },
+                        StepConfig.builder()
+                                .retryStrategy(RetryStrategies.fixedDelay(2, Duration.ofSeconds(1)))
+                                .build());
+            }
+        };
+
+        var runner = LocalDurableTestRunner.create(String.class, handler);
+        var result = runner.runUntilComplete("test-input");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("success", result.getResult(String.class));
+        assertEquals(List.of(1, 2), attempts);
     }
 }

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/TestOperation.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/TestOperation.java
@@ -128,7 +128,7 @@ public class TestOperation {
         return details != null ? details.error() : null;
     }
 
-    /** Returns the current retry attempt number (0-based), defaulting to 0 if not available. */
+    /** Returns the current retry attempt number (1-based), defaulting to 1 if not available. */
     public int getAttempt() {
         var details = operation.stepDetails();
         return details != null && details.attempt() != null ? details.attempt() : 1;

--- a/sdk/src/main/java/software/amazon/lambda/durable/StepContext.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/StepContext.java
@@ -5,7 +5,7 @@ package software.amazon.lambda.durable;
 import software.amazon.lambda.durable.context.BaseContext;
 
 public interface StepContext extends BaseContext {
-    /** Returns the current retry attempt number (0-based). */
+    /** Returns the current retry attempt number (1-based). */
     int getAttempt();
 
     static StepContext getCurrentContext() {

--- a/sdk/src/main/java/software/amazon/lambda/durable/context/DurableContextImpl.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/context/DurableContextImpl.java
@@ -117,7 +117,7 @@ public class DurableContextImpl extends BaseContextImpl implements DurableContex
      *
      * @param stepOperationId the ID of the step operation (used for thread registration)
      * @param stepOperationName the name of the step operation
-     * @param attempt the current retry attempt number (0-based)
+     * @param attempt the current retry attempt number (1-based)
      * @return a new StepContext instance
      */
     public StepContextImpl createStepContext(String stepOperationId, String stepOperationName, int attempt) {

--- a/sdk/src/main/java/software/amazon/lambda/durable/context/StepContextImpl.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/context/StepContextImpl.java
@@ -25,7 +25,7 @@ public class StepContextImpl extends BaseContextImpl implements StepContext {
      * @param lambdaContext AWS Lambda runtime context
      * @param stepOperationId Unique identifier for this context instance that equals to step operation id
      * @param stepOperationName the name of the step operation
-     * @param attempt the current retry attempt number (0-based)
+     * @param attempt the current retry attempt number (1-based)
      */
     protected StepContextImpl(
             ExecutionManager executionManager,
@@ -38,7 +38,7 @@ public class StepContextImpl extends BaseContextImpl implements StepContext {
         this.attempt = attempt;
     }
 
-    /** Returns the current retry attempt number (0-based). */
+    /** Returns the current retry attempt number (1-based). */
     @Override
     public int getAttempt() {
         return attempt;


### PR DESCRIPTION
## Summary

- document `StepContext.getAttempt()` and `TestOperation.getAttempt()` as one-based
- align context implementation Javadocs with the existing runtime and plugin contracts
- add an integration test proving a retried step observes attempts `1` and `2`

## Testing

- `mvn spotless:apply`
- `mvn -pl sdk-integration-tests -am -Dtest=RetryIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false test`

Related shared-docs PR: https://github.com/aws/aws-durable-execution-docs/pull/267
