### PR TITLE
test: add payload offloader runners and integration coverage

### DIFF
--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/MapIntegrationTest.java
@@ -586,8 +586,9 @@ class MapIntegrationTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"FLAT, 2", "NESTED, 12"})
-    void testMapUnlimitedConcurrencyWithToleratedFailureCount(NestingType nestingType, int events) {
+    @CsvSource({"FLAT, 2, 2", "NESTED, 11, 12"})
+    void testMapUnlimitedConcurrencyWithToleratedFailureCount(
+            NestingType nestingType, int minimumEvents, int maximumEvents) {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var items = List.of("ok1", "FAIL1", "ok2", "FAIL2", "ok3");
             var config = MapConfig.builder()
@@ -613,7 +614,8 @@ class MapIntegrationTest {
 
         var result = runner.runUntilComplete("test");
         assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
-        assertEquals(events, result.getHistoryEvents().size());
+        assertTrue(minimumEvents <= result.getHistoryEvents().size());
+        assertTrue(result.getHistoryEvents().size() <= maximumEvents);
     }
 
     @Test

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/ParallelIntegrationTest.java
@@ -526,8 +526,9 @@ class ParallelIntegrationTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"FLAT, 2", "NESTED, 12"})
-    void testParallelUnlimitedConcurrencyWithToleratedFailureCount(NestingType nestingType, int events) {
+    @CsvSource({"FLAT, 2, 2", "NESTED, 11, 12"})
+    void testParallelUnlimitedConcurrencyWithToleratedFailureCount(
+            NestingType nestingType, int minimumEvents, int maximumEvents) {
         var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
             var config = ParallelConfig.builder()
                     .completionConfig(CompletionConfig.toleratedFailureCount(1))
@@ -555,7 +556,8 @@ class ParallelIntegrationTest {
 
         var result = runner.runUntilComplete("test");
         assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
-        assertEquals(events, result.getHistoryEvents().size());
+        assertTrue(minimumEvents <= result.getHistoryEvents().size());
+        assertTrue(result.getHistoryEvents().size() <= maximumEvents);
     }
 
     @ParameterizedTest

--- a/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PayloadOffloaderIntegrationTest.java
+++ b/sdk-integration-tests/src/test/java/software/amazon/lambda/durable/PayloadOffloaderIntegrationTest.java
@@ -1,0 +1,1354 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
+import software.amazon.awssdk.services.lambda.model.ErrorObject;
+import software.amazon.awssdk.services.lambda.model.ExecutionDetails;
+import software.amazon.awssdk.services.lambda.model.Operation;
+import software.amazon.awssdk.services.lambda.model.OperationAction;
+import software.amazon.awssdk.services.lambda.model.OperationStatus;
+import software.amazon.awssdk.services.lambda.model.OperationType;
+import software.amazon.lambda.durable.config.InvokeConfig;
+import software.amazon.lambda.durable.config.MapConfig;
+import software.amazon.lambda.durable.config.NestingType;
+import software.amazon.lambda.durable.config.ParallelBranchConfig;
+import software.amazon.lambda.durable.config.ParallelConfig;
+import software.amazon.lambda.durable.config.RunInChildContextConfig;
+import software.amazon.lambda.durable.config.StepConfig;
+import software.amazon.lambda.durable.config.WaitForConditionConfig;
+import software.amazon.lambda.durable.config.WithRetryConfig;
+import software.amazon.lambda.durable.exception.CallbackFailedException;
+import software.amazon.lambda.durable.exception.DurableOperationException;
+import software.amazon.lambda.durable.exception.InvokeFailedException;
+import software.amazon.lambda.durable.exception.PayloadOffloadException;
+import software.amazon.lambda.durable.exception.RetryablePayloadOffloadException;
+import software.amazon.lambda.durable.execution.DurableExecutor;
+import software.amazon.lambda.durable.execution.PayloadCodec;
+import software.amazon.lambda.durable.execution.SuspendExecutionException;
+import software.amazon.lambda.durable.model.DurableExecutionInput;
+import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.model.InvocationSource;
+import software.amazon.lambda.durable.model.OperationIdentifier;
+import software.amazon.lambda.durable.model.OperationSubType;
+import software.amazon.lambda.durable.offload.OffloadedPayload;
+import software.amazon.lambda.durable.offload.PayloadOffloadContext;
+import software.amazon.lambda.durable.offload.PayloadOffloader;
+import software.amazon.lambda.durable.offload.SerDesPayloadKind;
+import software.amazon.lambda.durable.offload.filesystem.FileSystemPayloadOffloader;
+import software.amazon.lambda.durable.offload.filesystem.PreviewConfig;
+import software.amazon.lambda.durable.offload.filesystem.PreviewMode;
+import software.amazon.lambda.durable.offload.internal.ChainedInvokePayloadFrame;
+import software.amazon.lambda.durable.retry.RetryDecision;
+import software.amazon.lambda.durable.retry.RetryStrategies;
+import software.amazon.lambda.durable.serde.JacksonSerDes;
+import software.amazon.lambda.durable.serde.SerDes;
+import software.amazon.lambda.durable.testing.LocalDurableTestRunner;
+import software.amazon.lambda.durable.testing.local.LocalMemoryExecutionClient;
+import software.amazon.lambda.durable.testing.local.OperationResult;
+
+class PayloadOffloaderIntegrationTest {
+    @TempDir
+    Path payloadDirectory;
+
+    @Test
+    void filesystemOffloaderReplaysStepAndRootOutput() throws IOException {
+        var stepExecutions = new AtomicInteger();
+        var config = DurableConfig.builder()
+                .withPayloadOffloader(
+                        FileSystemPayloadOffloader.builder(payloadDirectory).build())
+                .build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    var future = context.stepAsync("offloaded-step", String.class, stepContext -> {
+                        stepExecutions.incrementAndGet();
+                        return "stored-" + input;
+                    });
+                    var first = future.get();
+                    var second = future.get();
+                    context.wait("replay-boundary", Duration.ofSeconds(1));
+                    return first + ":" + second;
+                },
+                config);
+
+        var result = runner.runUntilComplete("value");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("stored-value:stored-value", result.getResult(String.class));
+        assertEquals("stored-value", result.getOperation("offloaded-step").getStepResult(String.class));
+        assertEquals(1, stepExecutions.get());
+        try (var files = Files.walk(payloadDirectory)) {
+            assertTrue(files.filter(Files::isRegularFile).count() >= 2);
+        }
+    }
+
+    @Test
+    void offloadedExceptionIsReconstructedAfterReplay() {
+        var config = DurableConfig.builder()
+                .withPayloadOffloader(
+                        FileSystemPayloadOffloader.builder(payloadDirectory).build())
+                .build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    try {
+                        context.step(
+                                "failing-step",
+                                String.class,
+                                stepContext -> {
+                                    throw new IllegalStateException("offloaded failure");
+                                },
+                                StepConfig.builder()
+                                        .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                                        .build());
+                        return "unreachable";
+                    } catch (IllegalStateException expected) {
+                        context.wait("replay-after-failure", Duration.ofSeconds(1));
+                        return expected.getMessage();
+                    }
+                },
+                config);
+
+        var result = runner.runUntilComplete("value");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("offloaded failure", result.getResult(String.class));
+    }
+
+    @Test
+    void operationCanDisableGlobalOffloader() {
+        var config = DurableConfig.builder()
+                .withPayloadOffloader(
+                        FileSystemPayloadOffloader.builder(payloadDirectory).build())
+                .build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> context.step(
+                        "inline-step",
+                        String.class,
+                        stepContext -> "inline",
+                        StepConfig.builder()
+                                .payloadOffloader(PayloadOffloader.disabled())
+                                .build()),
+                config);
+
+        var result = runner.run("value");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(
+                "\"inline\"",
+                result.getOperation("inline-step").getStepDetails().result());
+    }
+
+    @Test
+    void reservedPayloadMarkerRoundTripsThroughFirstExecutionAndReplayWithoutOffloader() {
+        var marker = "@aws-durable-payload:v2:{}";
+        var stepExecutions = new AtomicInteger();
+        SerDes passThroughSerDes = new SerDes() {
+            @Override
+            public String serialize(Object value) {
+                return (String) value;
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public <T> T deserialize(String data, TypeToken<T> typeToken) {
+                return (T) data;
+            }
+        };
+        var config = DurableConfig.builder().withSerDes(passThroughSerDes).build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    var result = context.step("marker-step", String.class, stepContext -> {
+                        stepExecutions.incrementAndGet();
+                        return marker;
+                    });
+                    context.wait("replay-boundary", Duration.ofSeconds(1));
+                    return result;
+                },
+                config);
+
+        var result = runner.runUntilComplete("input");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(marker, result.getResult(String.class));
+        assertTrue(result.getOperation("marker-step").getStepDetails().result().startsWith("@aws-durable-payload:v1:"));
+        assertEquals(1, stepExecutions.get());
+    }
+
+    @Test
+    void nullStepAndRootOutputReplayWithoutOffloading() {
+        var offloader = new CountingPayloadOffloader();
+        var stepExecutions = new AtomicInteger();
+        var config = DurableConfig.builder().withPayloadOffloader(offloader).build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    assertNull(context.step("null-step", String.class, stepContext -> {
+                        stepExecutions.incrementAndGet();
+                        return null;
+                    }));
+                    context.wait("replay-boundary", Duration.ofSeconds(1));
+                    return null;
+                },
+                config);
+
+        var result = runner.runUntilComplete("value");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertNull(result.getResult(String.class));
+        assertEquals(1, stepExecutions.get());
+        assertEquals(0, offloader.offloadCount());
+    }
+
+    @Test
+    void flatMapOffloadsOnlyCheckpointedAggregateResult() {
+        var offloader = new CountingPayloadOffloader();
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var result = context.map(
+                    "flat-map",
+                    List.of("a", "b"),
+                    String.class,
+                    (item, index, childContext) -> item.toUpperCase(),
+                    MapConfig.builder()
+                            .nestingType(NestingType.FLAT)
+                            .payloadOffloader(offloader)
+                            .build());
+            return String.join(",", result.results());
+        });
+
+        var result = runner.runUntilComplete("value");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("A,B", result.getResult(String.class));
+        assertEquals(1, offloader.offloadCount());
+    }
+
+    @Test
+    void flatMapPreservesMarkerPrefixedStandardInvokeFailure() {
+        var marker = "@aws-durable-payload:v2:{}";
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var mapResult = context.map(
+                    "flat-marker-map",
+                    List.of("item"),
+                    String.class,
+                    (item, index, child) -> child.invoke("flat-map-standard-invoke", "standard", "{}", String.class),
+                    MapConfig.builder().nestingType(NestingType.FLAT).build());
+            return mapResult.failed().size() + ":" + mapResult.succeeded().size();
+        });
+
+        assertEquals(ExecutionStatus.PENDING, runner.run("value").getStatus());
+        runner.failChainedInvoke(
+                "flat-map-standard-invoke",
+                ErrorObject.builder()
+                        .errorType("RemoteError")
+                        .errorMessage("remote failure")
+                        .errorData(marker)
+                        .build());
+
+        var result = runner.runUntilComplete("value");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("1:0", result.getResult(String.class));
+    }
+
+    @Test
+    void flatParallelPreservesMarkerPrefixedStandardInvokeFailure() {
+        var marker = "@aws-durable-payload:v2:{}";
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var parallel = context.parallel(
+                    "flat-marker-parallel",
+                    ParallelConfig.builder().nestingType(NestingType.FLAT).build());
+            try (parallel) {
+                parallel.branch(
+                        "branch",
+                        String.class,
+                        child -> child.invoke("flat-parallel-standard-invoke", "standard", "{}", String.class));
+            }
+            var parallelResult = parallel.get();
+            return parallelResult.failed() + ":" + parallelResult.succeeded();
+        });
+
+        assertEquals(ExecutionStatus.PENDING, runner.run("value").getStatus());
+        runner.failChainedInvoke(
+                "flat-parallel-standard-invoke",
+                ErrorObject.builder()
+                        .errorType("RemoteError")
+                        .errorMessage("remote failure")
+                        .errorData(marker)
+                        .build());
+
+        var result = runner.runUntilComplete("value");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("1:0", result.getResult(String.class));
+    }
+
+    @Test
+    void flatMapEscapesMarkerPrefixedCustomExceptionSerialization() {
+        var serDes = markerExceptionSerDes();
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var mapResult = context.map(
+                    "flat-custom-error-map",
+                    List.of("item"),
+                    String.class,
+                    (item, index, child) -> {
+                        throw new IllegalStateException("branch failure");
+                    },
+                    MapConfig.builder()
+                            .serDes(serDes)
+                            .nestingType(NestingType.FLAT)
+                            .build());
+            return mapResult.failed().size();
+        });
+
+        var result = runner.runUntilComplete("value");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(1, result.getResult(Integer.class));
+    }
+
+    @Test
+    void flatParallelEscapesMarkerPrefixedCustomExceptionSerialization() {
+        var serDes = markerExceptionSerDes();
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var parallel = context.parallel(
+                    "flat-custom-error-parallel",
+                    ParallelConfig.builder().nestingType(NestingType.FLAT).build());
+            try (parallel) {
+                parallel.branch(
+                        "branch",
+                        String.class,
+                        child -> {
+                            throw new IllegalStateException("branch failure");
+                        },
+                        ParallelBranchConfig.builder().serDes(serDes).build());
+            }
+            return parallel.get().failed();
+        });
+
+        var result = runner.runUntilComplete("value");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(1, result.getResult(Integer.class));
+    }
+
+    @Test
+    void completedParallelReplayDoesNotOffloadAgain() {
+        var offloader = new CountingPayloadOffloader();
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var parallel = context.parallel(
+                    "parallel",
+                    ParallelConfig.builder().payloadOffloader(offloader).build());
+            try (parallel) {
+                parallel.branch("first", String.class, childContext -> "one");
+                parallel.branch("second", String.class, childContext -> "two");
+            }
+            return parallel.get().succeeded();
+        });
+
+        var first = runner.runUntilComplete("value");
+        assertEquals(ExecutionStatus.SUCCEEDED, first.getStatus());
+        assertEquals(1, offloader.offloadCount());
+
+        var replay = runner.run("value");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, replay.getStatus());
+        assertEquals(1, offloader.offloadCount());
+    }
+
+    @Test
+    void mapReplayPayloadLoadFailureEscapesBusinessOutcomeHandling() {
+        var failIterationLoads = new AtomicBoolean();
+        var offloader = replayFailingOffloader(
+                context -> context.operationSubType()
+                        == software.amazon.lambda.durable.model.OperationSubType.MAP_ITERATION,
+                failIterationLoads);
+        var largeResult = "x".repeat(300 * 1024);
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> context.map(
+                        "map",
+                        List.of("a"),
+                        String.class,
+                        (item, index, childContext) -> largeResult,
+                        MapConfig.builder().payloadOffloader(offloader).build())
+                .results()
+                .get(0));
+
+        assertEquals(ExecutionStatus.SUCCEEDED, runner.runUntilComplete("value").getStatus());
+        failIterationLoads.set(true);
+
+        assertThrows(RetryablePayloadOffloadException.class, () -> runner.run("value"));
+    }
+
+    @Test
+    void parallelReplayPayloadLoadFailureEscapesBusinessOutcomeHandling() {
+        var failBranchLoads = new AtomicBoolean();
+        var branchOffloader = replayFailingOffloader(
+                context -> context.operationSubType()
+                        == software.amazon.lambda.durable.model.OperationSubType.PARALLEL_BRANCH,
+                failBranchLoads);
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var parallel = context.parallel("parallel");
+            try (parallel) {
+                parallel.branch(
+                        "branch",
+                        String.class,
+                        childContext -> "result",
+                        ParallelBranchConfig.builder()
+                                .payloadOffloader(branchOffloader)
+                                .build());
+            }
+            return parallel.get().succeeded();
+        });
+
+        assertEquals(ExecutionStatus.SUCCEEDED, runner.runUntilComplete("value").getStatus());
+        failBranchLoads.set(true);
+
+        assertThrows(RetryablePayloadOffloadException.class, () -> runner.run("value"));
+    }
+
+    @Test
+    void callerAndCalleeExchangeOffloadedInvokePayloadAndResult() {
+        var callerArn =
+                "arn:aws:lambda:us-east-1:123456789012:function:caller:1/durable-execution/caller-execution/caller-invocation";
+        var calleeArn =
+                "arn:aws:lambda:us-east-1:123456789012:function:callee:1/durable-execution/callee-execution/callee-invocation";
+        var offloader = new ContextKeyedPayloadOffloader();
+        var callerClient = new LocalMemoryExecutionClient();
+        var callerConfig = DurableConfig.builder()
+                .withDurableExecutionClient(callerClient)
+                .withPayloadOffloader(offloader)
+                .build();
+        BiFunction<String, DurableContext, CrossInvokeResponse> callerHandler = (input, context) -> context.invoke(
+                "call-callee",
+                "callee",
+                new CrossInvokeRequest(input),
+                CrossInvokeResponse.class,
+                InvokeConfig.builder().usePayloadOffloaderForPayload(true).build());
+        var callerExecution = executionOperation("caller-invocation", "caller-execution", "\"request\"");
+
+        var pending = DurableExecutor.execute(
+                durableInput(callerArn, callerExecution, List.of(), List.of()),
+                null,
+                TypeToken.get(String.class),
+                callerHandler,
+                callerConfig);
+
+        assertEquals(ExecutionStatus.PENDING, pending.status());
+        var invokePayload = callerClient.getOperationUpdates().stream()
+                .filter(update ->
+                        update.type() == OperationType.CHAINED_INVOKE && update.action() == OperationAction.START)
+                .findFirst()
+                .orElseThrow()
+                .payload();
+        assertTrue(ChainedInvokePayloadFrame.isFramed(invokePayload));
+
+        var calleeClient = new LocalMemoryExecutionClient();
+        var calleeConfig = DurableConfig.builder()
+                .withDurableExecutionClient(calleeClient)
+                .withPayloadOffloader(offloader)
+                .withPayloadOffloaderForChainedInvokePayloads(true)
+                .build();
+        var calleeExecution = executionOperation("callee-invocation", "callee-execution", invokePayload);
+        var calleeOutput = DurableExecutor.execute(
+                durableInput(calleeArn, calleeExecution, List.of(), List.of(), InvocationSource.CHAINED_INVOKE),
+                null,
+                TypeToken.get(CrossInvokeRequest.class),
+                (request, context) -> new CrossInvokeResponse("reply:" + request.value()),
+                calleeConfig);
+
+        assertEquals(ExecutionStatus.SUCCEEDED, calleeOutput.status());
+        callerClient.completeChainedInvoke("call-callee", OperationResult.succeeded(calleeOutput.result()));
+        var resumed = DurableExecutor.execute(
+                durableInput(
+                        callerArn,
+                        callerExecution,
+                        callerClient.getAllOperations(),
+                        callerClient.getUpdatedOperationIdsSinceLastInvocation()),
+                null,
+                TypeToken.get(String.class),
+                callerHandler,
+                callerConfig);
+        var result = new PayloadCodec(null)
+                .deserialize(
+                        resumed.result(),
+                        TypeToken.get(CrossInvokeResponse.class),
+                        new JacksonSerDes(),
+                        offloader,
+                        PayloadOffloadContext.forExecution(
+                                callerArn, "caller-invocation", "caller-execution", SerDesPayloadKind.OUTPUT));
+
+        assertEquals(ExecutionStatus.SUCCEEDED, resumed.status());
+        assertEquals(new CrossInvokeResponse("reply:request"), result);
+    }
+
+    @Test
+    void nullInvokeRequestRetainsHandshakeForOffloadedResult() {
+        var callerArn =
+                "arn:aws:lambda:us-east-1:123456789012:function:caller:1/durable-execution/caller-execution/caller-invocation";
+        var calleeArn =
+                "arn:aws:lambda:us-east-1:123456789012:function:callee:1/durable-execution/callee-execution/callee-invocation";
+        var offloader = new ContextKeyedPayloadOffloader();
+        var callerClient = new LocalMemoryExecutionClient();
+        var callerConfig = DurableConfig.builder()
+                .withDurableExecutionClient(callerClient)
+                .withPayloadOffloader(offloader)
+                .build();
+        BiFunction<String, DurableContext, String> callerHandler = (input, context) -> context.invoke(
+                "call-null-callee",
+                "callee",
+                (String) null,
+                String.class,
+                InvokeConfig.builder().usePayloadOffloaderForPayload(true).build());
+        var callerExecution = executionOperation("caller-invocation", "caller-execution", "\"request\"");
+
+        var pending = DurableExecutor.execute(
+                durableInput(callerArn, callerExecution, List.of(), List.of()),
+                null,
+                TypeToken.get(String.class),
+                callerHandler,
+                callerConfig);
+        var invokePayload = callerClient.getOperationUpdates().stream()
+                .filter(update ->
+                        update.type() == OperationType.CHAINED_INVOKE && update.action() == OperationAction.START)
+                .findFirst()
+                .orElseThrow()
+                .payload();
+
+        assertEquals(ExecutionStatus.PENDING, pending.status());
+        assertTrue(ChainedInvokePayloadFrame.isFramed(invokePayload));
+        assertNull(ChainedInvokePayloadFrame.decode(invokePayload));
+
+        var calleeConfig = DurableConfig.builder()
+                .withDurableExecutionClient(new LocalMemoryExecutionClient())
+                .withPayloadOffloader(offloader)
+                .withPayloadOffloaderForChainedInvokePayloads(true)
+                .build();
+        var calleeOutput = DurableExecutor.execute(
+                durableInput(
+                        calleeArn,
+                        executionOperation("callee-invocation", "callee-execution", invokePayload),
+                        List.of(),
+                        List.of(),
+                        InvocationSource.CHAINED_INVOKE),
+                null,
+                TypeToken.get(String.class),
+                (request, context) -> {
+                    assertNull(request);
+                    return "reply";
+                },
+                calleeConfig);
+
+        callerClient.completeChainedInvoke("call-null-callee", OperationResult.succeeded(calleeOutput.result()));
+        var resumed = DurableExecutor.execute(
+                durableInput(
+                        callerArn,
+                        callerExecution,
+                        callerClient.getAllOperations(),
+                        callerClient.getUpdatedOperationIdsSinceLastInvocation()),
+                null,
+                TypeToken.get(String.class),
+                callerHandler,
+                callerConfig);
+        var result = new PayloadCodec(null)
+                .deserialize(
+                        resumed.result(),
+                        TypeToken.get(String.class),
+                        new JacksonSerDes(),
+                        offloader,
+                        PayloadOffloadContext.forExecution(
+                                callerArn, "caller-invocation", "caller-execution", SerDesPayloadKind.OUTPUT));
+
+        assertEquals(ExecutionStatus.SUCCEEDED, calleeOutput.status());
+        assertEquals(ExecutionStatus.SUCCEEDED, resumed.status());
+        assertEquals("reply", result);
+    }
+
+    @Test
+    void defaultCallerReceivesOrdinaryResultFromOffloadingTarget() {
+        var callerArn =
+                "arn:aws:lambda:us-east-1:123456789012:function:caller:1/durable-execution/caller-execution/caller-invocation";
+        var calleeArn =
+                "arn:aws:lambda:us-east-1:123456789012:function:callee:1/durable-execution/callee-execution/callee-invocation";
+        var callerClient = new LocalMemoryExecutionClient();
+        var callerConfig =
+                DurableConfig.builder().withDurableExecutionClient(callerClient).build();
+        BiFunction<String, DurableContext, String> callerHandler =
+                (input, context) -> context.invoke("call-callee", "callee", input, String.class);
+        var callerExecution = executionOperation("caller-invocation", "caller-execution", "\"request\"");
+
+        var pending = DurableExecutor.execute(
+                durableInput(callerArn, callerExecution, List.of(), List.of()),
+                null,
+                TypeToken.get(String.class),
+                callerHandler,
+                callerConfig);
+        var invokePayload = callerClient.getOperationUpdates().stream()
+                .filter(update ->
+                        update.type() == OperationType.CHAINED_INVOKE && update.action() == OperationAction.START)
+                .findFirst()
+                .orElseThrow()
+                .payload();
+        var targetOffloader = new CountingPayloadOffloader();
+        var targetConfig = DurableConfig.builder()
+                .withDurableExecutionClient(new LocalMemoryExecutionClient())
+                .withPayloadOffloader(targetOffloader)
+                .build();
+        var targetOutput = DurableExecutor.execute(
+                durableInput(
+                        calleeArn,
+                        executionOperation("callee-invocation", "callee-execution", invokePayload),
+                        List.of(),
+                        List.of(),
+                        InvocationSource.CHAINED_INVOKE),
+                null,
+                TypeToken.get(String.class),
+                (request, context) -> "reply:" + request,
+                targetConfig);
+
+        assertEquals(ExecutionStatus.PENDING, pending.status());
+        assertTrue(!ChainedInvokePayloadFrame.isFramed(invokePayload));
+        assertEquals(ExecutionStatus.SUCCEEDED, targetOutput.status());
+        assertTrue(!PayloadCodec.isOffloadEnvelope(targetOutput.result()));
+        assertEquals(0, targetOffloader.offloadCount());
+
+        callerClient.completeChainedInvoke("call-callee", OperationResult.succeeded(targetOutput.result()));
+        var resumed = DurableExecutor.execute(
+                durableInput(
+                        callerArn,
+                        callerExecution,
+                        callerClient.getAllOperations(),
+                        callerClient.getUpdatedOperationIdsSinceLastInvocation()),
+                null,
+                TypeToken.get(String.class),
+                callerHandler,
+                callerConfig);
+
+        assertEquals(ExecutionStatus.SUCCEEDED, resumed.status());
+        assertEquals("\"reply:request\"", resumed.result());
+    }
+
+    @Test
+    void defaultCallerReceivesOrdinaryErrorFromOffloadingTarget() {
+        var callerArn =
+                "arn:aws:lambda:us-east-1:123456789012:function:caller:1/durable-execution/caller-execution/caller-invocation";
+        var calleeArn =
+                "arn:aws:lambda:us-east-1:123456789012:function:callee:1/durable-execution/callee-execution/callee-invocation";
+        var callerClient = new LocalMemoryExecutionClient();
+        var callerConfig =
+                DurableConfig.builder().withDurableExecutionClient(callerClient).build();
+        BiFunction<String, DurableContext, String> callerHandler = (input, context) -> {
+            try {
+                return context.invoke("call-callee", "callee", input, String.class);
+            } catch (InvokeFailedException expected) {
+                return expected.getErrorObject().errorMessage();
+            }
+        };
+        var callerExecution = executionOperation("caller-invocation", "caller-execution", "\"request\"");
+
+        var pending = DurableExecutor.execute(
+                durableInput(callerArn, callerExecution, List.of(), List.of()),
+                null,
+                TypeToken.get(String.class),
+                callerHandler,
+                callerConfig);
+        var invokePayload = callerClient.getOperationUpdates().stream()
+                .filter(update ->
+                        update.type() == OperationType.CHAINED_INVOKE && update.action() == OperationAction.START)
+                .findFirst()
+                .orElseThrow()
+                .payload();
+        var targetOffloader = new CountingPayloadOffloader();
+        var targetConfig = DurableConfig.builder()
+                .withDurableExecutionClient(new LocalMemoryExecutionClient())
+                .withPayloadOffloader(targetOffloader)
+                .build();
+        BiFunction<String, DurableContext, String> targetHandler = (request, context) -> {
+            throw new IllegalStateException("target failed");
+        };
+        var targetOutput = DurableExecutor.execute(
+                durableInput(
+                        calleeArn,
+                        executionOperation("callee-invocation", "callee-execution", invokePayload),
+                        List.of(),
+                        List.of(),
+                        InvocationSource.CHAINED_INVOKE),
+                null,
+                TypeToken.get(String.class),
+                targetHandler,
+                targetConfig);
+
+        assertEquals(ExecutionStatus.PENDING, pending.status());
+        assertEquals(ExecutionStatus.FAILED, targetOutput.status());
+        assertTrue(!PayloadCodec.isOffloadEnvelope(targetOutput.error().errorData()));
+        assertEquals(0, targetOffloader.offloadCount());
+
+        callerClient.completeChainedInvoke("call-callee", OperationResult.failed(targetOutput.error()));
+        var resumed = DurableExecutor.execute(
+                durableInput(
+                        callerArn,
+                        callerExecution,
+                        callerClient.getAllOperations(),
+                        callerClient.getUpdatedOperationIdsSinceLastInvocation()),
+                null,
+                TypeToken.get(String.class),
+                callerHandler,
+                callerConfig);
+
+        assertEquals(ExecutionStatus.SUCCEEDED, resumed.status());
+        assertEquals("\"target failed\"", resumed.result());
+    }
+
+    @Test
+    void stepRebindsSourceOwnedFailureBeforeReplay() {
+        var sourceOffloader = new ContextKeyedPayloadOffloader();
+        var targetOffloader = new ContextKeyedPayloadOffloader();
+        var forwardedFailure = sourceBackedFailure(sourceOffloader, "source-step");
+        var executions = new AtomicInteger();
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            try {
+                context.step(
+                        "forwarding-step",
+                        String.class,
+                        stepContext -> {
+                            executions.incrementAndGet();
+                            throw forwardedFailure;
+                        },
+                        StepConfig.builder()
+                                .payloadOffloader(targetOffloader)
+                                .retryStrategy(RetryStrategies.Presets.NO_RETRY)
+                                .build());
+                return "unreachable";
+            } catch (IllegalStateException expected) {
+                context.wait("step-replay-boundary", Duration.ofSeconds(1));
+                return expected.getMessage();
+            }
+        });
+
+        var result = runner.runUntilComplete("value");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("forwarded failure", result.getResult(String.class));
+        assertEquals(1, executions.get());
+    }
+
+    @Test
+    void waitForConditionRebindsSourceOwnedFailureBeforeReplay() {
+        var sourceOffloader = new ContextKeyedPayloadOffloader();
+        var targetOffloader = new ContextKeyedPayloadOffloader();
+        var forwardedFailure = sourceBackedFailure(sourceOffloader, "source-condition");
+        var executions = new AtomicInteger();
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            try {
+                context.waitForCondition(
+                        "forwarding-condition",
+                        String.class,
+                        (state, stepContext) -> {
+                            executions.incrementAndGet();
+                            throw forwardedFailure;
+                        },
+                        WaitForConditionConfig.<String>builder()
+                                .initialState("state")
+                                .payloadOffloader(targetOffloader)
+                                .build());
+                return "unreachable";
+            } catch (IllegalStateException expected) {
+                context.wait("condition-replay-boundary", Duration.ofSeconds(1));
+                return expected.getMessage();
+            }
+        });
+
+        var result = runner.runUntilComplete("value");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals("forwarded failure", result.getResult(String.class));
+        assertEquals(1, executions.get());
+    }
+
+    @Test
+    void retryableOffloadFailureEscapesStepOutcomeHandling() {
+        var userExecutions = new AtomicInteger();
+        var offloadAttempts = new AtomicInteger();
+        var offloader = new PayloadOffloader() {
+            @Override
+            public OffloadedPayload offload(String serializedPayload, PayloadOffloadContext context) {
+                offloadAttempts.incrementAndGet();
+                throw new RetryablePayloadOffloadException("storage unavailable");
+            }
+
+            @Override
+            public String load(OffloadedPayload payload, PayloadOffloadContext context) {
+                throw new AssertionError("load should not be called");
+            }
+        };
+        var client = new LocalMemoryExecutionClient();
+        var config = DurableConfig.builder()
+                .withDurableExecutionClient(client)
+                .withPayloadOffloader(offloader)
+                .build();
+        var executionArn =
+                "arn:aws:lambda:us-east-1:123456789012:function:test:1/durable-execution/execution/invocation";
+        var execution = executionOperation("invocation", "execution", "\"input\"");
+
+        assertThrows(
+                RetryablePayloadOffloadException.class,
+                () -> DurableExecutor.execute(
+                        durableInput(executionArn, execution, List.of(), List.of()),
+                        null,
+                        TypeToken.get(String.class),
+                        (input, context) -> context.step("successful-user-code", String.class, stepContext -> {
+                            userExecutions.incrementAndGet();
+                            return "result";
+                        }),
+                        config));
+
+        assertEquals(1, userExecutions.get());
+        assertEquals(1, offloadAttempts.get());
+        assertTrue(client.getOperationUpdates().stream()
+                .noneMatch(
+                        update -> update.action() == OperationAction.FAIL || update.action() == OperationAction.RETRY));
+    }
+
+    @Test
+    void withRetryDoesNotHandleFirstExecutionPayloadOffloadFailure() {
+        var userExecutions = new AtomicInteger();
+        var retryDecisions = new AtomicInteger();
+        var offloader = new PayloadOffloader() {
+            @Override
+            public OffloadedPayload offload(String serializedPayload, PayloadOffloadContext context) {
+                throw new RetryablePayloadOffloadException("storage unavailable");
+            }
+
+            @Override
+            public String load(OffloadedPayload payload, PayloadOffloadContext context) {
+                throw new AssertionError("load should not be called");
+            }
+        };
+        var retryConfig = WithRetryConfig.builder()
+                .retryStrategy((error, attempt) -> {
+                    retryDecisions.incrementAndGet();
+                    return RetryDecision.retry(Duration.ofSeconds(1));
+                })
+                .build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> context.withRetry(
+                        "retry",
+                        (attempt, retryContext) -> retryContext.step(
+                                "step",
+                                String.class,
+                                stepContext -> {
+                                    userExecutions.incrementAndGet();
+                                    return "result";
+                                },
+                                StepConfig.builder().payloadOffloader(offloader).build()),
+                        retryConfig));
+
+        assertThrows(RetryablePayloadOffloadException.class, () -> runner.run("value"));
+
+        assertEquals(1, userExecutions.get());
+        assertEquals(0, retryDecisions.get());
+    }
+
+    @Test
+    void withRetryDoesNotHandleReplayPayloadLoadFailure() {
+        var userExecutions = new AtomicInteger();
+        var retryDecisions = new AtomicInteger();
+        var failLoads = new AtomicBoolean();
+        var values = new ConcurrentHashMap<String, String>();
+        var sequence = new AtomicInteger();
+        var offloader = new PayloadOffloader() {
+            @Override
+            public OffloadedPayload offload(String serializedPayload, PayloadOffloadContext context) {
+                var reference = "memory://" + sequence.incrementAndGet();
+                values.put(reference, serializedPayload);
+                return OffloadedPayload.reference(reference, null);
+            }
+
+            @Override
+            public String load(OffloadedPayload payload, PayloadOffloadContext context) {
+                if (failLoads.get()) {
+                    throw new RetryablePayloadOffloadException("storage unavailable during replay");
+                }
+                return values.get(payload.reference());
+            }
+        };
+        var retryConfig = WithRetryConfig.builder()
+                .retryStrategy((error, attempt) -> {
+                    retryDecisions.incrementAndGet();
+                    return RetryDecision.retry(Duration.ofSeconds(1));
+                })
+                .build();
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            var result = context.withRetry(
+                    "retry",
+                    (attempt, retryContext) -> retryContext.step(
+                            "step",
+                            String.class,
+                            stepContext -> {
+                                userExecutions.incrementAndGet();
+                                return "result";
+                            },
+                            StepConfig.builder().payloadOffloader(offloader).build()),
+                    retryConfig);
+            context.wait("replay-boundary", Duration.ofSeconds(1));
+            return result;
+        });
+
+        assertEquals(ExecutionStatus.PENDING, runner.run("value").getStatus());
+        assertEquals(1, userExecutions.get());
+        failLoads.set(true);
+        runner.advanceTime();
+
+        assertThrows(RetryablePayloadOffloadException.class, () -> runner.run("value"));
+
+        assertEquals(1, userExecutions.get());
+        assertEquals(0, retryDecisions.get());
+    }
+
+    @Test
+    void waitForCallbackUnsupportedEnvelopeRemainsExternalFailure() {
+        var unsupportedEnvelope = "@aws-durable-payload:v2:{}";
+        var observedErrorData = new AtomicReference<String>();
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> {
+            try {
+                return context.waitForCallback("approval", String.class, (callbackId, stepContext) -> {});
+            } catch (SuspendExecutionException e) {
+                throw e;
+            } catch (CallbackFailedException e) {
+                observedErrorData.set(e.getErrorObject().errorData());
+                throw e;
+            }
+        });
+
+        assertEquals(ExecutionStatus.PENDING, runner.run("value").getStatus());
+        runner.failCallback(
+                runner.getCallbackId("approval-callback"),
+                ErrorObject.builder()
+                        .errorType("ExternalCallbackError")
+                        .errorMessage("callback failed")
+                        .errorData(unsupportedEnvelope)
+                        .build());
+
+        var result = runner.run("value");
+
+        assertEquals(ExecutionStatus.FAILED, result.getStatus());
+        assertEquals(unsupportedEnvelope, observedErrorData.get());
+        assertEquals(unsupportedEnvelope, result.getError().orElseThrow().errorData());
+    }
+
+    @Test
+    void waitForCallbackReferenceEnvelopeIsNotLoaded() {
+        var sequence = new AtomicInteger();
+        var offloadCount = new AtomicInteger();
+        var loadCount = new AtomicInteger();
+        var values = new ConcurrentHashMap<String, String>();
+        var offloader = new PayloadOffloader() {
+            @Override
+            public OffloadedPayload offload(String serializedPayload, PayloadOffloadContext context) {
+                offloadCount.incrementAndGet();
+                var reference = "memory://" + sequence.incrementAndGet();
+                values.put(reference, serializedPayload);
+                return OffloadedPayload.reference(reference, null);
+            }
+
+            @Override
+            public String load(OffloadedPayload payload, PayloadOffloadContext context) {
+                loadCount.incrementAndGet();
+                return values.get(payload.reference());
+            }
+        };
+        var producerContext = PayloadOffloadContext.forOperation(
+                "arn:aws:lambda:us-east-1:123456789012:function:external:$LATEST/durable-execution/name/id",
+                OperationIdentifier.of("callback-error", "callback-error", OperationSubType.CALLBACK),
+                null,
+                SerDesPayloadKind.EXCEPTION,
+                null);
+        var externalEnvelope =
+                new PayloadCodec(null).offloadSerializedPayload("external-error-data", offloader, producerContext);
+        offloadCount.set(0);
+        var observedErrorData = new AtomicReference<String>();
+        var config = DurableConfig.builder().withPayloadOffloader(offloader).build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> {
+                    try {
+                        return context.waitForCallback("approval", String.class, (callbackId, stepContext) -> {});
+                    } catch (SuspendExecutionException e) {
+                        throw e;
+                    } catch (CallbackFailedException e) {
+                        observedErrorData.set(e.getErrorObject().errorData());
+                        throw e;
+                    }
+                },
+                config);
+
+        assertEquals(ExecutionStatus.PENDING, runner.run("value").getStatus());
+        runner.failCallback(
+                runner.getCallbackId("approval-callback"),
+                ErrorObject.builder()
+                        .errorType("ExternalCallbackError")
+                        .errorMessage("callback failed")
+                        .errorData(externalEnvelope)
+                        .build());
+
+        var result = runner.run("value");
+
+        assertEquals(ExecutionStatus.FAILED, result.getStatus());
+        assertEquals(externalEnvelope, observedErrorData.get());
+        assertEquals(0, loadCount.get());
+        assertEquals(2, offloadCount.get());
+    }
+
+    @Test
+    void disabledInvokeErrorIsOffloadedAtChildBoundary() {
+        var sequence = new AtomicInteger();
+        var loadCount = new AtomicInteger();
+        var storedPayloads = new CopyOnWriteArrayList<StoredPayload>();
+        var values = new ConcurrentHashMap<String, String>();
+        var offloader = new PayloadOffloader() {
+            @Override
+            public OffloadedPayload offload(String serializedPayload, PayloadOffloadContext context) {
+                storedPayloads.add(new StoredPayload(context.withOriginalValue(null), serializedPayload));
+                var reference = "memory://" + sequence.incrementAndGet();
+                values.put(reference, serializedPayload);
+                return OffloadedPayload.reference(reference, null);
+            }
+
+            @Override
+            public String load(OffloadedPayload payload, PayloadOffloadContext context) {
+                loadCount.incrementAndGet();
+                return values.get(payload.reference());
+            }
+        };
+        var config = DurableConfig.builder().withPayloadOffloader(offloader).build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> context.runInChildContext(
+                        "child",
+                        String.class,
+                        child -> child.invoke(
+                                "disabled-invoke",
+                                "target",
+                                "{}",
+                                String.class,
+                                InvokeConfig.builder()
+                                        .payloadOffloader(PayloadOffloader.disabled())
+                                        .build()),
+                        RunInChildContextConfig.builder().build()),
+                config);
+
+        assertEquals(ExecutionStatus.PENDING, runner.run("value").getStatus());
+        runner.failChainedInvoke(
+                "disabled-invoke",
+                ErrorObject.builder()
+                        .errorType("RemoteError")
+                        .errorMessage("remote failure")
+                        .errorData("raw-error-data")
+                        .build());
+
+        var result = runner.run("value");
+        var childError = result.getOperation("child").getContextDetails().error();
+
+        assertEquals(ExecutionStatus.FAILED, result.getStatus());
+        assertTrue(PayloadCodec.isOffloadEnvelope(childError.errorData()));
+        assertTrue(
+                PayloadCodec.isOffloadEnvelope(result.getError().orElseThrow().errorData()));
+        assertEquals(2, storedPayloads.size());
+        assertEquals(
+                List.of("raw-error-data", "raw-error-data"),
+                storedPayloads.stream().map(StoredPayload::serializedPayload).toList());
+        assertTrue(storedPayloads.stream()
+                .anyMatch(payload -> payload.context().operationType() == OperationType.CONTEXT));
+        assertTrue(storedPayloads.stream()
+                .anyMatch(payload -> payload.context().operationType() == OperationType.EXECUTION));
+        assertEquals(1, loadCount.get());
+    }
+
+    @Test
+    void nestedStandardInvokeMarkerErrorIsEscapedAtChildAndRootBoundaries() {
+        var marker = "@aws-durable-payload:v2:{}";
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> context.runInChildContext(
+                        "child",
+                        String.class,
+                        child -> child.invoke("standard-invoke", "standard", "{}", String.class),
+                        RunInChildContextConfig.builder().build()));
+
+        assertEquals(ExecutionStatus.PENDING, runner.run("value").getStatus());
+        runner.failChainedInvoke(
+                "standard-invoke",
+                ErrorObject.builder()
+                        .errorType("RemoteError")
+                        .errorMessage("remote failure")
+                        .errorData(marker)
+                        .build());
+
+        var result = runner.run("value");
+        var childError = result.getOperation("child").getContextDetails().error();
+        var rootError = result.getError().orElseThrow();
+        var rootPayload = new JacksonSerDes()
+                .deserialize(
+                        rootError.errorData().substring("@aws-durable-payload:v1:".length()),
+                        TypeToken.get(OffloadedPayload.class));
+
+        assertEquals(ExecutionStatus.FAILED, result.getStatus());
+        assertEquals("RemoteError", rootError.errorType());
+        assertTrue(PayloadCodec.isOffloadEnvelope(childError.errorData()));
+        assertTrue(PayloadCodec.isOffloadEnvelope(rootError.errorData()));
+        assertEquals(
+                marker,
+                new PayloadCodec(null)
+                        .resolveSerializedPayload(rootError.errorData(), null, rootPayload.producerContext()));
+    }
+
+    @Test
+    void rawInvokeErrorWorksWithStructuredPreviewsEnabled() throws IOException {
+        var offloader = FileSystemPayloadOffloader.builder(payloadDirectory)
+                .previewConfig(PreviewConfig.builder(PreviewMode.INCLUDE_ALL).build())
+                .build();
+        var config = DurableConfig.builder().withPayloadOffloader(offloader).build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, context) -> context.invoke(
+                        "disabled-invoke",
+                        "target",
+                        "{}",
+                        String.class,
+                        InvokeConfig.builder()
+                                .payloadOffloader(PayloadOffloader.disabled())
+                                .build()),
+                config);
+
+        assertEquals(ExecutionStatus.PENDING, runner.run("value").getStatus());
+        runner.failChainedInvoke(
+                "disabled-invoke",
+                ErrorObject.builder()
+                        .errorType("RemoteError")
+                        .errorMessage("remote failure")
+                        .errorData("raw-error-data")
+                        .build());
+
+        var result = runner.run("value");
+
+        assertEquals(ExecutionStatus.FAILED, result.getStatus());
+        assertEquals("RemoteError", result.getError().orElseThrow().errorType());
+        assertTrue(
+                PayloadCodec.isOffloadEnvelope(result.getError().orElseThrow().errorData()));
+        try (var files = Files.walk(payloadDirectory)) {
+            assertTrue(files.anyMatch(Files::isRegularFile));
+        }
+    }
+
+    @Test
+    void defaultInvokePayloadPreservesStandardLambdaWireFormat() {
+        var callerArn =
+                "arn:aws:lambda:us-east-1:123456789012:function:caller:1/durable-execution/caller-execution/caller-invocation";
+        var callerClient = new LocalMemoryExecutionClient();
+        var config = DurableConfig.builder()
+                .withDurableExecutionClient(callerClient)
+                .withPayloadOffloader(
+                        FileSystemPayloadOffloader.builder(payloadDirectory).build())
+                .build();
+        var execution = executionOperation("caller-invocation", "caller-execution", "\"request\"");
+
+        var output = DurableExecutor.execute(
+                durableInput(callerArn, execution, List.of(), List.of()),
+                null,
+                TypeToken.get(String.class),
+                (input, context) ->
+                        context.invoke("call-standard", "standard", new CrossInvokeRequest(input), String.class),
+                config);
+
+        assertEquals(ExecutionStatus.PENDING, output.status());
+        var invokePayload = callerClient.getOperationUpdates().stream()
+                .filter(update ->
+                        update.type() == OperationType.CHAINED_INVOKE && update.action() == OperationAction.START)
+                .findFirst()
+                .orElseThrow()
+                .payload();
+        assertEquals("{\"value\":\"request\"}", invokePayload);
+        assertTrue(!ChainedInvokePayloadFrame.isFramed(invokePayload));
+    }
+
+    private static DurableExecutionInput durableInput(
+            String executionArn, Operation executionOperation, List<Operation> operations, List<String> updatedIds) {
+        return durableInput(executionArn, executionOperation, operations, updatedIds, InvocationSource.DIRECT);
+    }
+
+    private static DurableExecutionInput durableInput(
+            String executionArn,
+            Operation executionOperation,
+            List<Operation> operations,
+            List<String> updatedIds,
+            InvocationSource invocationSource) {
+        var allOperations = new ArrayList<Operation>();
+        allOperations.add(executionOperation);
+        allOperations.addAll(operations);
+        return new DurableExecutionInput(
+                executionArn,
+                "checkpoint-token",
+                CheckpointUpdatedExecutionState.builder()
+                        .operations(allOperations)
+                        .build(),
+                updatedIds,
+                invocationSource);
+    }
+
+    private static Operation executionOperation(String id, String name, String inputPayload) {
+        return Operation.builder()
+                .id(id)
+                .name(name)
+                .type(OperationType.EXECUTION)
+                .status(OperationStatus.STARTED)
+                .startTimestamp(Instant.now())
+                .executionDetails(
+                        ExecutionDetails.builder().inputPayload(inputPayload).build())
+                .build();
+    }
+
+    private static PayloadOffloader replayFailingOffloader(
+            Predicate<PayloadOffloadContext> shouldFail, AtomicBoolean failLoads) {
+        return new PayloadOffloader() {
+            private final AtomicInteger sequence = new AtomicInteger();
+            private final Map<String, String> values = new ConcurrentHashMap<>();
+
+            @Override
+            public OffloadedPayload offload(String serializedPayload, PayloadOffloadContext context) {
+                if (context.operationSubType() == software.amazon.lambda.durable.model.OperationSubType.MAP) {
+                    return OffloadedPayload.inline(serializedPayload);
+                }
+                var reference = "memory://" + sequence.incrementAndGet();
+                values.put(reference, serializedPayload);
+                return OffloadedPayload.reference(reference, null);
+            }
+
+            @Override
+            public String load(OffloadedPayload payload, PayloadOffloadContext context) {
+                if (failLoads.get() && shouldFail.test(context)) {
+                    throw new RetryablePayloadOffloadException("storage unavailable during replay");
+                }
+                return payload.data() != null ? payload.data() : values.get(payload.reference());
+            }
+        };
+    }
+
+    private static DurableOperationException sourceBackedFailure(
+            PayloadOffloader sourceOffloader, String producerName) {
+        var producerContext = PayloadOffloadContext.forOperation(
+                "arn:aws:lambda:us-east-1:123456789012:function:source:$LATEST/durable-execution/name/id",
+                OperationIdentifier.of(producerName, producerName, OperationSubType.STEP),
+                null,
+                SerDesPayloadKind.EXCEPTION,
+                1);
+        var errorData = new PayloadCodec(null)
+                .serialize(
+                        new IllegalStateException("forwarded failure"),
+                        new JacksonSerDes(),
+                        sourceOffloader,
+                        producerContext);
+        var error = ErrorObject.builder()
+                .errorType(IllegalStateException.class.getName())
+                .errorMessage("forwarded failure")
+                .errorData(errorData)
+                .build();
+        var operation = Operation.builder()
+                .id(producerName)
+                .type(OperationType.STEP)
+                .status(OperationStatus.FAILED)
+                .build();
+        return new DurableOperationException(operation, error).withPayloadSource(sourceOffloader, producerContext);
+    }
+
+    private static SerDes markerExceptionSerDes() {
+        var delegate = new JacksonSerDes();
+        return new SerDes() {
+            @Override
+            public String serialize(Object value) {
+                return value instanceof Throwable ? "@aws-durable-payload:v2:{}" : delegate.serialize(value);
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public <T> T deserialize(String data, TypeToken<T> typeToken) {
+                if ("@aws-durable-payload:v2:{}".equals(data)) {
+                    return (T) new IllegalStateException("branch failure");
+                }
+                return delegate.deserialize(data, typeToken);
+            }
+        };
+    }
+
+    record CrossInvokeRequest(String value) {}
+
+    record CrossInvokeResponse(String value) {}
+
+    private static final class CountingPayloadOffloader implements PayloadOffloader {
+        private final AtomicInteger offloadCount = new AtomicInteger();
+
+        @Override
+        public OffloadedPayload offload(String serializedPayload, PayloadOffloadContext context) {
+            Objects.requireNonNull(serializedPayload, "serializedPayload cannot be null");
+            offloadCount.incrementAndGet();
+            return OffloadedPayload.inline(serializedPayload);
+        }
+
+        @Override
+        public String load(OffloadedPayload payload, PayloadOffloadContext context) {
+            return payload.data();
+        }
+
+        private int offloadCount() {
+            return offloadCount.get();
+        }
+    }
+
+    private static final class ContextKeyedPayloadOffloader implements PayloadOffloader {
+        private final AtomicInteger sequence = new AtomicInteger();
+        private final Map<String, StoredPayload> values = new ConcurrentHashMap<>();
+
+        @Override
+        public OffloadedPayload offload(String serializedPayload, PayloadOffloadContext context) {
+            var reference = "memory://" + sequence.incrementAndGet();
+            values.put(reference, new StoredPayload(context.withOriginalValue(null), serializedPayload));
+            return OffloadedPayload.reference(reference, null);
+        }
+
+        @Override
+        public String load(OffloadedPayload payload, PayloadOffloadContext context) {
+            var stored = values.get(payload.reference());
+            if (stored == null || !stored.context().equals(context)) {
+                throw new PayloadOffloadException("payload loaded with a different producer context");
+            }
+            return stored.serializedPayload();
+        }
+    }
+
+    private record StoredPayload(PayloadOffloadContext context, String serializedPayload) {}
+}

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/AsyncExecution.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/AsyncExecution.java
@@ -5,6 +5,7 @@ package software.amazon.lambda.durable.testing;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.LambdaClient;
@@ -14,7 +15,9 @@ import software.amazon.awssdk.services.lambda.model.EventType;
 import software.amazon.awssdk.services.lambda.model.GetDurableExecutionHistoryRequest;
 import software.amazon.awssdk.services.lambda.model.ResourceNotFoundException;
 import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.execution.PayloadCodec;
 import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.offload.PayloadOffloader;
 import software.amazon.lambda.durable.serde.SerDes;
 import software.amazon.lambda.durable.testing.cloud.HistoryEventProcessor;
 
