### PR TITLE
feat(insight): add SQSExporter

### DIFF
--- a/insight-plugin/README.md
+++ b/insight-plugin/README.md
@@ -28,7 +28,8 @@ DurableConfig config = DurableConfig.builder()
 
 Exporters: `LambdaLogExporter` (default; writes the `operationsByName` map to stdout →
 CloudWatch), `S3Exporter` (canonical `operations` array, one object per execution),
-`CloudWatchLogsExporter` (PutLogEvents to a specific log group, `operationsByName` map). Implement
+`CloudWatchLogsExporter` (PutLogEvents to a specific log group, `operationsByName` map),
+`SQSExporter` (one `SendMessage` per emission; standard or FIFO queue). Implement
 `InsightExporter` for custom sinks.
 
 `LambdaLogExporter` needs no extra dependency. The AWS SDK service modules used by the remote
@@ -50,6 +51,62 @@ application:
     <artifactId>cloudwatchlogs</artifactId>
     <version>AWS_SDK_VERSION</version>
 </dependency>
+
+<!-- Required only for SQSExporter -->
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>sqs</artifactId>
+    <version>AWS_SDK_VERSION</version>
+</dependency>
+```
+
+## SQSExporter
+
+Sends one SQS `SendMessage` per emission, with the full record JSON as the message body. Works with
+standard and FIFO queues. **Resource:** an SQS queue (standard or FIFO). **IAM:** `sqs:SendMessage`
+on the target queue.
+
+```java
+.addExporter(SQSExporter.builder()
+    .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/workflow-insight")
+    .region("us-east-1")                                  // optional; defaults to the SDK chain
+    .operationsFormat(SQSExporter.OperationsFormat.ARRAY) // ARRAY (default) | BY_NAME | BOTH
+    .build())
+```
+
+- **`queueUrl`** (required) — the target queue URL. A URL ending in `.fifo` is treated as a FIFO
+  queue.
+- **`messageGroupId`** (optional, FIFO only) — defaults to the record's `executionArn`, so all
+  messages for one execution stay ordered together. Ignored for standard queues.
+- **`region`** (optional) — region for the created client; ignored when a client is injected.
+- **`operationsFormat`** (optional) — `ARRAY` (canonical `operations` array, default), `BY_NAME`
+  (the `operationsByName` map replacing the array), or `BOTH` (the array plus the map).
+- **`maxRecordSizeBytes`** (optional) — defaults to `256_000` (SQS's 256 KB message limit).
+
+**FIFO behavior:** on a `.fifo` queue the exporter sets `MessageGroupId` (see above) and a
+`MessageDeduplicationId` of `executionArn:emittedAt`, so a redelivery of the same emission is
+de-duplicated while a later update to the same execution is delivered. Every message carries
+`status` and `functionName` string message attributes for consumer-side filtering.
+
+**Queue setup:**
+
+```bash
+# Standard queue
+aws sqs create-queue --queue-name workflow-insight-queue
+
+# FIFO queue (content-based dedup off — the exporter supplies dedup ids)
+aws sqs create-queue --queue-name workflow-insight-queue.fifo \
+  --attributes FifoQueue=true,ContentBasedDeduplication=false
+```
+
+**IAM policy:**
+
+```json
+{
+    "Effect": "Allow",
+    "Action": "sqs:SendMessage",
+    "Resource": "arn:aws:sqs:*:*:workflow-insight-queue*"
+}
 ```
 
 ## Design

--- a/insight-plugin/README.md
+++ b/insight-plugin/README.md
@@ -77,16 +77,26 @@ on the target queue.
 - **`queueUrl`** (required) — the target queue URL. A URL ending in `.fifo` is treated as a FIFO
   queue.
 - **`messageGroupId`** (optional, FIFO only) — defaults to the record's `executionArn`, so all
-  messages for one execution stay ordered together. Ignored for standard queues.
+  messages for one execution stay ordered together. Bounded to SQS's 128-character limit (hashed
+  when longer; see FIFO behavior below). Ignored for standard queues.
 - **`region`** (optional) — region for the created client; ignored when a client is injected.
 - **`operationsFormat`** (optional) — `ARRAY` (canonical `operations` array, default), `BY_NAME`
   (the `operationsByName` map replacing the array), or `BOTH` (the array plus the map).
-- **`maxRecordSizeBytes`** (optional) — defaults to `256_000` (SQS's 256 KB message limit).
+- **`maxRecordSizeBytes`** (optional) — defaults to `256_000` (SQS's 256 KB message limit). Must be
+  positive; a non-positive value is rejected at build time. This bounds the rendered JSON **body**
+  only. SQS counts message attributes toward the same 256 KB message quota, so the default is not
+  set to the exact quota — leave headroom below the quota for the `status` and `functionName`
+  attributes when tuning it.
 
 **FIFO behavior:** on a `.fifo` queue the exporter sets `MessageGroupId` (see above) and a
-`MessageDeduplicationId` of `executionArn:emittedAt`, so a redelivery of the same emission is
-de-duplicated while a later update to the same execution is delivered. Every message carries
-`status` and `functionName` string message attributes for consumer-side filtering.
+`MessageDeduplicationId`. SQS caps both ids at 128 characters. The group id is used verbatim when
+it already fits and is otherwise replaced by a deterministic SHA-256 hex digest of the raw value,
+so grouping stays stable per execution. The deduplication id is a SHA-256 hex digest over the
+execution ARN, the emitted timestamp, and the rendered body: an exact redelivery of the same
+emission produces the same id and is de-duplicated, while two distinct rapid `ON_CHANGE` snapshots
+of the same execution produce different ids and are not silently dropped inside SQS's 5-minute
+dedup window. Hashing uses only the JDK (`java.security.MessageDigest`), no extra dependency. Every
+message carries `status` and `functionName` string message attributes for consumer-side filtering.
 
 **Queue setup:**
 

--- a/insight-plugin/pom.xml
+++ b/insight-plugin/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
-        <!-- AWS SDK exporters (S3 + CloudWatch Logs) -->
+        <!-- AWS SDK exporters (S3 + CloudWatch Logs + SQS) -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
@@ -43,6 +43,11 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatchlogs</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/insight-plugin/src/main/java/software/amazon/lambda/durable/insight/exporters/SQSExporter.java
+++ b/insight-plugin/src/main/java/software/amazon/lambda/durable/insight/exporters/SQSExporter.java
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.lambda.durable.insight.exporters;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.awssdk.regions.Region;
@@ -22,10 +25,20 @@ import software.amazon.lambda.durable.insight.WorkflowInsightRecord;
  *
  * <p>FIFO queues are detected by a {@code .fifo} suffix on the queue URL. For a FIFO queue the message group id
  * defaults to the record's {@code executionArn} (so all messages for one execution are ordered together) unless an
- * explicit {@code messageGroupId} is configured, and the message deduplication id is derived from
- * {@code executionArn:emittedAt} so a redelivery of the same emission is de-duplicated while a later update to the same
- * execution is not. Standard queues carry neither field. Every message additionally carries {@code status} and
- * {@code functionName} string message attributes for consumer-side filtering.
+ * explicit {@code messageGroupId} is configured. The message deduplication id is derived from the execution identity,
+ * the emitted timestamp, and the rendered body, so two distinct rapid {@code ON_CHANGE} snapshots of the same execution
+ * stay distinct (they are not silently dropped inside SQS's 5-minute dedup window) while an exact redelivery of the
+ * same emission is de-duplicated. Standard queues carry neither field. Every message additionally carries
+ * {@code status} and {@code functionName} string message attributes for consumer-side filtering.
+ *
+ * <p>SQS caps both the message group id and the message deduplication id at 128 characters. The group id is used
+ * verbatim when it already fits and is otherwise replaced by a deterministic SHA-256 hex digest (64 characters) of the
+ * raw value, so grouping stays stable per execution without a new dependency. The deduplication id is always a SHA-256
+ * hex digest, so it is bounded by construction.
+ *
+ * <p>{@code maxRecordSizeBytes} bounds the rendered JSON <em>body</em> only. SQS counts message attributes toward the
+ * same 256 KB message quota, so the default (256 KB) is intentionally not raised to the exact quota; leave headroom for
+ * the {@code status} and {@code functionName} attributes when tuning it.
  *
  * <p>Use this exporter when you need guaranteed delivery to a single consumer, or want to decouple record processing
  * from the Lambda invocation. Requires {@code sqs:SendMessage} on the target queue.
@@ -119,10 +132,55 @@ public final class SQSExporter implements InsightExporter {
                 .messageBody(body)
                 .messageAttributes(attributes);
         if (isFifo) {
-            request = request.messageGroupId(messageGroupId != null ? messageGroupId : record.executionArn())
-                    .messageDeduplicationId(record.executionArn() + ":" + emittedAt(rendered));
+            String groupId = messageGroupId != null ? messageGroupId : record.executionArn();
+            request = request.messageGroupId(boundedId(groupId))
+                    .messageDeduplicationId(deduplicationId(record.executionArn(), emittedAt(rendered), body));
         }
         client.sendMessage(request.build());
+    }
+
+    /** SQS caps the message group id and the message deduplication id at this many characters. */
+    private static final int SQS_ID_MAX_LENGTH = 128;
+
+    /**
+     * Returns {@code raw} unchanged when it already fits SQS's 128-character id limit; otherwise a deterministic
+     * SHA-256 hex digest (64 characters) of it, so a long execution identity still yields a stable, bounded, and
+     * collision-resistant group id. {@code null} is passed through so a missing identity fails the same way it would
+     * without bounding rather than throwing here.
+     */
+    private static String boundedId(String raw) {
+        if (raw == null || raw.length() <= SQS_ID_MAX_LENGTH) {
+            return raw;
+        }
+        return sha256Hex(raw);
+    }
+
+    /**
+     * Builds the FIFO deduplication id from the execution identity, the emitted timestamp, and the full rendered body.
+     * Because the body is folded in, two distinct {@code ON_CHANGE} snapshots emitted within the same timestamp
+     * granularity produce different ids (SQS will not drop the second inside its dedup window), while an exact
+     * redelivery of the identical emission produces the same id and is de-duplicated. The SHA-256 hex digest is 64
+     * characters, so the result is always within SQS's 128-character limit regardless of body size.
+     */
+    private static String deduplicationId(String executionArn, String emittedAt, String body) {
+        String arn = executionArn != null ? executionArn : "";
+        return sha256Hex(arn + '\u0000' + emittedAt + '\u0000' + body);
+    }
+
+    /** Lowercase hex SHA-256 of {@code input}. SHA-256 is a mandated JDK algorithm, so it is always available. */
+    private static String sha256Hex(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+                sb.append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is required but unavailable", e);
+        }
     }
 
     /**
@@ -183,7 +241,11 @@ public final class SQSExporter implements InsightExporter {
             return this;
         }
 
-        /** Maximum serialized record size before truncation. Defaults to SQS's 256 KB message limit. */
+        /**
+         * Maximum serialized size of the rendered JSON <em>body</em>, in bytes, before truncation. Must be positive.
+         * Defaults to SQS's 256 KB message limit. SQS counts message attributes toward the same 256 KB quota, so leave
+         * headroom below the quota for the {@code status} and {@code functionName} attributes when tuning this.
+         */
         public Builder maxRecordSizeBytes(Integer maxRecordSizeBytes) {
             this.maxRecordSizeBytes = maxRecordSizeBytes;
             return this;
@@ -198,6 +260,9 @@ public final class SQSExporter implements InsightExporter {
         public SQSExporter build() {
             if (queueUrl == null || queueUrl.isEmpty()) {
                 throw new IllegalArgumentException("SQSExporter requires a non-empty queueUrl");
+            }
+            if (maxRecordSizeBytes != null && maxRecordSizeBytes <= 0) {
+                throw new IllegalArgumentException("SQSExporter maxRecordSizeBytes must be positive when set");
             }
             return new SQSExporter(this);
         }

--- a/insight-plugin/src/main/java/software/amazon/lambda/durable/insight/exporters/SQSExporter.java
+++ b/insight-plugin/src/main/java/software/amazon/lambda/durable/insight/exporters/SQSExporter.java
@@ -1,0 +1,205 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.insight.exporters;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.SqsClientBuilder;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.lambda.durable.annotations.Experimental;
+import software.amazon.lambda.durable.insight.InsightExporter;
+import software.amazon.lambda.durable.insight.Json;
+import software.amazon.lambda.durable.insight.OperationSummary;
+import software.amazon.lambda.durable.insight.OperationsIndex;
+import software.amazon.lambda.durable.insight.WorkflowInsightRecord;
+
+/**
+ * Exports workflow insight records to Amazon SQS via {@code SendMessage}, one message per emission with the full JSON
+ * as the message body. Mirrors the JS {@code SQSExporter}.
+ *
+ * <p>FIFO queues are detected by a {@code .fifo} suffix on the queue URL. For a FIFO queue the message group id
+ * defaults to the record's {@code executionArn} (so all messages for one execution are ordered together) unless an
+ * explicit {@code messageGroupId} is configured, and the message deduplication id is derived from
+ * {@code executionArn:emittedAt} so a redelivery of the same emission is de-duplicated while a later update to the same
+ * execution is not. Standard queues carry neither field. Every message additionally carries {@code status} and
+ * {@code functionName} string message attributes for consumer-side filtering.
+ *
+ * <p>Use this exporter when you need guaranteed delivery to a single consumer, or want to decouple record processing
+ * from the Lambda invocation. Requires {@code sqs:SendMessage} on the target queue.
+ */
+@Experimental
+public final class SQSExporter implements InsightExporter {
+
+    /** How operations are rendered in the message body. Mirrors the JS {@code OperationsFormat}. */
+    @Experimental
+    public enum OperationsFormat {
+        /** The canonical {@code operations} array (default). */
+        ARRAY,
+        /** The {@code operationsByName} map, with the {@code operations} array replaced. */
+        BY_NAME,
+        /** The canonical {@code operations} array plus an added {@code operationsByName} map. */
+        BOTH
+    }
+
+    private final String queueUrl;
+    private final String messageGroupId;
+    private final boolean isFifo;
+    private final OperationsFormat operationsFormat;
+    private final Integer maxRecordSizeBytes;
+    private final SqsClient client;
+
+    private SQSExporter(Builder b) {
+        this.queueUrl = b.queueUrl;
+        this.messageGroupId = b.messageGroupId;
+        this.isFifo = b.queueUrl.endsWith(".fifo");
+        this.operationsFormat = b.operationsFormat != null ? b.operationsFormat : OperationsFormat.ARRAY;
+        this.maxRecordSizeBytes = b.maxRecordSizeBytes != null ? b.maxRecordSizeBytes : 256_000;
+        SqsClientBuilder cb = SqsClient.builder();
+        if (b.region != null) {
+            cb = cb.region(Region.of(b.region));
+        }
+        this.client = b.client != null ? b.client : cb.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Integer maxRecordSizeBytes() {
+        return maxRecordSizeBytes;
+    }
+
+    @Override
+    public Object render(WorkflowInsightRecord record) {
+        switch (operationsFormat) {
+            case BY_NAME:
+                return record.toByNameWireMap();
+            case BOTH:
+                return toBothWireMap(record);
+            case ARRAY:
+            default:
+                return record.toWireMap();
+        }
+    }
+
+    /**
+     * The {@code "both"} shape: the canonical {@code operations} array wire map with an added {@code operationsByName}
+     * map. Built from the record's public wire map and operations so the plugin's {@code WorkflowInsightRecord} does
+     * not need a dedicated rendering.
+     */
+    private static Map<String, Object> toBothWireMap(WorkflowInsightRecord record) {
+        Map<String, Object> data = record.toWireMap();
+        Map<String, Object> byName = new LinkedHashMap<>();
+        for (Map.Entry<String, OperationSummary> e :
+                OperationsIndex.buildOperationsByName(record.operations()).entrySet()) {
+            byName.put(e.getKey(), e.getValue().toWireMap());
+        }
+        data.put("operationsByName", byName);
+        return data;
+    }
+
+    @Override
+    public void export(WorkflowInsightRecord record) {
+        Object rendered = render(record);
+        String body = Json.stringify(rendered);
+        Map<String, MessageAttributeValue> attributes = new LinkedHashMap<>();
+        if (record.status() != null) {
+            attributes.put("status", stringAttribute(record.status()));
+        }
+        if (record.functionName() != null) {
+            attributes.put("functionName", stringAttribute(record.functionName()));
+        }
+
+        SendMessageRequest.Builder request = SendMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .messageBody(body)
+                .messageAttributes(attributes);
+        if (isFifo) {
+            request = request.messageGroupId(messageGroupId != null ? messageGroupId : record.executionArn())
+                    .messageDeduplicationId(record.executionArn() + ":" + emittedAt(rendered));
+        }
+        client.sendMessage(request.build());
+    }
+
+    /**
+     * Reads {@code emittedAt} from the rendered wire map. Every render shape ({@code ARRAY}/{@code BY_NAME}/
+     * {@code BOTH}) carries the base scalar fields, so this avoids depending on a package-private record accessor. The
+     * value is only used to build a FIFO deduplication id.
+     */
+    private static String emittedAt(Object rendered) {
+        if (rendered instanceof Map<?, ?> map) {
+            Object value = map.get("emittedAt");
+            if (value != null) {
+                return value.toString();
+            }
+        }
+        return "";
+    }
+
+    private static MessageAttributeValue stringAttribute(String value) {
+        return MessageAttributeValue.builder()
+                .dataType("String")
+                .stringValue(value)
+                .build();
+    }
+
+    /** Builder for {@link SQSExporter}. */
+    public static final class Builder {
+        private String queueUrl;
+        private String messageGroupId;
+        private String region;
+        private OperationsFormat operationsFormat;
+        private Integer maxRecordSizeBytes;
+        private SqsClient client;
+
+        /** The target SQS queue URL. A URL ending in {@code .fifo} is treated as a FIFO queue. Required. */
+        public Builder queueUrl(String queueUrl) {
+            this.queueUrl = queueUrl;
+            return this;
+        }
+
+        /**
+         * The FIFO message group id. Ignored for standard queues. Defaults to the record's {@code executionArn} for a
+         * FIFO queue when unset.
+         */
+        public Builder messageGroupId(String messageGroupId) {
+            this.messageGroupId = messageGroupId;
+            return this;
+        }
+
+        /** AWS region for the created client. Ignored when a client is injected. Defaults to the SDK default chain. */
+        public Builder region(String region) {
+            this.region = region;
+            return this;
+        }
+
+        /** How operations are rendered in the message body. Defaults to {@link OperationsFormat#ARRAY}. */
+        public Builder operationsFormat(OperationsFormat operationsFormat) {
+            this.operationsFormat = operationsFormat;
+            return this;
+        }
+
+        /** Maximum serialized record size before truncation. Defaults to SQS's 256 KB message limit. */
+        public Builder maxRecordSizeBytes(Integer maxRecordSizeBytes) {
+            this.maxRecordSizeBytes = maxRecordSizeBytes;
+            return this;
+        }
+
+        /** Test seam: inject a client. */
+        public Builder client(SqsClient client) {
+            this.client = client;
+            return this;
+        }
+
+        public SQSExporter build() {
+            if (queueUrl == null || queueUrl.isEmpty()) {
+                throw new IllegalArgumentException("SQSExporter requires a non-empty queueUrl");
+            }
+            return new SQSExporter(this);
+        }
+    }
+}

--- a/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/SQSExporterTest.java
+++ b/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/SQSExporterTest.java
@@ -4,14 +4,19 @@ package software.amazon.lambda.durable.insight;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.services.sqs.SqsClient;
@@ -56,6 +61,27 @@ class SQSExporterTest {
         return req.getValue();
     }
 
+    private static List<SendMessageRequest> captureAll(SqsClient client, int count) {
+        ArgumentCaptor<SendMessageRequest> req = ArgumentCaptor.forClass(SendMessageRequest.class);
+        verify(client, times(count)).sendMessage(req.capture());
+        return req.getAllValues();
+    }
+
+    /** Mirrors the exporter's dedup/group hashing so tests can pin the exact value it must emit. */
+    private static String sha256Hex(String input) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256").digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+                sb.append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
     @Test
     void standardQueueSendsAttributesAndArrayBodyWithoutFifoFields() {
         SqsClient client = mockClient();
@@ -77,7 +103,7 @@ class SQSExporterTest {
     }
 
     @Test
-    void fifoQueueDefaultsGroupIdToExecutionArnAndDerivesDedupId() {
+    void fifoQueueDefaultsGroupIdToExecutionArnAndDerivesHashedDedupId() {
         SqsClient client = mockClient();
         SQSExporter exporter =
                 SQSExporter.builder().queueUrl(FIFO_URL).client(client).build();
@@ -85,8 +111,95 @@ class SQSExporterTest {
         exporter.export(sampleRecord());
 
         SendMessageRequest req = capture(client);
-        assertEquals(EXEC_ARN, req.messageGroupId());
-        assertEquals(EXEC_ARN + ":2026-08-05T00:00:01Z", req.messageDeduplicationId());
+        assertEquals(EXEC_ARN, req.messageGroupId(), "a group id within 128 chars is used verbatim");
+        String expected = sha256Hex(EXEC_ARN + '\u0000' + "2026-08-05T00:00:01Z" + '\u0000' + req.messageBody());
+        assertEquals(expected, req.messageDeduplicationId(), "dedup id folds in arn, emittedAt, and body");
+        assertEquals(64, req.messageDeduplicationId().length(), "sha-256 hex is 64 chars, within SQS's 128 limit");
+    }
+
+    @Test
+    void fifoBoundsLongGroupIdToSqsLimitWithDeterministicHash() {
+        SqsClient client = mockClient();
+        SQSExporter exporter =
+                SQSExporter.builder().queueUrl(FIFO_URL).client(client).build();
+
+        WorkflowInsightRecord record = sampleRecord();
+        String longArn = "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST/durable-execution/"
+                + "e".repeat(200) + "/invocation-1";
+        assertTrue(longArn.length() > 128, "precondition: raw group id exceeds the SQS limit");
+        record.executionArn = longArn;
+
+        exporter.export(record);
+
+        SendMessageRequest req = capture(client);
+        assertEquals(64, req.messageGroupId().length(), "an over-long group id is replaced by a 64-char digest");
+        assertTrue(req.messageGroupId().length() <= 128, "group id is within the SQS 128-char limit");
+        assertEquals(sha256Hex(longArn), req.messageGroupId(), "group id hash is deterministic for the execution");
+    }
+
+    @Test
+    void fifoRapidSnapshotsWithSameTimestampGetDistinctDedupIdsButRetriesDeduplicate() {
+        SqsClient client = mockClient();
+        SQSExporter exporter =
+                SQSExporter.builder().queueUrl(FIFO_URL).client(client).build();
+
+        WorkflowInsightRecord first = sampleRecord();
+        WorkflowInsightRecord second = sampleRecord();
+        // Same execution and same emittedAt, but a distinct ON_CHANGE snapshot (an extra operation).
+        second.addOperation(new OperationRecord()
+                .id("op-2")
+                .name("verify")
+                .type("STEP")
+                .subType("Step")
+                .status("SUCCEEDED"));
+
+        exporter.export(first);
+        exporter.export(first); // exact retry of the first snapshot
+        exporter.export(second);
+
+        List<SendMessageRequest> reqs = captureAll(client, 3);
+        assertEquals(
+                reqs.get(0).messageDeduplicationId(),
+                reqs.get(1).messageDeduplicationId(),
+                "an exact retry produces the same dedup id so SQS de-duplicates it");
+        assertNotEquals(
+                reqs.get(0).messageDeduplicationId(),
+                reqs.get(2).messageDeduplicationId(),
+                "a distinct snapshot at the same timestamp produces a different dedup id");
+    }
+
+    @Test
+    void fifoByNameFormatStillDerivesBoundedDedupIdFromEmittedAt() {
+        SqsClient client = mockClient();
+        SQSExporter exporter = SQSExporter.builder()
+                .queueUrl(FIFO_URL)
+                .operationsFormat(SQSExporter.OperationsFormat.BY_NAME)
+                .client(client)
+                .build();
+
+        exporter.export(sampleRecord());
+
+        SendMessageRequest req = capture(client);
+        assertTrue(req.messageBody().contains("operationsByName"), "precondition: by-name shape is rendered");
+        String expected = sha256Hex(EXEC_ARN + '\u0000' + "2026-08-05T00:00:01Z" + '\u0000' + req.messageBody());
+        assertEquals(expected, req.messageDeduplicationId(), "emittedAt extraction is pinned across the by-name shape");
+    }
+
+    @Test
+    void fifoBothFormatStillDerivesBoundedDedupIdFromEmittedAt() {
+        SqsClient client = mockClient();
+        SQSExporter exporter = SQSExporter.builder()
+                .queueUrl(FIFO_URL)
+                .operationsFormat(SQSExporter.OperationsFormat.BOTH)
+                .client(client)
+                .build();
+
+        exporter.export(sampleRecord());
+
+        SendMessageRequest req = capture(client);
+        assertTrue(req.messageBody().contains("operationsByName"), "precondition: both shape is rendered");
+        String expected = sha256Hex(EXEC_ARN + '\u0000' + "2026-08-05T00:00:01Z" + '\u0000' + req.messageBody());
+        assertEquals(expected, req.messageDeduplicationId(), "emittedAt extraction is pinned across the both shape");
     }
 
     @Test
@@ -152,6 +265,20 @@ class SQSExporterTest {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> SQSExporter.builder().queueUrl("").client(mockClient()).build());
+    }
+
+    @Test
+    void builderRejectsNonPositiveMaxRecordSizeBytes() {
+        assertThrows(IllegalArgumentException.class, () -> SQSExporter.builder()
+                .queueUrl(STANDARD_URL)
+                .maxRecordSizeBytes(0)
+                .client(mockClient())
+                .build());
+        assertThrows(IllegalArgumentException.class, () -> SQSExporter.builder()
+                .queueUrl(STANDARD_URL)
+                .maxRecordSizeBytes(-1)
+                .client(mockClient())
+                .build());
     }
 
     @Test

--- a/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/SQSExporterTest.java
+++ b/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/SQSExporterTest.java
@@ -1,0 +1,167 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.insight;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.lambda.durable.insight.exporters.SQSExporter;
+
+class SQSExporterTest {
+
+    private static final String STANDARD_URL = "https://sqs.us-east-1.amazonaws.com/123456789012/insight";
+    private static final String FIFO_URL = "https://sqs.us-east-1.amazonaws.com/123456789012/insight.fifo";
+    private static final String EXEC_ARN =
+            "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST/durable-execution/exec-1/invocation-1";
+
+    private WorkflowInsightRecord sampleRecord() {
+        WorkflowInsightRecord r = new WorkflowInsightRecord();
+        r.executionArn = EXEC_ARN;
+        r.executionName = "exec-1";
+        r.functionName = "fn";
+        r.status = "SUCCEEDED";
+        r.startTime = "2026-08-05T00:00:00Z";
+        r.emittedAt = "2026-08-05T00:00:01Z";
+        r.addOperation(new OperationRecord()
+                .id("op-1")
+                .name("greet")
+                .type("STEP")
+                .subType("Step")
+                .status("SUCCEEDED"));
+        return r;
+    }
+
+    private static SqsClient mockClient() {
+        SqsClient client = mock(SqsClient.class);
+        when(client.sendMessage(any(SendMessageRequest.class)))
+                .thenReturn(SendMessageResponse.builder().build());
+        return client;
+    }
+
+    private static SendMessageRequest capture(SqsClient client) {
+        ArgumentCaptor<SendMessageRequest> req = ArgumentCaptor.forClass(SendMessageRequest.class);
+        verify(client).sendMessage(req.capture());
+        return req.getValue();
+    }
+
+    @Test
+    void standardQueueSendsAttributesAndArrayBodyWithoutFifoFields() {
+        SqsClient client = mockClient();
+        SQSExporter exporter =
+                SQSExporter.builder().queueUrl(STANDARD_URL).client(client).build();
+
+        exporter.export(sampleRecord());
+
+        SendMessageRequest req = capture(client);
+        assertEquals(STANDARD_URL, req.queueUrl());
+        assertNull(req.messageGroupId(), "standard queue carries no message group id");
+        assertNull(req.messageDeduplicationId(), "standard queue carries no dedup id");
+        assertEquals("SUCCEEDED", req.messageAttributes().get("status").stringValue());
+        assertEquals("fn", req.messageAttributes().get("functionName").stringValue());
+        assertEquals("String", req.messageAttributes().get("status").dataType());
+        assertTrue(req.messageBody().contains("\"operations\""), "array format emits the operations array");
+        assertFalse(req.messageBody().contains("operationsByName"), "array format omits the by-name map");
+        assertTrue(req.messageBody().contains("\"greet\""));
+    }
+
+    @Test
+    void fifoQueueDefaultsGroupIdToExecutionArnAndDerivesDedupId() {
+        SqsClient client = mockClient();
+        SQSExporter exporter =
+                SQSExporter.builder().queueUrl(FIFO_URL).client(client).build();
+
+        exporter.export(sampleRecord());
+
+        SendMessageRequest req = capture(client);
+        assertEquals(EXEC_ARN, req.messageGroupId());
+        assertEquals(EXEC_ARN + ":2026-08-05T00:00:01Z", req.messageDeduplicationId());
+    }
+
+    @Test
+    void fifoQueueHonorsExplicitMessageGroupId() {
+        SqsClient client = mockClient();
+        SQSExporter exporter = SQSExporter.builder()
+                .queueUrl(FIFO_URL)
+                .messageGroupId("custom-group")
+                .client(client)
+                .build();
+
+        exporter.export(sampleRecord());
+
+        assertEquals("custom-group", capture(client).messageGroupId());
+    }
+
+    @Test
+    void byNameFormatEmitsOperationsByNameMap() {
+        SqsClient client = mockClient();
+        SQSExporter exporter = SQSExporter.builder()
+                .queueUrl(STANDARD_URL)
+                .operationsFormat(SQSExporter.OperationsFormat.BY_NAME)
+                .client(client)
+                .build();
+
+        exporter.export(sampleRecord());
+
+        String body = capture(client).messageBody();
+        assertTrue(body.contains("operationsByName"), "by-name format emits the map");
+        assertFalse(body.contains("\"operations\":["), "by-name format replaces the array");
+    }
+
+    @Test
+    void bothFormatEmitsArrayAndByNameMap() {
+        SqsClient client = mockClient();
+        SQSExporter exporter = SQSExporter.builder()
+                .queueUrl(STANDARD_URL)
+                .operationsFormat(SQSExporter.OperationsFormat.BOTH)
+                .client(client)
+                .build();
+
+        exporter.export(sampleRecord());
+
+        String body = capture(client).messageBody();
+        assertTrue(body.contains("\"operations\":["), "both format keeps the array");
+        assertTrue(body.contains("operationsByName"), "both format also adds the map");
+    }
+
+    @Test
+    void defaultMaxRecordSizeIs256Kb() {
+        SQSExporter exporter = SQSExporter.builder()
+                .queueUrl(STANDARD_URL)
+                .client(mockClient())
+                .build();
+        assertEquals(256_000, exporter.maxRecordSizeBytes());
+    }
+
+    @Test
+    void builderRejectsMissingQueueUrl() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SQSExporter.builder().client(mockClient()).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SQSExporter.builder().queueUrl("").client(mockClient()).build());
+    }
+
+    @Test
+    void sendFailurePropagatesToCaller() {
+        SqsClient client = mock(SqsClient.class);
+        when(client.sendMessage(any(SendMessageRequest.class))).thenThrow(new RuntimeException("send failed"));
+        SQSExporter exporter =
+                SQSExporter.builder().queueUrl(STANDARD_URL).client(client).build();
+
+        RuntimeException e = assertThrows(RuntimeException.class, () -> exporter.export(sampleRecord()));
+        assertEquals("send failed", e.getMessage());
+    }
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Related: #679

### Description

Adds `SQSExporter` to the Workflow Insight plugin, so insight records can be shipped to an Amazon SQS queue. It is modeled on the existing `S3Exporter` and `CloudWatchLogsExporter` and mirrors the official JavaScript `SQSExporter` contract where practical. No change was made to the SDK core, `WorkflowInsight`, or `WorkflowInsightRecord`.

**Standard vs FIFO queues.** The queue type is detected from the URL: a `queueUrl` ending in `.fifo` is treated as FIFO. For a standard queue the `SendMessage` request carries no `MessageGroupId` and no `MessageDeduplicationId`. For a FIFO queue both are always set.

**FIFO id hashing, bounds, and dedup.** SQS caps both ids at 128 characters. The `MessageGroupId` is the explicit `messageGroupId` (else the `executionArn`) used verbatim when it is 128 characters or shorter, otherwise a deterministic 64-character SHA-256 hex digest of that raw value, so grouping stays stable per execution. The `MessageDeduplicationId` is always a 64-character SHA-256 digest of `executionArn \0 emittedAt \0 renderedBody`. Two different snapshots at the same `emittedAt` differ by body, so they get different dedup ids and both survive the SQS 5-minute dedup window; an exact retry has the same body and the same id, so SQS de-duplicates it. Hashing uses the JDK `java.security.MessageDigest`, no new dependency.

**Operation formats.** `operationsFormat` mirrors the JS enum: `ARRAY` (default), `BY_NAME`, and `BOTH`. `render()` produces the matching wire map. `BOTH` is built inside the exporter from the record's public API, so `WorkflowInsightRecord` needed no new method.

**Optional dependency.** The `sqs` Maven dependency is declared `<optional>true</optional>` with its version inherited from the imported AWS SDK BOM, matching the `s3` and `cloudwatchlogs` treatment, so default Lambda-log consumers do not inherit it.

**IAM docs.** The README documents the required `sqs:SendMessage` permission and FIFO queue setup alongside the usage and options.

**Size headroom.** `maxRecordSizeBytes` defaults to `256000` and bounds the rendered JSON body only. SQS counts message attributes toward the same 256 KB quota, so the default is left below the quota to leave attribute headroom. `build()` rejects a non-positive `maxRecordSizeBytes` (which previously disabled truncation silently).

### Demo/Screenshots

N/A -- backend-only change, no user-visible UI.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Yes. `SQSExporterTest` has 13 tests covering: standard-queue requests omit FIFO fields; FIFO default group id is the `executionArn` and dedup id is derived from `executionArn`/`emittedAt`/body; an explicit `messageGroupId` is honored; a long group id is bounded to a stable SHA-256 hash; rapid same-timestamp snapshots get distinct dedup ids while exact retries de-duplicate; `build()` rejects a non-positive `maxRecordSizeBytes`; and `BY_NAME` and `BOTH` render shapes still derive the bounded dedup id from `emittedAt`. Insight-plugin reactor: 82 tests, 0 failures. Full reactor `mvn install`: BUILD SUCCESS, 1954 tests, 0 failures, 31 skipped (cloud tests disabled by default).

#### Integration Tests

None added. The exporter is an isolated component fully covered by mocked-client unit tests, consistent with `S3ExporterTest` and `CloudWatchLogsExporterTest`, which are also unit-only.

#### Examples

No new example added.
