### PR TITLE
test: add replay identity conformance case

### DIFF
--- a/conformance-tests/src/main/java/general/ReplayOperationIdentity.java
+++ b/conformance-tests/src/main/java/general/ReplayOperationIdentity.java
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package general;
+
+import java.time.Duration;
+import software.amazon.lambda.durable.DurableConfig;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.logging.LoggerConfig;
+
+/** 11-1: Replay rejects an operation-type mismatch. */
+public class ReplayOperationIdentity extends DurableHandler<Object, String> {
+
+    @Override
+    protected DurableConfig createConfiguration() {
+        return DurableConfig.builder()
+                .withLoggerConfig(LoggerConfig.withReplayLogging())
+                .build();
+    }
+
+    @Override
+    public String handleRequest(Object input, DurableContext context) {
+        if (context.isReplaying()) {
+            context.getLogger().info("DETERMINISM_REPLAY_CANARY");
+            return context.step("identity-slot", String.class, stepContext -> {
+                stepContext.getLogger().info("DETERMINISM_STEP_BODY_EXECUTED");
+                return "unexpected";
+            });
+        }
+
+        context.wait("identity-slot", Duration.ofSeconds(1));
+        return null;
+    }
+}

--- a/conformance-tests/template_general.yaml
+++ b/conformance-tests/template_general.yaml
@@ -23,6 +23,8 @@ Globals:
       Ref: JavaVersion
     Architectures:
       - Ref: Architecture
+    LoggingConfig:
+      LogFormat: JSON
 
 Resources:
   DurableFunctionRole:

--- a/conformance-tests/template_general.yaml
+++ b/conformance-tests/template_general.yaml
@@ -1,0 +1,65 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Durable Execution Conformance Test Examples - Java (General)
+
+Parameters:
+  Architecture:
+    Type: String
+    Default: arm64
+    Description: Lambda Function Architecture
+    AllowedValues:
+      - x86_64
+      - arm64
+  JavaVersion:
+    Type: String
+    Default: 'java21'
+    Description: Java runtime version
+
+Globals:
+  Function:
+    Timeout: 60
+    MemorySize: 512
+    Runtime:
+      Ref: JavaVersion
+    Architectures:
+      - Ref: Architecture
+
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+
+  ReplayOperationIdentity:
+    Type: AWS::Serverless::Function
+    TestingMetadata:
+      TestDescription: ["11-1"]
+    Properties:
+      CodeUri: .
+      Handler: general.ReplayOperationIdentity
+      Description: Replay rejects an operation-type mismatch
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Implements https://github.com/aws/aws-durable-execution-conformance-tests/pull/111.

### Description

Adds the `general` conformance suite and Java handler for requirement `11-1`.
The handler emits a named `WAIT` initially, then deliberately emits a named
`STEP` at the same durable position on replay. Replay logging is enabled so the
suite can assert that replay occurred and that the mismatched step body never
ran.

### Demo/Screenshots

Not applicable.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

- `mvn -pl conformance-tests -am test` (1,157 tests passed)
- `mvn spotless:apply`

#### Integration Tests

The new `general` suite is discovered by the existing conformance workflow and
will run requirement `11-1` against the deployed handler.

#### Examples

Added `general.ReplayOperationIdentity` as the conformance handler for `11-1`.