@@ -27,17 +30,33 @@ public class AsyncExecution<O> {
     private final LambdaClient lambdaClient;
     private final TypeToken<O> outputType;
     private final SerDes serDes;
+    private final PayloadOffloader payloadOffloader;
+    private final ExecutorService payloadOffloadExecutorService;
     private final Duration pollInterval;
     private final Duration timeout;
     private final HistoryEventProcessor processor;
     private List<Event> currentHistory;
     private TestResult<O> currentResult;
 
+    /** Creates an execution handle without payload-offloader-aware history decoding. */
     public AsyncExecution(
             String executionArn,
             LambdaClient lambdaClient,
             TypeToken<O> outputType,
             SerDes serDes,
+            Duration pollInterval,
+            Duration timeout) {
+        this(executionArn, lambdaClient, outputType, serDes, null, null, pollInterval, timeout);
+    }
+
+    /** Creates an execution handle with optional payload-offloader-aware history decoding. */
+    public AsyncExecution(
+            String executionArn,
+            LambdaClient lambdaClient,
+            TypeToken<O> outputType,
+            SerDes serDes,
+            PayloadOffloader payloadOffloader,
+            ExecutorService payloadOffloadExecutorService,
             Duration pollInterval,
             Duration timeout) {
         this.executionArn = executionArn;
@@ -46,6 +65,8 @@ public class AsyncExecution<O> {
         this.pollInterval = pollInterval;
         this.timeout = timeout;
         this.serDes = serDes;
+        this.payloadOffloader = payloadOffloader;
+        this.payloadOffloadExecutorService = payloadOffloadExecutorService;
         this.processor = new HistoryEventProcessor();
     }
 
@@ -195,7 +216,13 @@ public class AsyncExecution<O> {
                     .build();
             var response = lambdaClient.getDurableExecutionHistory(request);
             this.currentHistory = response.events();
-            this.currentResult = processor.processEvents(currentHistory, outputType, serDes);
+            this.currentResult = processor.processEvents(
+                    currentHistory,
+                    outputType,
+                    serDes,
+                    new PayloadCodec(payloadOffloadExecutorService),
+                    payloadOffloader,
+                    executionArn);
         } catch (ResourceNotFoundException e) {
             // Execution doesn't exist yet - this can happen immediately after async invoke
             // Leave currentHistory as null, pollUntil will retry

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/CloudDurableTestRunner.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/CloudDurableTestRunner.java
@@ -4,12 +4,15 @@ package software.amazon.lambda.durable.testing;
 
 import java.time.Duration;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvocationType;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.execution.PayloadCodec;
+import software.amazon.lambda.durable.offload.PayloadOffloader;
 import software.amazon.lambda.durable.serde.JacksonSerDes;
 import software.amazon.lambda.durable.serde.SerDes;
 import software.amazon.lambda.durable.testing.cloud.HistoryEventProcessor;
@@ -31,6 +34,8 @@ public class CloudDurableTestRunner<I, O> {
     private final Duration timeout;
     private final InvocationType invocationType;
     private final SerDes serDes;
+    private final PayloadOffloader payloadOffloader;
+    private final ExecutorService payloadOffloadExecutorService;
     // Store last execution result for operation inspection
     private TestResult<O> lastResult;
 
@@ -42,7 +47,9 @@ public class CloudDurableTestRunner<I, O> {
             Duration pollInterval,
             Duration timeout,
             InvocationType invocationType,
-            SerDes serDes) {
+            SerDes serDes,
+            PayloadOffloader payloadOffloader,
+            ExecutorService payloadOffloadExecutorService) {
         this.functionArn = functionArn;
         this.inputType = inputType;
         this.outputType = outputType;
@@ -52,6 +59,8 @@ public class CloudDurableTestRunner<I, O> {
         this.timeout = timeout;
         this.invocationType = invocationType;
         this.serDes = Objects.requireNonNullElseGet(serDes, JacksonSerDes::new);
+        this.payloadOffloader = payloadOffloader;
+        this.payloadOffloadExecutorService = payloadOffloadExecutorService;
     }
 
     private static LambdaClient createDefaultLambdaClient() {
@@ -77,6 +86,8 @@ public class CloudDurableTestRunner<I, O> {
                 Duration.ofSeconds(2),
                 Duration.ofSeconds(300),
                 InvocationType.REQUEST_RESPONSE,
+                null,
+                null,
                 null);
     }
 
@@ -97,36 +108,113 @@ public class CloudDurableTestRunner<I, O> {
                 Duration.ofSeconds(2),
                 Duration.ofSeconds(300),
                 InvocationType.REQUEST_RESPONSE,
+                null,
+                null,
                 null);
     }
 
     /** Returns a new runner with the specified lambda client. */
     public CloudDurableTestRunner<I, O> withLambdaClient(LambdaClient lambdaClient) {
         return new CloudDurableTestRunner<>(
-                functionArn, inputType, outputType, lambdaClient, pollInterval, timeout, invocationType, serDes);
+                functionArn,
+                inputType,
+                outputType,
+                lambdaClient,
+                pollInterval,
+                timeout,
+                invocationType,
+                serDes,
+                payloadOffloader,
+                payloadOffloadExecutorService);
     }
 
     /** Returns a new runner with the specified poll interval between history checks. */
     public CloudDurableTestRunner<I, O> withPollInterval(Duration interval) {
         return new CloudDurableTestRunner<>(
-                functionArn, inputType, outputType, lambdaClient, interval, timeout, invocationType, serDes);
+                functionArn,
+                inputType,
+                outputType,
+                lambdaClient,
+                interval,
+                timeout,
+                invocationType,
+                serDes,
+                payloadOffloader,
+                payloadOffloadExecutorService);
     }
 
     /** Returns a new runner with the specified maximum wait time for execution completion. */
     public CloudDurableTestRunner<I, O> withTimeout(Duration timeout) {
         return new CloudDurableTestRunner<>(
-                functionArn, inputType, outputType, lambdaClient, pollInterval, timeout, invocationType, serDes);
+                functionArn,
+                inputType,
+                outputType,
+                lambdaClient,
+                pollInterval,
+                timeout,
+                invocationType,
+                serDes,
+                payloadOffloader,
+                payloadOffloadExecutorService);
     }
 
     /** Returns a new runner with the specified Lambda invocation type. */
     public CloudDurableTestRunner<I, O> withInvocationType(InvocationType type) {
         return new CloudDurableTestRunner<>(
-                functionArn, inputType, outputType, lambdaClient, pollInterval, timeout, type, serDes);
+                functionArn,
+                inputType,
+                outputType,
+                lambdaClient,
+                pollInterval,
+                timeout,
+                type,
+                serDes,
+                payloadOffloader,
+                payloadOffloadExecutorService);
     }
 
     public CloudDurableTestRunner<I, O> withSerDes(SerDes serDes) {
         return new CloudDurableTestRunner<>(
-                functionArn, inputType, outputType, lambdaClient, pollInterval, timeout, invocationType, serDes);
+                functionArn,
+                inputType,
+                outputType,
+                lambdaClient,
+                pollInterval,
+                timeout,
+                invocationType,
+                serDes,
+                payloadOffloader,
+                payloadOffloadExecutorService);
+    }
+
+    /** Returns a new runner that resolves payloads with the supplied offloader. */
+    public CloudDurableTestRunner<I, O> withPayloadOffloader(PayloadOffloader payloadOffloader) {
+        return new CloudDurableTestRunner<>(
+                functionArn,
+                inputType,
+                outputType,
+                lambdaClient,
+                pollInterval,
+                timeout,
+                invocationType,
+                serDes,
+                Objects.requireNonNull(payloadOffloader, "payloadOffloader cannot be null"),
+                payloadOffloadExecutorService);
+    }
+
+    /** Returns a new runner with a dedicated payload I/O executor. */
+    public CloudDurableTestRunner<I, O> withPayloadOffloadExecutorService(ExecutorService executorService) {
+        return new CloudDurableTestRunner<>(
+                functionArn,
+                inputType,
+                outputType,
+                lambdaClient,
+                pollInterval,
+                timeout,
+                invocationType,
+                serDes,
+                payloadOffloader,
+                Objects.requireNonNull(executorService, "executorService cannot be null"));
     }
 
     /** Invokes the Lambda function, polls execution history until completion, and returns the result. */
