### PR TITLE
chore: remove scheduled OTel conformance runs

### DIFF
--- a/.github/workflows/otel-conformance-tests.yml
+++ b/.github/workflows/otel-conformance-tests.yml
@@ -25,8 +25,6 @@ on:
       - "conformance-tests-otel/**"
       - "pom.xml"
       - ".github/workflows/otel-conformance-tests.yml"
-  schedule:
-    - cron: "0 7 * * *"
   workflow_dispatch:
     inputs:
       phase:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

N/A

### Description

Remove the daily scheduled trigger from the OpenTelemetry conformance workflow.

The workflow remains available for pull requests, matching pushes to `main`, and manual dispatch. This prevents runs such as https://github.com/aws/aws-durable-execution-sdk-java/actions/runs/34322197884/workflow from being started by the cron schedule.

### Demo/Screenshots

N/A — workflow configuration only.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

Validated the workflow diff with `git diff --check` and confirmed that `pull_request`, `push`, and `workflow_dispatch` remain configured while `schedule` is absent.

#### Unit Tests

Not applicable — no runtime code changed.

#### Integration Tests

Not applicable — no runtime code changed.

#### Examples

Not applicable.
