### PR TITLE
docs(logging): document Java 2.x MDC keys

### DIFF
--- a/docs/advanced/logging.md
+++ b/docs/advanced/logging.md
@@ -27,13 +27,47 @@ Logs include execution context via MDC (works with any SLF4J-compatible logging 
 {
   "timestamp": "2024-01-15T10:30:00.000Z",
   "level": "INFO",
-  "message": "Processing order: ORD-123",
-  "durableExecutionArn": "arn:aws:lambda:us-east-1:123456789:function:order-processor:exec-abc123",
+  "message": "Validating order details",
+  "executionArn": "arn:aws:lambda:us-east-1:123456789:function:order-processor:exec-abc123",
   "requestId": "a1b2c3d4-5678-90ab-cdef-example12345",
   "operationId": "1",
-  "operationName": "validate"
+  "operationName": "validate",
+  "attempt": "1"
 }
 ```
+
+Java SDK 2.x uses `executionArn`, `operationId`, and `operationName` by default.
+Applications migrating log queries or dashboards from 1.x can temporarily emit
+`durableExecutionArn`, `contextId`, and `contextName` instead:
+
+```java
+@Override
+protected DurableConfig createConfiguration() {
+    return DurableConfig.builder()
+        .withLoggerConfig(new LoggerConfig(true, true))
+        .build();
+}
+```
+
+The first argument controls replay suppression. The second enables the old MDC key
+names.
+
+### Custom SLF4J Delegate
+
+`getLogger()` uses the SDK's default SLF4J logger. Pass a specific SLF4J `Logger` to
+`getLogger(Logger delegate)` when you want the durable metadata and replay behavior
+applied to another logger:
+
+```java
+private static final Logger applicationLogger =
+    LoggerFactory.getLogger(OrderProcessor.class);
+
+var logger = ctx.getLogger(applicationLogger);
+logger.info("Processing order: {}", order.getId());
+```
+
+This creates a `DurableLogger` around the supplied delegate for that call. It does not
+replace the default returned by later parameterless `getLogger()` calls.
 
 ### Replay Behavior
 


### PR DESCRIPTION
## Summary

- update the logging example to use the Java 2.x MDC keys
- document the temporary `oldKeyNames` compatibility option for 1.x dashboards
- document `getLogger(Logger delegate)` for wrapping a custom SLF4J logger

## Validation

- `git diff --check`

Related shared documentation update: aws/aws-durable-execution-docs#283.