@@ -161,7 +249,13 @@ public class CloudDurableTestRunner<I, O> {
 
             // Process events into TestResult
             var processor = new HistoryEventProcessor();
-            var result = processor.processEvents(events, outputType, serDes);
+            var result = processor.processEvents(
+                    events,
+                    outputType,
+                    serDes,
+                    new PayloadCodec(payloadOffloadExecutorService),
+                    payloadOffloader,
+                    executionArn);
             this.lastResult = result;
             return result;
         } catch (Exception e) {
@@ -200,7 +294,15 @@ public class CloudDurableTestRunner<I, O> {
             // This prevents immediate polling from failing with "execution does not exist"
             Thread.sleep(100);
 
-            return new AsyncExecution<>(executionArn, lambdaClient, outputType, serDes, pollInterval, timeout);
+            return new AsyncExecution<>(
+                    executionArn,
+                    lambdaClient,
+                    outputType,
+                    serDes,
+                    payloadOffloader,
+                    payloadOffloadExecutorService,
+                    pollInterval,
+                    timeout);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Interrupted while starting async execution", e);

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/LocalDurableTestRunner.java
@@ -5,8 +5,11 @@ package software.amazon.lambda.durable.testing;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
@@ -19,8 +22,15 @@ import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.TypeToken;
 import software.amazon.lambda.durable.execution.DurableExecutor;
+import software.amazon.lambda.durable.execution.PayloadCodec;
 import software.amazon.lambda.durable.model.DurableExecutionInput;
+import software.amazon.lambda.durable.model.DurableExecutionOutput;
 import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.model.OperationSubType;
+import software.amazon.lambda.durable.offload.PayloadOffloadContext;
+import software.amazon.lambda.durable.offload.PayloadOffloader;
+import software.amazon.lambda.durable.offload.SerDesPayloadKind;
+import software.amazon.lambda.durable.offload.internal.PayloadOffloadTracking;
 import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
 import software.amazon.lambda.durable.serde.SerDes;
 import software.amazon.lambda.durable.testing.local.LocalMemoryExecutionClient;
@@ -42,11 +52,15 @@ public class LocalDurableTestRunner<I, O> {
     private final LocalMemoryExecutionClient storage;
     private final SerDes serDes;
     private final DurableConfig customerConfig;
+    private final Map<String, PayloadOffloader> operationPayloadOffloaders = new ConcurrentHashMap<>();
     private final Instant executionStartTime = Instant.now();
     // The execution identity is fixed for the whole execution, matching the backend: the ARN and the EXECUTION
     // operation ID stay stable across reinvocations, while only per-invocation values (the checkpoint token) change.
     private final String executionName = UUID.randomUUID().toString();
     private final String executionOperationId = UUID.randomUUID().toString();
+    private final String executionArn = String.format(
+            "arn:aws:lambda:us-east-1:123456789012:function:test:$LATEST/durable-execution/%s/%s",
+            executionName, executionOperationId);
 
     private LocalDurableTestRunner(
             TypeToken<I> inputType,
@@ -61,17 +75,26 @@ public class LocalDurableTestRunner<I, O> {
         // Create config that uses customer's configuration but overrides the client with in-memory storage
         if (customerConfig != null) {
             // Use customer's config but override the client with our in-memory implementation
-            this.customerConfig = DurableConfig.builder()
+            var builder = DurableConfig.builder()
                     .withDurableExecutionClient(storage)
                     .withSerDes(customerConfig.getSerDes())
                     .withExecutorService(customerConfig.getExecutorService())
                     .withPollingStrategy(customerConfig.getPollingStrategy())
                     .withCheckpointDelay(customerConfig.getCheckpointDelay())
                     .withLoggerConfig(customerConfig.getLoggerConfig())
+                    .withDeserializeAfterSerialization(customerConfig.shouldDeserializeAfterSerialization())
+                    .withPayloadOffloaderForChainedInvokePayloads(
+                            customerConfig.shouldUsePayloadOffloaderForChainedInvokePayloads())
                     // Temporary: remove along with the checkpointEmptyMap flag in a future major version.
                     .withCheckpointEmptyMap(customerConfig.shouldCheckpointEmptyMap())
-                    .withPlugins(customerConfig.getPluginRunner().getPlugins().toArray(new DurableExecutionPlugin[0]))
-                    .build();
+                    .withPlugins(customerConfig.getPluginRunner().getPlugins().toArray(new DurableExecutionPlugin[0]));
+            if (customerConfig.getPayloadOffloader() != null) {
+                builder.withPayloadOffloader(customerConfig.getPayloadOffloader());
+            }
+            if (customerConfig.getPayloadOffloadExecutorService() != null) {
+                builder.withPayloadOffloadExecutorService(customerConfig.getPayloadOffloadExecutorService());
+            }
+            this.customerConfig = builder.build();
         } else {
             // Fallback to default config with in-memory client
             this.customerConfig =
@@ -244,9 +267,19 @@ public class LocalDurableTestRunner<I, O> {
     public TestResult<O> run(I input) {
         var durableInput = createDurableInput(input);
 
-        var output = DurableExecutor.execute(durableInput, mockLambdaContext(), inputType, handler, customerConfig);
+        final DurableExecutionOutput output;
+        try (var ignored = PayloadOffloadTracking.observe(
+                executionArn, (context, offloader) -> operationPayloadOffloaders.put(context.entityId(), offloader))) {
+            output = DurableExecutor.execute(durableInput, mockLambdaContext(), inputType, handler, customerConfig);
+        }
+        var codec = new PayloadCodec(customerConfig.getPayloadOffloadExecutorService());
 
-        return storage.toTestResult(output, outputType, serDes);
+        return storage.toTestResult(
+                output,
+                outputType,
+                serDes,
+                payload -> resolveExecutionPayload(payload, durableInput, codec),
+                (operation, payload) -> resolveOperationPayload(operation, payload, codec));
     }
 
     /**
@@ -285,7 +318,11 @@ public class LocalDurableTestRunner<I, O> {
     /** Returns the {@link TestOperation} for the given operation name, or null if not found. */
     public TestOperation getOperation(String name) {
         var op = storage.getOperationByName(name);
-        return op != null ? new TestOperation(op, serDes) : null;
+        if (op == null) {
+            return null;
+        }
+        var codec = new PayloadCodec(customerConfig.getPayloadOffloadExecutorService());
+        return new TestOperation(op, List.of(), serDes, payload -> resolveOperationPayload(op, payload, codec));
     }
 
     /** Get callback ID for a named callback operation. */
@@ -334,11 +371,6 @@ public class LocalDurableTestRunner<I, O> {
     }
 
     private DurableExecutionInput createDurableInput(I input) {
-        // The last ARN segment must equal the EXECUTION operation ID (ExecutionManager parses the ARN to find it), and
-        // both are stable across reinvocations so the execution keeps one identity — and one derived trace ID.
-        var executionArn = String.format(
-                "arn:aws:lambda:us-east-1:123456789012:function:test:$LATEST/durable-execution/%s/%s",
-                executionName, executionOperationId);
         var inputJson = serDes.serialize(input);
 
         // The list must contain exactly one EXECUTION operation, matching the backend, which keeps a single EXECUTION
@@ -396,6 +428,51 @@ public class LocalDurableTestRunner<I, O> {
                 UUID.randomUUID().toString(),
                 CheckpointUpdatedExecutionState.builder().operations(allOps).build(),
                 updatedOperationIds);
+    }
+
+    private String resolveExecutionPayload(String payload, DurableExecutionInput input, PayloadCodec codec) {
+        var executionOperation = input.initialExecutionState().operations().stream()
+                .filter(operation -> operation.type() == OperationType.EXECUTION)
+                .findFirst()
+                .orElseThrow();
+        var context = PayloadOffloadContext.forExecution(
+                input.durableExecutionArn(),
+                executionOperation.id(),
+                executionOperation.name(),
+                SerDesPayloadKind.OUTPUT);
+        return codec.resolveSerializedPayload(payload, customerConfig.getPayloadOffloader(), context);
+    }
+
+    private String resolveOperationPayload(Operation operation, String payload, PayloadCodec codec) {
+        var payloadKind = OperationSubType.WAIT_FOR_CONDITION.getValue().equals(operation.subType())
+                ? SerDesPayloadKind.STATE
+                : SerDesPayloadKind.RESULT;
+        var attempt = operation.stepDetails() != null ? operation.stepDetails().attempt() : null;
+        var operationSubType = operation.subType() == null
+                ? null
+                : Arrays.stream(OperationSubType.values())
+                        .filter(value -> value.getValue().equals(operation.subType()))
+                        .findFirst()
+                        .orElse(null);
+        var entityId = "operation/" + operation.id() + "/"
+                + payloadKind.name().toLowerCase().replace('_', '-');
+        if (attempt != null) {
+            entityId += "/attempt-" + attempt;
+        }
+        var context = new PayloadOffloadContext(
+                executionArn,
+                entityId,
+                payloadKind,
+                operation.id(),
+                operation.name(),
+                operation.parentId(),
+                operation.type(),
+                operationSubType,
+                attempt,
+                null);
+        var offloader =
+                operationPayloadOffloaders.getOrDefault(context.entityId(), customerConfig.getPayloadOffloader());
+        return codec.resolveSerializedPayload(payload, offloader, context);
     }
 
     private Context mockLambdaContext() {

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/TestOperation.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/TestOperation.java
@@ -5,6 +5,8 @@ package software.amazon.lambda.durable.testing;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
 import software.amazon.awssdk.services.lambda.model.CallbackDetails;
 import software.amazon.awssdk.services.lambda.model.ChainedInvokeDetails;
 import software.amazon.awssdk.services.lambda.model.ContextDetails;
@@ -25,15 +27,23 @@ public class TestOperation {
     private final Operation operation;
     private final List<Event> events;
     private final SerDes serDes;
+    private final Function<String, String> payloadResolver;
 
     public TestOperation(Operation operation, SerDes serDes) {
         this(operation, List.of(), serDes);
     }
 
     public TestOperation(Operation operation, List<Event> events, SerDes serDes) {
+        this(operation, events, serDes, Function.identity());
+    }
+
+    /** Creates an operation wrapper that resolves stored payloads before passing them to SerDes. */
+    public TestOperation(
+            Operation operation, List<Event> events, SerDes serDes, Function<String, String> payloadResolver) {
         this.operation = operation;
         this.events = events;
         this.serDes = serDes;
+        this.payloadResolver = payloadResolver;
     }
 
     /** Returns the raw history events associated with this operation. */
@@ -73,9 +83,25 @@ public class TestOperation {
 
     /** Returns the duration of the operation */
     public Duration getDuration() {
-        return Duration.between(
-                operation.startTimestamp(),
-                operation.endTimestamp() != null ? operation.endTimestamp() : Instant.now());
+        var startTimestamp = operation.startTimestamp();
+        if (startTimestamp == null) {
+            startTimestamp = events.stream()
+                    .map(Event::eventTimestamp)
+                    .filter(Objects::nonNull)
+                    .min(Instant::compareTo)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Operation duration is unavailable because no start timestamp was recorded"));
+        }
+
+        var endTimestamp = operation.endTimestamp();
+        if (endTimestamp == null && isCompleted()) {
+            endTimestamp = events.stream()
+                    .map(Event::eventTimestamp)
+                    .filter(Objects::nonNull)
+                    .max(Instant::compareTo)
+                    .orElse(startTimestamp);
+        }
+        return Duration.between(startTimestamp, endTimestamp != null ? endTimestamp : Instant.now());
     }
 
     /** Returns the step details, or null if this is not a step operation. */
@@ -119,7 +145,7 @@ public class TestOperation {
         if (details == null || details.result() == null) {
             return null;
         }
-        return serDes.deserialize(details.result(), type);
+        return serDes.deserialize(payloadResolver.apply(details.result()), type);
     }
 
     /** Returns the step error, or null if the step succeeded or this is not a step operation. */

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/TestResult.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/TestResult.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.services.lambda.model.ErrorObject;
 import software.amazon.awssdk.services.lambda.model.Event;
@@ -33,6 +34,7 @@ public class TestResult<O> {
     private final List<Event> allEvents;
     private final SerDes serDes;
     private final TypeToken<O> resultType;
+    private final Function<String, String> payloadResolver;
 
     public TestResult(
             ExecutionStatus status,
@@ -42,6 +44,19 @@ public class TestResult<O> {
             List<Event> allEvents,
             TypeToken<O> resultType,
             SerDes serDes) {
+        this(status, resultPayload, error, operations, allEvents, resultType, serDes, Function.identity());
+    }
+
+    /** Creates a result whose execution payload is resolved lazily when result access is requested. */
+    public TestResult(
+            ExecutionStatus status,
+            String resultPayload,
+            ErrorObject error,
+            List<TestOperation> operations,
+            List<Event> allEvents,
+            TypeToken<O> resultType,
+            SerDes serDes,
+            Function<String, String> payloadResolver) {
         this.status = status;
         this.resultPayload = resultPayload;
         this.error = error;
@@ -51,6 +66,7 @@ public class TestResult<O> {
         this.allEvents = List.copyOf(allEvents);
         this.serDes = serDes;
         this.resultType = resultType;
+        this.payloadResolver = payloadResolver;
     }
 
     /** Returns the execution status (SUCCEEDED, FAILED, or PENDING). */
@@ -76,11 +92,13 @@ public class TestResult<O> {
             var lastEvent = allEvents.get(allEvents.size() - 1);
             if (lastEvent.eventType() == EventType.EXECUTION_SUCCEEDED) {
                 return serDes.deserialize(
-                        lastEvent.executionSucceededDetails().result().payload(), resultType);
+                        payloadResolver.apply(
+                                lastEvent.executionSucceededDetails().result().payload()),
+                        resultType);
             }
             return null;
         }
-        return serDes.deserialize(resultPayload, resultType);
+        return serDes.deserialize(payloadResolver.apply(resultPayload), resultType);
     }
 
     /** Deserializes and returns the execution output if the result type is known. */

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/cloud/HistoryEventProcessor.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/cloud/HistoryEventProcessor.java
@@ -3,6 +3,7 @@
 package software.amazon.lambda.durable.testing.cloud;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import software.amazon.awssdk.services.lambda.model.CallbackDetails;
@@ -16,7 +17,12 @@ import software.amazon.awssdk.services.lambda.model.OperationType;
 import software.amazon.awssdk.services.lambda.model.StepDetails;
 import software.amazon.awssdk.services.lambda.model.WaitDetails;
 import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.execution.PayloadCodec;
 import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.model.OperationSubType;
+import software.amazon.lambda.durable.offload.PayloadOffloadContext;
+import software.amazon.lambda.durable.offload.PayloadOffloader;
+import software.amazon.lambda.durable.offload.SerDesPayloadKind;
 import software.amazon.lambda.durable.serde.SerDes;
 import software.amazon.lambda.durable.testing.AsyncExecution;
 import software.amazon.lambda.durable.testing.CloudDurableTestRunner;
@@ -37,6 +43,17 @@ public class HistoryEventProcessor {
      * @return a TestResult containing the execution status, output, and operation details
      */
     public <O> TestResult<O> processEvents(List<Event> events, TypeToken<O> outputType, SerDes serDes) {
+        return processEvents(events, outputType, serDes, new PayloadCodec(null), null, null);
+    }
+
+    /** Processes history while resolving SDK payload offload envelopes. */
+    public <O> TestResult<O> processEvents(
+            List<Event> events,
+            TypeToken<O> outputType,
+            SerDes serDes,
+            PayloadCodec codec,
+            PayloadOffloader offloader,
+            String executionArn) {
         var operations = new HashMap<String, Operation>();
         var operationEvents = new HashMap<String, List<Event>>();
         var status = ExecutionStatus.PENDING;
@@ -111,7 +128,14 @@ public class HistoryEventProcessor {
                     if (operationId != null) {
                         operations.putIfAbsent(
                                 operationId,
-                                createStepOperation(operationId, event.name(), null, OperationStatus.STARTED, 1));
+                                createStepOperation(
+                                        operationId,
+                                        event.name(),
+                                        event.parentId(),
+                                        event.subType(),
+                                        null,
+                                        OperationStatus.STARTED,
+                                        1));
                     }
                 }
                 case STEP_SUCCEEDED -> {
@@ -126,7 +150,13 @@ public class HistoryEventProcessor {
                         operations.put(
                                 operationId,
                                 createStepOperation(
-                                        operationId, event.name(), stepResult, OperationStatus.SUCCEEDED, attempt));
+                                        operationId,
+                                        event.name(),
+                                        event.parentId(),
+                                        event.subType(),
+                                        stepResult,
+                                        OperationStatus.SUCCEEDED,
+                                        attempt));
                     }
                 }
                 case STEP_FAILED -> {
@@ -137,7 +167,14 @@ public class HistoryEventProcessor {
                                 : 1;
                         operations.put(
                                 operationId,
-                                createStepOperation(operationId, event.name(), null, OperationStatus.FAILED, attempt));
+                                createStepOperation(
+                                        operationId,
+                                        event.name(),
+                                        event.parentId(),
+                                        event.subType(),
+                                        null,
+                                        OperationStatus.FAILED,
+                                        attempt));
                     }
                 }
 
@@ -236,14 +273,95 @@ public class HistoryEventProcessor {
         var testOperations = new ArrayList<TestOperation>();
         for (var entry : operations.entrySet()) {
             var opEvents = operationEvents.getOrDefault(entry.getKey(), List.of());
-            testOperations.add(new TestOperation(entry.getValue(), opEvents, serDes));
+            var operation = entry.getValue();
+            testOperations.add(new TestOperation(
+                    operation,
+                    opEvents,
+                    serDes,
+                    payload -> resolveOperationPayload(operation, payload, codec, offloader, executionArn)));
         }
 
-        return new TestResult<>(status, result, error, testOperations, events, outputType, serDes);
+        return new TestResult<>(
+                status,
+                result,
+                error,
+                testOperations,
+                events,
+                outputType,
+                serDes,
+                payload -> resolveExecutionPayload(payload, codec, offloader, executionArn));
+    }
+
+    private String resolveExecutionPayload(
+            String payload, PayloadCodec codec, PayloadOffloader offloader, String executionArn) {
+        if (!PayloadCodec.isOffloadEnvelope(payload)) {
+            return payload;
+        }
+        if (executionArn == null) {
+            return codec.resolveSerializedPayloadUsingProducerContext(payload, offloader);
+        }
+        var parts = executionParts(executionArn);
+        var context = PayloadOffloadContext.forExecution(executionArn, parts[1], parts[0], SerDesPayloadKind.OUTPUT);
+        return codec.resolveSerializedPayload(payload, offloader, context);
+    }
+
+    private String resolveOperationPayload(
+            Operation operation, String payload, PayloadCodec codec, PayloadOffloader offloader, String executionArn) {
+        if (!PayloadCodec.isOffloadEnvelope(payload)) {
+            return payload;
+        }
+        if (executionArn == null) {
+            return codec.resolveSerializedPayloadUsingProducerContext(payload, offloader);
+        }
+        var payloadKind = OperationSubType.WAIT_FOR_CONDITION.getValue().equals(operation.subType())
+                ? SerDesPayloadKind.STATE
+                : SerDesPayloadKind.RESULT;
+        var attempt = operation.stepDetails() != null ? operation.stepDetails().attempt() : null;
+        var operationSubType = operation.subType() == null
+                ? null
+                : Arrays.stream(OperationSubType.values())
+                        .filter(value -> value.getValue().equals(operation.subType()))
+                        .findFirst()
+                        .orElse(null);
+        var context = new PayloadOffloadContext(
+                executionArn,
+                operationEntityId(operation, payloadKind, attempt),
+                payloadKind,
+                operation.id(),
+                operation.name(),
+                operation.parentId(),
+                operation.type(),
+                operationSubType,
+                attempt,
+                null);
+        return codec.resolveSerializedPayload(payload, offloader, context);
+    }
+
+    private static String operationEntityId(Operation operation, SerDesPayloadKind payloadKind, Integer attempt) {
+        var entityId = "operation/" + operation.id() + "/"
+                + payloadKind.name().toLowerCase().replace('_', '-');
+        return attempt == null ? entityId : entityId + "/attempt-" + attempt;
+    }
+
+    private static String[] executionParts(String executionArn) {
+        if (executionArn == null) {
+            throw new IllegalStateException("Execution ARN is required to resolve offloaded history payloads");
+        }
+        var parts = executionArn.split("/", -1);
+        if (parts.length < 2) {
+            throw new IllegalStateException("Invalid durable execution ARN: " + executionArn);
+        }
+        return new String[] {parts[parts.length - 2], parts[parts.length - 1]};
     }
 
     private Operation createStepOperation(
-            String id, String name, String stepResult, OperationStatus status, Integer attempt) {
+            String id,
+            String name,
+            String parentId,
+            String subType,
+            String stepResult,
+            OperationStatus status,
+            Integer attempt) {
         var stepDetails = StepDetails.builder()
                 .result(stepResult)
                 .attempt(attempt != null ? attempt : 1)
@@ -252,8 +370,10 @@ public class HistoryEventProcessor {
         return Operation.builder()
                 .id(id)
                 .name(name)
+                .parentId(parentId)
                 .status(status)
                 .type(OperationType.STEP)
+                .subType(subType)
                 .stepDetails(stepDetails)
                 .build();
     }

--- a/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/LocalMemoryExecutionClient.java
+++ b/sdk-testing/src/main/java/software/amazon/lambda/durable/testing/local/LocalMemoryExecutionClient.java
@@ -12,6 +12,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import software.amazon.awssdk.services.lambda.model.CheckpointDurableExecutionResponse;
 import software.amazon.awssdk.services.lambda.model.CheckpointUpdatedExecutionState;
 import software.amazon.awssdk.services.lambda.model.GetDurableExecutionStateResponse;
@@ -131,9 +133,32 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
 
     /** Build TestResult from current state. */
     public <O> TestResult<O> toTestResult(DurableExecutionOutput output, TypeToken<O> resultType, SerDes serDes) {
+        return toTestResult(output, resultType, serDes, Function.identity(), (operation, payload) -> payload);
+    }
+
+    /** Build TestResult from current state, resolving operation payloads before deserialization. */
+    public <O> TestResult<O> toTestResult(
+            DurableExecutionOutput output,
+            TypeToken<O> resultType,
+            SerDes serDes,
+            BiFunction<Operation, String, String> payloadResolver) {
+        return toTestResult(output, resultType, serDes, Function.identity(), payloadResolver);
+    }
+
+    /** Build TestResult from current state, resolving execution and operation payloads lazily. */
+    public <O> TestResult<O> toTestResult(
+            DurableExecutionOutput output,
+            TypeToken<O> resultType,
+            SerDes serDes,
+            Function<String, String> executionPayloadResolver,
+            BiFunction<Operation, String, String> operationPayloadResolver) {
         var testOperations = existingOperations.values().stream()
                 .filter(op -> op.type() != OperationType.EXECUTION)
-                .map(op -> new TestOperation(op, eventProcessor.getEventsForOperation(op.id()), serDes))
+                .map(op -> new TestOperation(
+                        op,
+                        eventProcessor.getEventsForOperation(op.id()),
+                        serDes,
+                        payload -> operationPayloadResolver.apply(op, payload)))
                 .toList();
         return new TestResult<>(
                 output.status(),
@@ -142,7 +167,8 @@ public class LocalMemoryExecutionClient implements DurableExecutionClient {
                 testOperations,
                 eventProcessor.getAllEvents(),
                 resultType,
-                serDes);
+                serDes,
+                executionPayloadResolver);
     }
 
     /** Simulate checkpoint failure by forcing an operation into STARTED state */

--- a/sdk-testing/src/test/java/software/amazon/lambda/durable/testing/CloudDurableTestRunnerTest.java
+++ b/sdk-testing/src/test/java/software/amazon/lambda/durable/testing/CloudDurableTestRunnerTest.java
@@ -6,9 +6,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.Duration;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvocationType;
+import software.amazon.lambda.durable.offload.PayloadOffloader;
 
 class CloudDurableTestRunnerTest {
 
@@ -21,6 +23,22 @@ class CloudDurableTestRunnerTest {
                 .withInvocationType(InvocationType.EVENT);
 
         assertNotNull(runner);
+    }
+
+    @Test
+    void payloadOffloaderConfigurationIsFluent() {
+        var mockClient = mock(LambdaClient.class);
+        var executor = Executors.newSingleThreadExecutor();
+        try {
+            var runner = CloudDurableTestRunner.create(
+                            "arn:aws:lambda:us-east-2:123:function:test", String.class, String.class, mockClient)
+                    .withPayloadOffloader(PayloadOffloader.disabled())
+                    .withPayloadOffloadExecutorService(executor);
+
+            assertNotNull(runner);
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     @Test

--- a/sdk-testing/src/test/java/software/amazon/lambda/durable/testing/LocalDurableTestRunnerTest.java
+++ b/sdk-testing/src/test/java/software/amazon/lambda/durable/testing/LocalDurableTestRunnerTest.java
@@ -5,17 +5,27 @@ package software.amazon.lambda.durable.testing;
 import static org.junit.jupiter.api.Assertions.*;
 import static software.amazon.lambda.durable.TypeToken.get;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.config.StepConfig;
 import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.offload.OffloadedPayload;
+import software.amazon.lambda.durable.offload.PayloadOffloadContext;
+import software.amazon.lambda.durable.offload.PayloadOffloader;
 import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
 import software.amazon.lambda.durable.plugin.InvocationInfo;
+import software.amazon.lambda.durable.serde.SerDes;
 
 class LocalDurableTestRunnerTest {
 
@@ -70,6 +80,119 @@ class LocalDurableTestRunnerTest {
     }
 
     @Test
+    void operationLevelOffloaderIsUsedForResultInspection() {
+        var offloader = new InMemoryOffloader();
+        var config = DurableConfig.builder().build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, ctx) -> ctx.step(
+                        "offloaded",
+                        String.class,
+                        stepCtx -> "operation-result",
+                        StepConfig.builder().payloadOffloader(offloader).build()),
+                config);
+
+        var result = runner.run("input");
+
+        assertEquals("operation-result", result.getOperation("offloaded").getStepResult(String.class));
+        assertEquals("operation-result", runner.getOperation("offloaded").getStepResult(String.class));
+        assertTrue(offloader.loadCount.get() >= 2);
+    }
+
+    @Test
+    void disabledOperationOffloaderKeepsInlineInspectionWithGlobalOffloader() {
+        var globalOffloader = new InMemoryOffloader();
+        var config =
+                DurableConfig.builder().withPayloadOffloader(globalOffloader).build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, ctx) -> ctx.step(
+                        "inline",
+                        String.class,
+                        stepCtx -> "inline-result",
+                        StepConfig.builder()
+                                .payloadOffloader(PayloadOffloader.disabled())
+                                .build()),
+                config);
+
+        var result = runner.run("input");
+        var loadsBeforeInspection = globalOffloader.loadCount.get();
+
+        assertEquals("inline-result", result.getOperation("inline").getStepResult(String.class));
+        assertEquals(loadsBeforeInspection, globalOffloader.loadCount.get());
+    }
+
+    @Test
+    void disabledOperationMarkerEnvelopeUsesDisabledPolicyForInspection() {
+        var marker = "@aws-durable-payload:v2:{}";
+        var globalOffloader = new TransformingInlineOffloader();
+        SerDes passThroughSerDes = new SerDes() {
+            @Override
+            public String serialize(Object value) {
+                return (String) value;
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public <T> T deserialize(String data, TypeToken<T> typeToken) {
+                return (T) data;
+            }
+        };
+        var config = DurableConfig.builder()
+                .withSerDes(passThroughSerDes)
+                .withPayloadOffloader(globalOffloader)
+                .build();
+        var runner = LocalDurableTestRunner.create(
+                String.class,
+                (input, ctx) -> {
+                    ctx.step(
+                            "inline-marker",
+                            String.class,
+                            stepCtx -> marker,
+                            StepConfig.builder()
+                                    .serDes(passThroughSerDes)
+                                    .payloadOffloader(PayloadOffloader.disabled())
+                                    .build());
+                    return "done";
+                },
+                config);
+
+        var result = runner.run("input");
+
+        assertEquals(marker, result.getOperation("inline-marker").getStepResult(String.class));
+        assertEquals(0, globalOffloader.loadCount.get());
+    }
+
+    @Test
+    void rootOutputIsResolvedOnlyWhenResultIsAccessed() {
+        var offloader = new InMemoryOffloader();
+        var config = DurableConfig.builder().withPayloadOffloader(offloader).build();
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> "result", config);
+
+        var result = runner.run("input");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(0, offloader.loadCount.get());
+        assertEquals("result", result.getResult(String.class));
+        assertEquals(1, offloader.loadCount.get());
+    }
+
+    @Test
+    void historyBackedRootOutputUsesLazyResolver() {
+        var offloader = new InlineOffloader();
+        var config = DurableConfig.builder().withPayloadOffloader(offloader).build();
+        var largeResult = "x".repeat(7 * 1024 * 1024);
+        var runner = LocalDurableTestRunner.create(String.class, (input, context) -> largeResult, config);
+
+        var result = runner.run("input");
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(0, offloader.loadCount.get());
+        assertEquals(largeResult, result.getResult(String.class));
+        assertEquals(1, offloader.loadCount.get());
+    }
+
+    @Test
     void testGenericTypeInput() {
         var resultType = new TypeToken<ArrayList<String>>() {};
         var runner = LocalDurableTestRunner.create(resultType, (input, ctx) -> {
@@ -113,5 +236,55 @@ class LocalDurableTestRunnerTest {
         assertEquals(2, executionStartTimes.size());
         assertNotNull(executionStartTimes.get(0));
         assertEquals(executionStartTimes.get(0), executionStartTimes.get(1));
+    }
+
+    private static final class InMemoryOffloader implements PayloadOffloader {
+        private final Map<String, String> values = new ConcurrentHashMap<>();
+        private final AtomicInteger sequence = new AtomicInteger();
+        private final AtomicInteger loadCount = new AtomicInteger();
+
+        @Override
+        public OffloadedPayload offload(String serializedPayload, PayloadOffloadContext context) {
+            var reference = "memory://" + sequence.incrementAndGet();
+            values.put(reference, serializedPayload);
+            return OffloadedPayload.reference(reference, null);
+        }
+
+        @Override
+        public String load(OffloadedPayload payload, PayloadOffloadContext context) {
+            loadCount.incrementAndGet();
+            return values.get(payload.reference());
+        }
+    }
+
+    private static final class InlineOffloader implements PayloadOffloader {
+        private final AtomicInteger loadCount = new AtomicInteger();
+
+        @Override
+        public OffloadedPayload offload(String serializedPayload, PayloadOffloadContext context) {
+            return OffloadedPayload.inline(serializedPayload);
+        }
+
+        @Override
+        public String load(OffloadedPayload payload, PayloadOffloadContext context) {
+            loadCount.incrementAndGet();
+            return payload.data();
+        }
+    }
+
+    private static final class TransformingInlineOffloader implements PayloadOffloader {
+        private final AtomicInteger loadCount = new AtomicInteger();
+
+        @Override
+        public OffloadedPayload offload(String serializedPayload, PayloadOffloadContext context) {
+            return OffloadedPayload.inline(
+                    Base64.getEncoder().encodeToString(serializedPayload.getBytes(StandardCharsets.UTF_8)));
+        }
+
+        @Override
+        public String load(OffloadedPayload payload, PayloadOffloadContext context) {
+            loadCount.incrementAndGet();
+            return new String(Base64.getDecoder().decode(payload.data()), StandardCharsets.UTF_8);
+        }
     }
 }

--- a/sdk-testing/src/test/java/software/amazon/lambda/durable/testing/cloud/HistoryEventProcessorTest.java
+++ b/sdk-testing/src/test/java/software/amazon/lambda/durable/testing/cloud/HistoryEventProcessorTest.java
@@ -1,0 +1,268 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.testing.cloud;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import software.amazon.awssdk.services.lambda.model.Event;
+import software.amazon.awssdk.services.lambda.model.EventResult;
+import software.amazon.awssdk.services.lambda.model.EventType;
+import software.amazon.awssdk.services.lambda.model.ExecutionStartedDetails;
+import software.amazon.awssdk.services.lambda.model.ExecutionSucceededDetails;
+import software.amazon.awssdk.services.lambda.model.RetryDetails;
+import software.amazon.awssdk.services.lambda.model.StepStartedDetails;
+import software.amazon.awssdk.services.lambda.model.StepSucceededDetails;
+import software.amazon.lambda.durable.TypeToken;
+import software.amazon.lambda.durable.exception.PayloadOffloadException;
+import software.amazon.lambda.durable.execution.PayloadCodec;
+import software.amazon.lambda.durable.model.ExecutionStatus;
+import software.amazon.lambda.durable.model.OperationIdentifier;
+import software.amazon.lambda.durable.model.OperationSubType;
+import software.amazon.lambda.durable.offload.PayloadOffloadContext;
+import software.amazon.lambda.durable.offload.PayloadOffloader;
+import software.amazon.lambda.durable.offload.SerDesPayloadKind;
+import software.amazon.lambda.durable.offload.filesystem.FileSystemPayloadOffloader;
+import software.amazon.lambda.durable.serde.JacksonSerDes;
+import software.amazon.lambda.durable.serde.SerDes;
+
+class HistoryEventProcessorTest {
+    private static final String EXECUTION_ARN = "arn:aws:lambda:us-east-1:123456789012:function:test:$LATEST"
+            + "/durable-execution/execution-id/invocation-id";
+
+    @TempDir
+    Path payloadDirectory;
+
+    @Test
+    void resolvesOffloadedCloudExecutionAndStepResults() {
+        var serDes = new JacksonSerDes();
+        var offloader = FileSystemPayloadOffloader.builder(payloadDirectory).build();
+        var writer = new PayloadCodec(null);
+        var outputPayload = writer.serialize(
+                "execution-result",
+                serDes,
+                offloader,
+                PayloadOffloadContext.forExecution(
+                        EXECUTION_ARN, "invocation-id", "execution-id", SerDesPayloadKind.OUTPUT));
+        var stepPayload = writer.serialize(
+                "step-result",
+                serDes,
+                offloader,
+                PayloadOffloadContext.forOperation(
+                        EXECUTION_ARN,
+                        OperationIdentifier.of("step-id", "step", OperationSubType.STEP),
+                        null,
+                        SerDesPayloadKind.RESULT,
+                        2));
+        var startedAt = Instant.parse("2026-09-01T00:00:00Z");
+        var events = List.of(
+                Event.builder()
+                        .id("invocation-id")
+                        .name("execution-id")
+                        .eventType(EventType.EXECUTION_STARTED)
+                        .eventTimestamp(startedAt)
+                        .executionStartedDetails(
+                                ExecutionStartedDetails.builder().build())
+                        .build(),
+                Event.builder()
+                        .id("step-id")
+                        .name("step")
+                        .subType(OperationSubType.STEP.getValue())
+                        .eventType(EventType.STEP_STARTED)
+                        .eventTimestamp(startedAt.plusSeconds(1))
+                        .stepStartedDetails(StepStartedDetails.builder().build())
+                        .build(),
+                Event.builder()
+                        .id("step-id")
+                        .name("step")
+                        .subType(OperationSubType.STEP.getValue())
+                        .eventType(EventType.STEP_SUCCEEDED)
+                        .eventTimestamp(startedAt.plusSeconds(2))
+                        .stepSucceededDetails(StepSucceededDetails.builder()
+                                .result(EventResult.builder()
+                                        .payload(stepPayload)
+                                        .build())
+                                .retryDetails(
+                                        RetryDetails.builder().currentAttempt(2).build())
+                                .build())
+                        .build(),
+                Event.builder()
+                        .id("invocation-id")
+                        .name("execution-id")
+                        .eventType(EventType.EXECUTION_SUCCEEDED)
+                        .eventTimestamp(startedAt.plusSeconds(3))
+                        .executionSucceededDetails(ExecutionSucceededDetails.builder()
+                                .result(EventResult.builder()
+                                        .payload(outputPayload)
+                                        .build())
+                                .build())
+                        .build());
+
+        var result = new HistoryEventProcessor()
+                .processEvents(
+                        events, TypeToken.get(String.class), serDes, new PayloadCodec(null), offloader, EXECUTION_ARN);
+
+        assertEquals("execution-result", result.getResult());
+        assertEquals("step-result", result.getOperation("step").getStepResult(String.class));
+        assertEquals(Duration.ofSeconds(1), result.getOperation("step").getDuration());
+    }
+
+    @Test
+    void resolvesOffloadedWaitForConditionStateUsingHistorySubtype() {
+        var serDes = new JacksonSerDes();
+        var offloader = FileSystemPayloadOffloader.builder(payloadDirectory).build();
+        var statePayload = new PayloadCodec(null)
+                .serialize(
+                        42,
+                        serDes,
+                        offloader,
+                        PayloadOffloadContext.forOperation(
+                                EXECUTION_ARN,
+                                OperationIdentifier.of(
+                                        "condition-id", "condition", OperationSubType.WAIT_FOR_CONDITION),
+                                "parent-id",
+                                SerDesPayloadKind.STATE,
+                                3));
+        var startedAt = Instant.parse("2026-09-01T00:00:00Z");
+        var events = List.of(
+                Event.builder()
+                        .id("condition-id")
+                        .name("condition")
+                        .parentId("parent-id")
+                        .subType(OperationSubType.WAIT_FOR_CONDITION.getValue())
+                        .eventType(EventType.STEP_STARTED)
+                        .eventTimestamp(startedAt)
+                        .stepStartedDetails(StepStartedDetails.builder().build())
+                        .build(),
+                Event.builder()
+                        .id("condition-id")
+                        .name("condition")
+                        .parentId("parent-id")
+                        .subType(OperationSubType.WAIT_FOR_CONDITION.getValue())
+                        .eventType(EventType.STEP_SUCCEEDED)
+                        .eventTimestamp(startedAt.plusSeconds(1))
+                        .stepSucceededDetails(StepSucceededDetails.builder()
+                                .result(EventResult.builder()
+                                        .payload(statePayload)
+                                        .build())
+                                .retryDetails(
+                                        RetryDetails.builder().currentAttempt(3).build())
+                                .build())
+                        .build());
+
+        var result = new HistoryEventProcessor()
+                .processEvents(
+                        events, TypeToken.get(Integer.class), serDes, new PayloadCodec(null), offloader, EXECUTION_ARN);
+
+        assertEquals(42, result.getOperation("condition").getStepResult(Integer.class));
+        assertEquals(
+                OperationSubType.WAIT_FOR_CONDITION.getValue(),
+                result.getOperation("condition").getSubtype());
+    }
+
+    @Test
+    void threeArgumentOverloadResolvesInlineMarkerEnvelopesFromProducerContext() {
+        var marker = "@aws-durable-payload:v2:{}";
+        var serDes = new SerDes() {
+            @Override
+            public String serialize(Object value) {
+                return (String) value;
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public <T> T deserialize(String data, TypeToken<T> typeToken) {
+                return (T) data;
+            }
+        };
+        var codec = new PayloadCodec(null);
+        var outputPayload = codec.serialize(
+                marker,
+                serDes,
+                PayloadOffloader.disabled(),
+                PayloadOffloadContext.forExecution(
+                        EXECUTION_ARN, "invocation-id", "execution-id", SerDesPayloadKind.OUTPUT));
+        var stepPayload = codec.serialize(
+                marker,
+                serDes,
+                PayloadOffloader.disabled(),
+                PayloadOffloadContext.forOperation(
+                        EXECUTION_ARN,
+                        OperationIdentifier.of("step-id", "step", OperationSubType.STEP),
+                        null,
+                        SerDesPayloadKind.RESULT,
+                        1));
+        var startedAt = Instant.parse("2026-09-01T00:00:00Z");
+        var events = List.of(
+                Event.builder()
+                        .id("step-id")
+                        .name("step")
+                        .subType(OperationSubType.STEP.getValue())
+                        .eventType(EventType.STEP_SUCCEEDED)
+                        .eventTimestamp(startedAt)
+                        .stepSucceededDetails(StepSucceededDetails.builder()
+                                .result(EventResult.builder()
+                                        .payload(stepPayload)
+                                        .build())
+                                .retryDetails(
+                                        RetryDetails.builder().currentAttempt(1).build())
+                                .build())
+                        .build(),
+                Event.builder()
+                        .id("invocation-id")
+                        .name("execution-id")
+                        .eventType(EventType.EXECUTION_SUCCEEDED)
+                        .eventTimestamp(startedAt.plusSeconds(1))
+                        .executionSucceededDetails(ExecutionSucceededDetails.builder()
+                                .result(EventResult.builder()
+                                        .payload(outputPayload)
+                                        .build())
+                                .build())
+                        .build());
+
+        var result = new HistoryEventProcessor().processEvents(events, TypeToken.get(String.class), serDes);
+
+        assertEquals(marker, result.getResult());
+        assertEquals(marker, result.getOperation("step").getStepResult(String.class));
+    }
+
+    @Test
+    void recognizedReferenceEnvelopeWithoutOffloaderFailsOnResultAccess() {
+        var serDes = new JacksonSerDes();
+        var offloader = FileSystemPayloadOffloader.builder(payloadDirectory).build();
+        var outputPayload = new PayloadCodec(null)
+                .serialize(
+                        "execution-result",
+                        serDes,
+                        offloader,
+                        PayloadOffloadContext.forExecution(
+                                EXECUTION_ARN, "invocation-id", "execution-id", SerDesPayloadKind.OUTPUT));
+        var event = Event.builder()
+                .id("invocation-id")
+                .name("execution-id")
+                .eventType(EventType.EXECUTION_SUCCEEDED)
+                .eventTimestamp(Instant.parse("2026-09-01T00:00:00Z"))
+                .executionSucceededDetails(ExecutionSucceededDetails.builder()
+                        .result(EventResult.builder().payload(outputPayload).build())
+                        .build())
+                .build();
+
+        var result = new HistoryEventProcessor()
+                .processEvents(
+                        List.of(event),
+                        TypeToken.get(String.class),
+                        serDes,
+                        new PayloadCodec(null),
+                        null,
+                        EXECUTION_ARN);
+
+        assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+        assertThrows(PayloadOffloadException.class, result::getResult);
+    }
+}


### PR DESCRIPTION
## Stack

| Layer | PR | Scope |
|---|---|---|
| Architecture | #678 | ADR-006 and design decision |
| 1 | #649 | Core API, envelopes, runtime, operations |
| 2 | #681 | Filesystem implementation and retries |
| 3 | **#682 (this PR)** | Testing utilities and integration coverage |
| 4 | #683 | Examples, E2E infrastructure, and implementation docs |

## Scope

- make local and cloud test runners resolve offloaded execution and operation payloads lazily
- retain per-operation payload policies and history operation subtype/attempt identity
- add payload-aware `TestResult` and `TestOperation` inspection
- add integration coverage for root/step/error replay, operation overrides, map/parallel/child behavior, callbacks, chained invokes, caching, retries, and failure boundaries
- stabilize concurrency integration assertions for valid early-completion outcomes

Intentionally excluded:

- examples and EFS infrastructure
- README, configuration, and wire-format documentation

## Validation

- full eight-module Maven reactor on Java 17
- `git diff --check`
- `mvn spotless:check`

Related to #463.
