### PR TITLE
Round-trip WaitForCondition's initialState through SerDes on start()

### DIFF
--- a/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitForConditionOperation.java
+++ b/sdk/src/main/java/software/amazon/lambda/durable/operation/WaitForConditionOperation.java
@@ -54,7 +54,10 @@ public class WaitForConditionOperation<T> extends SerializableDurableOperation<T
 
     @Override
     protected void start() {
-        executeCheckLogic(config.initialState(), FIRST_ATTEMPT);
+        // Round-trip through SerDes so the first check observes the same shape as every subsequent
+        // check, which always deserializes state from a checkpoint (see resumeCheckLoop below).
+        var initialState = serializeAndDeserializeResult(config.initialState()).deserialized();
+        executeCheckLogic(initialState, FIRST_ATTEMPT);
     }
 
     @Override

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/WaitForConditionOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/WaitForConditionOperationTest.java
@@ -7,7 +7,9 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,7 @@ import software.amazon.lambda.durable.model.OperationIdentifier;
 import software.amazon.lambda.durable.model.OperationSubType;
 import software.amazon.lambda.durable.model.WaitForConditionResult;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
+import software.amazon.lambda.durable.serde.SerDes;
 
 class WaitForConditionOperationTest {
 
@@ -371,13 +374,14 @@ class WaitForConditionOperationTest {
 
     @Test
     void startNormalizesInitialStateThroughSerDes() throws Exception {
-        var mockSerDes = mock(software.amazon.lambda.durable.serde.SerDes.class);
+        var mockSerDes = mock(SerDes.class);
         when(mockSerDes.serialize(42)).thenReturn("42-normalized");
         when(mockSerDes.deserialize(eq("42-normalized"), any())).thenReturn(99);
 
         when(executionManager.getOperationAndUpdateReplayState(OPERATION_ID)).thenReturn(null);
 
         var receivedState = new java.util.concurrent.atomic.AtomicInteger(-1);
+        var checkRan = new CountDownLatch(1);
         var config = WaitForConditionConfig.<Integer>builder()
                 .serDes(mockSerDes)
                 .initialState(42)
@@ -385,18 +389,61 @@ class WaitForConditionOperationTest {
         var operation = createOperation(
                 (state, ctx) -> {
                     receivedState.set(state);
+                    checkRan.countDown();
                     return WaitForConditionResult.stopPolling(state);
                 },
                 config);
 
         operation.execute();
 
-        Thread.sleep(200);
+        assertTrue(checkRan.await(2, TimeUnit.SECONDS), "check function should have run");
         assertEquals(
                 99,
                 receivedState.get(),
                 "start() should round-trip initialState through SerDes before the first check, "
                         + "the same way resumeCheckLoop deserializes state from a checkpoint");
+    }
+
+    @Test
+    void startSerializesInitialStateButSkipsDeserializeWhenDisabled() throws Exception {
+        var mockSerDes = mock(SerDes.class);
+        when(mockSerDes.serialize(42)).thenReturn("42-normalized");
+        when(mockSerDes.deserialize(eq("42-normalized"), any())).thenReturn(99);
+
+        when(executionManager.getOperationAndUpdateReplayState(OPERATION_ID)).thenReturn(null);
+        when(durableContext.getDurableConfig())
+                .thenReturn(DurableConfig.builder()
+                        .withExecutorService(Executors.newCachedThreadPool())
+                        .withDeserializeAfterSerialization(false)
+                        .build());
+
+        var receivedState = new java.util.concurrent.atomic.AtomicInteger(-1);
+        var checkRan = new CountDownLatch(1);
+        var config = WaitForConditionConfig.<Integer>builder()
+                .serDes(mockSerDes)
+                .initialState(42)
+                .build();
+        var operation = createOperation(
+                (state, ctx) -> {
+                    receivedState.set(state);
+                    checkRan.countDown();
+                    return WaitForConditionResult.stopPolling(state);
+                },
+                config);
+
+        operation.execute();
+
+        assertTrue(checkRan.await(2, TimeUnit.SECONDS), "check function should have run");
+        // serialize(42) runs at least once for the initial state; it also runs again for the check
+        // result, since the check echoes the received state back via stopPolling(state).
+        verify(mockSerDes, atLeastOnce()).serialize(42);
+        verify(mockSerDes, never()).deserialize(any(), any());
+        assertEquals(
+                42,
+                receivedState.get(),
+                "with deserializeAfterSerialization disabled, the check should receive the raw "
+                        + "initialState even though it was still serialized (e.g. to fail fast on a "
+                        + "non-serializable value)");
     }
 
     // ===== resumeCheckLoop checkpoint deserialize exception =====

--- a/sdk/src/test/java/software/amazon/lambda/durable/operation/WaitForConditionOperationTest.java
+++ b/sdk/src/test/java/software/amazon/lambda/durable/operation/WaitForConditionOperationTest.java
@@ -367,6 +367,38 @@ class WaitForConditionOperationTest {
         assertEquals(42, receivedState.get(), "Should use initialState when checkpoint data is null");
     }
 
+    // ===== start() SerDes round-trip =====
+
+    @Test
+    void startNormalizesInitialStateThroughSerDes() throws Exception {
+        var mockSerDes = mock(software.amazon.lambda.durable.serde.SerDes.class);
+        when(mockSerDes.serialize(42)).thenReturn("42-normalized");
+        when(mockSerDes.deserialize(eq("42-normalized"), any())).thenReturn(99);
+
+        when(executionManager.getOperationAndUpdateReplayState(OPERATION_ID)).thenReturn(null);
+
+        var receivedState = new java.util.concurrent.atomic.AtomicInteger(-1);
+        var config = WaitForConditionConfig.<Integer>builder()
+                .serDes(mockSerDes)
+                .initialState(42)
+                .build();
+        var operation = createOperation(
+                (state, ctx) -> {
+                    receivedState.set(state);
+                    return WaitForConditionResult.stopPolling(state);
+                },
+                config);
+
+        operation.execute();
+
+        Thread.sleep(200);
+        assertEquals(
+                99,
+                receivedState.get(),
+                "start() should round-trip initialState through SerDes before the first check, "
+                        + "the same way resumeCheckLoop deserializes state from a checkpoint");
+    }
+
     // ===== resumeCheckLoop checkpoint deserialize exception =====
 
     @Test


### PR DESCRIPTION
Fixes #671

## Root cause

`WaitForConditionOperation.start()` passed `config.initialState()` straight into the first check:

```java
@Override
protected void start() {
    executeCheckLogic(config.initialState(), FIRST_ATTEMPT);
}
```

Every subsequent attempt goes through `resumeCheckLoop`, which derives `currentState` by deserializing either the checkpoint payload or, when there's no checkpoint yet, `config.initialState()` itself:

```java
T currentState;
if (checkpointData != null) {
    currentState = deserializeResult(checkpointData);
} else {
    currentState = config.initialState();
}
```

So every check after the first sees a value that has gone through the configured `SerDes`, but the very first check sees the raw, un-normalized value. A `SerDes` that changes shape on round-trip (narrows a type, drops unknown fields, changes floating-point precision, etc.) makes the first invocation observe a different shape than every later one for the exact same logical state — matching the inconsistency this issue describes relative to the Python SDK's `wait_for_condition`.

## Fix

`SerializableDurableOperation` already has `serializeAndDeserializeResult()`, documented for exactly this purpose ("keeps first execution consistent with replay when a SerDes normalizes or otherwise changes the value") and already used in `executeCheckLogic` to normalize the check *result*. `start()` now uses the same helper on the initial state before the first check:

```java
@Override
protected void start() {
    var initialState = serializeAndDeserializeResult(config.initialState()).deserialized();
    executeCheckLogic(initialState, FIRST_ATTEMPT);
}
```

## Testing

- Added `startNormalizesInitialStateThroughSerDes` to `WaitForConditionOperationTest`, using a `SerDes` mock where `deserialize` returns a value distinct from the raw `initialState`, to prove the check function receives the round-tripped value rather than the raw one. Confirmed this test fails on the unfixed code (`expected: <99> but was: <42>`) and passes with the fix.
- `mvn -pl sdk -am test`: full `sdk` module suite passes, no failures.
- `mvn -pl sdk spotless:check`: clean.