### PR TITLE
fix(insight): schedule exports off the hook threads

### DIFF
--- a/insight-plugin/README.md
+++ b/insight-plugin/README.md
@@ -92,8 +92,14 @@ application:
   then whole operations oldest-first, then execution input, then output — setting `truncated`,
   `droppedOperations`, `droppedInput`, `droppedOutput` as applicable. The size is measured against
   the exact shape each exporter emits (its `render`).
-- **Exporter isolation.** Every exporter is truncated, exported, and flushed independently; a
-  failing exporter is logged and never blocks the others or the execution.
+- **Exporter isolation.** Every exporter receives its own copy of each record, truncated to its own
+  limit; a failing or slow exporter is logged and never blocks the others or the execution.
+- **Export scheduling.** Exporter I/O never runs on the SDK threads that deliver plugin hooks.
+  Records are handed to a background worker that exports at most one record at a time; each
+  record is a complete snapshot, so while an export is in flight newer updates coalesce into a
+  single pending slot and only the latest is exported next. At invocation end the plugin waits
+  for the queue to drain and then flushes every exporter once, so the final record is always
+  delivered before the invocation returns.
 
 ## Conformance
 

--- a/insight-plugin/src/main/java/software/amazon/lambda/durable/insight/ExportScheduler.java
+++ b/insight-plugin/src/main/java/software/amazon/lambda/durable/insight/ExportScheduler.java
@@ -82,12 +82,14 @@ final class ExportScheduler {
             executor.execute(() -> pump(handle));
         } catch (Throwable t) {
             // No worker could be started. Keep the pending record and return to idle so a later schedule() retries,
-            // and drain() runs whatever is still pending on the calling thread before the invocation returns.
+            // and drain() runs whatever is still pending on the calling thread before the invocation returns. Complete
+            // the handle too: a drain() that already observed it must wake up and take that inline path.
             synchronized (this) {
                 if (inFlight == handle) {
                     inFlight = null;
                 }
             }
+            handle.complete(null);
             reportFailure(t);
         }
     }
@@ -148,17 +150,30 @@ final class ExportScheduler {
     }
 
     /**
+     * Flushes every exporter, each on its own worker, and waits for all of them to settle. A slow or failing flush on
+     * one exporter never delays or fails the others.
+     */
+    void flushAll() {
+        forEachExporterSettled(InsightExporter::flush);
+    }
+
+    /**
      * Exports one record to every exporter, each on its own worker, and waits for all of them to settle. One failing or
      * slow exporter never blocks or fails the others, and an export error never propagates into the execution.
      */
     private void exportToAll(WorkflowInsightRecord record) {
+        forEachExporterSettled(exporter -> exportOne.accept(record, exporter));
+    }
+
+    /** Runs the action for every exporter concurrently and returns once all have settled, reporting each failure. */
+    private void forEachExporterSettled(Consumer<InsightExporter> action) {
         if (exporters.size() == 1) {
-            runSafely(() -> exportOne.accept(record, exporters.get(0)));
+            runSafely(() -> action.accept(exporters.get(0)));
             return;
         }
         List<CompletableFuture<Void>> settled = new ArrayList<>(exporters.size());
         for (InsightExporter exporter : exporters) {
-            Runnable task = () -> runSafely(() -> exportOne.accept(record, exporter));
+            Runnable task = () -> runSafely(() -> action.accept(exporter));
             try {
                 settled.add(CompletableFuture.runAsync(task, executor));
             } catch (Throwable t) {

--- a/insight-plugin/src/main/java/software/amazon/lambda/durable/insight/ExportScheduler.java
+++ b/insight-plugin/src/main/java/software/amazon/lambda/durable/insight/ExportScheduler.java
@@ -1,0 +1,189 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.insight;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * Serializes record exports so that, at most, one export runs at a time.
+ *
+ * <p>Each {@link WorkflowInsightRecord} is a complete snapshot of the execution, so a newer record fully supersedes any
+ * record still waiting to be exported. While an export is in flight, additional updates are coalesced into a single
+ * "pending" slot — intermediate records are dropped because the latest one already contains all of their information.
+ * This prevents overlapping {@code export()} calls when updates arrive faster than the exporters can keep up, and it
+ * keeps exporter I/O off the SDK threads that deliver plugin hooks.
+ *
+ * <p>Exports are otherwise fire-and-forget; {@link #drain()} is called before the invocation returns to guarantee the
+ * final record is delivered.
+ */
+final class ExportScheduler {
+
+    private static final AtomicInteger THREAD_NUMBER = new AtomicInteger();
+
+    /** Shared for the process lifetime; idle daemon workers are reclaimed, so nothing keeps the runtime alive. */
+    private static final ExecutorService WORKERS = Executors.newCachedThreadPool(runnable -> {
+        var thread = new Thread(runnable, "workflow-insight-export-" + THREAD_NUMBER.incrementAndGet());
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private final List<InsightExporter> exporters;
+    private final BiConsumer<WorkflowInsightRecord, InsightExporter> exportOne;
+    private final Consumer<Throwable> failureHandler;
+    private final Executor executor;
+
+    /** Completes when the current pump finishes; {@code null} while idle. Guarded by {@code this}. */
+    private CompletableFuture<Void> inFlight;
+
+    /** The latest record not yet picked up by the pump. Guarded by {@code this}. */
+    private WorkflowInsightRecord pending;
+
+    ExportScheduler(
+            List<InsightExporter> exporters,
+            BiConsumer<WorkflowInsightRecord, InsightExporter> exportOne,
+            Consumer<Throwable> failureHandler) {
+        this(exporters, exportOne, failureHandler, WORKERS);
+    }
+
+    ExportScheduler(
+            List<InsightExporter> exporters,
+            BiConsumer<WorkflowInsightRecord, InsightExporter> exportOne,
+            Consumer<Throwable> failureHandler,
+            Executor executor) {
+        this.exporters = List.copyOf(exporters);
+        this.exportOne = exportOne;
+        this.failureHandler = failureHandler;
+        this.executor = executor;
+    }
+
+    /**
+     * Queues the latest record for export. If an export is already running, the record is held in the pending slot
+     * (replacing any earlier pending record) and exported once the in-flight export completes.
+     */
+    void schedule(WorkflowInsightRecord record) {
+        CompletableFuture<Void> handle;
+        synchronized (this) {
+            pending = record;
+            if (inFlight != null) {
+                return;
+            }
+            handle = new CompletableFuture<>();
+            inFlight = handle;
+        }
+        try {
+            executor.execute(() -> pump(handle));
+        } catch (Throwable t) {
+            // No worker could be started. Keep the pending record and return to idle so a later schedule() retries,
+            // and drain() runs whatever is still pending on the calling thread before the invocation returns.
+            synchronized (this) {
+                if (inFlight == handle) {
+                    inFlight = null;
+                }
+            }
+            reportFailure(t);
+        }
+    }
+
+    /**
+     * Waits for any in-flight and pending exports to complete. Safe to call when idle. Used before the invocation
+     * returns to guarantee the final record is delivered.
+     */
+    void drain() {
+        while (true) {
+            CompletableFuture<Void> handle;
+            boolean runInline = false;
+            synchronized (this) {
+                handle = inFlight;
+                if (handle == null) {
+                    if (pending == null) {
+                        return;
+                    }
+                    // A record is pending with no pump running (a worker could not be started): export it here.
+                    handle = new CompletableFuture<>();
+                    inFlight = handle;
+                    runInline = true;
+                }
+            }
+            if (runInline) {
+                pump(handle);
+            } else {
+                handle.join();
+            }
+        }
+    }
+
+    private void pump(CompletableFuture<Void> handle) {
+        try {
+            // Drain the pending slot until no newer record has arrived. Taking the record and returning to idle both
+            // happen under the lock, so an update scheduled at any point is either exported by this pump or starts
+            // the next one — never lost.
+            while (true) {
+                WorkflowInsightRecord record;
+                synchronized (this) {
+                    record = pending;
+                    pending = null;
+                    if (record == null) {
+                        inFlight = null;
+                        return;
+                    }
+                }
+                exportToAll(record);
+            }
+        } finally {
+            synchronized (this) {
+                if (inFlight == handle) {
+                    inFlight = null;
+                }
+            }
+            handle.complete(null);
+        }
+    }
+
+    /**
+     * Exports one record to every exporter, each on its own worker, and waits for all of them to settle. One failing or
+     * slow exporter never blocks or fails the others, and an export error never propagates into the execution.
+     */
+    private void exportToAll(WorkflowInsightRecord record) {
+        if (exporters.size() == 1) {
+            runSafely(() -> exportOne.accept(record, exporters.get(0)));
+            return;
+        }
+        List<CompletableFuture<Void>> settled = new ArrayList<>(exporters.size());
+        for (InsightExporter exporter : exporters) {
+            Runnable task = () -> runSafely(() -> exportOne.accept(record, exporter));
+            try {
+                settled.add(CompletableFuture.runAsync(task, executor));
+            } catch (Throwable t) {
+                reportFailure(t);
+                task.run();
+            }
+        }
+        for (CompletableFuture<Void> task : settled) {
+            runSafely(task::join);
+        }
+    }
+
+    private void runSafely(Runnable action) {
+        try {
+            action.run();
+        } catch (Throwable t) {
+            reportFailure(t);
+        }
+    }
+
+    private void reportFailure(Throwable t) {
+        try {
+            failureHandler.accept(t);
+        } catch (Throwable ignored) {
+            // A scheduler diagnostic must never disrupt durable execution.
+        }
+    }
+}

--- a/insight-plugin/src/main/java/software/amazon/lambda/durable/insight/WorkflowInsight.java
+++ b/insight-plugin/src/main/java/software/amazon/lambda/durable/insight/WorkflowInsight.java
@@ -76,12 +76,18 @@ public final class WorkflowInsight {
         private final ContentConfig content;
         private final Map<String, OperationOverride> overridesByName = new LinkedHashMap<>();
         private final List<InsightExporter> exporters;
+        private final ExportScheduler scheduler;
 
         private final Map<String, ExecutionState> byArn = new ConcurrentHashMap<>();
 
         /** Test seam: number of live per-execution state entries retained across invocations. */
         int retainedStateCount() {
             return byArn.size();
+        }
+
+        /** Test seam: waits until every scheduled record has been handed to the exporters. */
+        void drainExports() {
+            scheduler.drain();
         }
 
         InsightPlugin(WorkflowInsightConfig config) {
@@ -97,6 +103,8 @@ public final class WorkflowInsight {
             }
             this.exporters =
                     config.exporters().isEmpty() ? List.of(new LambdaLogExporter()) : List.copyOf(config.exporters());
+            this.scheduler =
+                    new ExportScheduler(exporters, this::exportRecord, t -> logSafely("export scheduling failed", t));
         }
 
         private ExecutionState getState(String arn, Instant startTime) {
@@ -123,7 +131,7 @@ public final class WorkflowInsight {
                     state.cachedInput = null;
                 }
                 if (emitMode == WorkflowInsightConfig.EmitMode.ON_CHANGE) {
-                    emit(buildRecord(
+                    scheduler.schedule(buildRecord(
                             state,
                             info.durableExecutionArn(),
                             "RUNNING",
@@ -148,7 +156,7 @@ public final class WorkflowInsight {
                 if (state == null || !state.sampledIn) {
                     return;
                 }
-                emit(buildRecord(
+                scheduler.schedule(buildRecord(
                         state,
                         info.durableExecutionArn(),
                         "RUNNING",
@@ -162,10 +170,14 @@ public final class WorkflowInsight {
             }
         }
 
+        // onInvocationEnd is the hook the SDK awaits, so it is where the export queue is drained before the invocation
+        // returns; this guarantees the final record (scheduled above the drain) is delivered. The drain and flush run
+        // in finally so they also cover the paths where record construction fails.
         @Override
         public void onInvocationEnd(InvocationEndInfo info) {
+            ExecutionState state = null;
             try {
-                ExecutionState state = getState(info.durableExecutionArn(), info.executionStartTime());
+                state = getState(info.durableExecutionArn(), info.executionStartTime());
                 String status = mapStatus(info.invocationStatus());
                 boolean isTerminal = "SUCCEEDED".equals(status) || "FAILED".equals(status);
                 boolean isFailure = "FAILED".equals(status);
@@ -184,7 +196,7 @@ public final class WorkflowInsight {
                 }
 
                 if (state.sampledIn && shouldEmit) {
-                    emit(buildRecord(
+                    scheduler.schedule(buildRecord(
                             state,
                             info.durableExecutionArn(),
                             status,
@@ -199,6 +211,11 @@ public final class WorkflowInsight {
                 // or optional exporter class linkage) must never disrupt durable execution.
                 logSafely("onInvocationEnd failed", t);
             } finally {
+                // Sampled-out executions never schedule a record, so there is nothing to drain or flush. If the state
+                // lookup itself failed, drain anyway: it is a no-op when idle and otherwise delivers what is pending.
+                if (state == null || state.sampledIn) {
+                    drainAndFlush();
+                }
                 // Remove per-execution state on EVERY invocation end, including non-terminal PENDING/RETRYING suspends,
                 // once any emission work above is done. Nothing durable is lost: the next invocation's onInvocation
                 // start recreates the stable startTime from InvocationInfo.executionStartTime() (stable across
@@ -211,25 +228,38 @@ public final class WorkflowInsight {
             }
         }
 
-        /** Serializes each record to every exporter, isolating failures so one exporter never blocks the others. */
-        private void emit(WorkflowInsightRecord record) {
+        /** Waits for every scheduled record to reach the exporters, then flushes each exporter once. */
+        private void drainAndFlush() {
+            try {
+                scheduler.drain();
+            } catch (Throwable t) {
+                logSafely("failed to drain export scheduler", t);
+            }
             for (InsightExporter exporter : exporters) {
                 try {
-                    // Give each exporter its own deep copy: truncation returns the original record when it already
-                    // fits, so without this a custom exporter that mutates operations or nested content would corrupt
-                    // every exporter that runs after it.
-                    WorkflowInsightRecord isolated = record.deepCopy();
-                    WorkflowInsightRecord shaped =
-                            Truncation.truncateRecord(isolated, exporter.maxRecordSizeBytes(), exporter::render);
-                    exporter.export(shaped);
                     exporter.flush();
                 } catch (Throwable t) {
-                    // Catch Throwable, not just RuntimeException: deep copy, truncation, an exporter's render/export/
-                    // flush, or the linkage of an optional exporter class (a NoClassDefFoundError when the S3 /
-                    // CloudWatch SDK is absent) can each fail with an Error. Isolating every Throwable here guarantees
-                    // one failing exporter cannot block the exporters that run after it, nor disrupt the execution.
-                    logSafely("exporter failed", t);
+                    logSafely("exporter flush failed", t);
                 }
+            }
+        }
+
+        /** Shapes and exports one record to one exporter; runs on a scheduler worker, never on an SDK hook thread. */
+        private void exportRecord(WorkflowInsightRecord record, InsightExporter exporter) {
+            try {
+                // Give each exporter its own deep copy: truncation returns the original record when it already fits,
+                // so without this a custom exporter that mutates operations or nested content would corrupt every
+                // other exporter's view of the same record.
+                WorkflowInsightRecord isolated = record.deepCopy();
+                WorkflowInsightRecord shaped =
+                        Truncation.truncateRecord(isolated, exporter.maxRecordSizeBytes(), exporter::render);
+                exporter.export(shaped);
+            } catch (Throwable t) {
+                // Catch Throwable, not just RuntimeException: deep copy, truncation, an exporter's render/export, or
+                // the linkage of an optional exporter class (a NoClassDefFoundError when the S3 / CloudWatch SDK is
+                // absent) can each fail with an Error. Isolating every Throwable here guarantees one failing exporter
+                // cannot affect the others, nor disrupt the execution.
+                logSafely("exporter failed", t);
             }
         }
 

--- a/insight-plugin/src/main/java/software/amazon/lambda/durable/insight/WorkflowInsight.java
+++ b/insight-plugin/src/main/java/software/amazon/lambda/durable/insight/WorkflowInsight.java
@@ -61,10 +61,38 @@ public final class WorkflowInsight {
         final boolean sampledIn;
         volatile Object cachedInput;
 
+        /**
+         * Set once invocation end begins; guarded by {@code this}. A checkpoint that completes while the end record is
+         * being drained still delivers an operation-change hook, and that RUNNING snapshot must not supersede the final
+         * record.
+         */
+        boolean closed;
+
         ExecutionState(Instant startTime, ArnParser arn, boolean sampledIn) {
             this.startTime = startTime;
             this.arn = arn;
             this.sampledIn = sampledIn;
+        }
+
+        /** Schedules the record unless the invocation has already ended; the check and the hand-off are atomic. */
+        boolean scheduleIfOpen(ExportScheduler scheduler, WorkflowInsightRecord record) {
+            synchronized (this) {
+                if (closed) {
+                    return false;
+                }
+                scheduler.schedule(record);
+                return true;
+            }
+        }
+
+        /** Marks the invocation ended and, when given a record, schedules it as the last one for this execution. */
+        void closeAndSchedule(ExportScheduler scheduler, WorkflowInsightRecord finalRecord) {
+            synchronized (this) {
+                closed = true;
+                if (finalRecord != null) {
+                    scheduler.schedule(finalRecord);
+                }
+            }
         }
     }
 
@@ -156,15 +184,17 @@ public final class WorkflowInsight {
                 if (state == null || !state.sampledIn) {
                     return;
                 }
-                scheduler.schedule(buildRecord(
-                        state,
-                        info.durableExecutionArn(),
-                        "RUNNING",
-                        info.operations(),
-                        null,
-                        state.cachedInput,
-                        null,
-                        null));
+                state.scheduleIfOpen(
+                        scheduler,
+                        buildRecord(
+                                state,
+                                info.durableExecutionArn(),
+                                "RUNNING",
+                                info.operations(),
+                                null,
+                                state.cachedInput,
+                                null,
+                                null));
             } catch (Throwable t) {
                 logSafely("onOperationChange failed", t);
             }
@@ -195,8 +225,9 @@ public final class WorkflowInsight {
                         break;
                 }
 
+                WorkflowInsightRecord finalRecord = null;
                 if (state.sampledIn && shouldEmit) {
-                    scheduler.schedule(buildRecord(
+                    finalRecord = buildRecord(
                             state,
                             info.durableExecutionArn(),
                             status,
@@ -204,13 +235,21 @@ public final class WorkflowInsight {
                             Instant.now(),
                             state.cachedInput,
                             info.executionResult(),
-                            info.executionError()));
+                            info.executionError());
                 }
+                // Close before the drain below: an operation-change hook arriving from a checkpoint that completes
+                // during the drain is rejected, so no RUNNING snapshot can follow (or replace) the final record.
+                state.closeAndSchedule(scheduler, finalRecord);
             } catch (Throwable t) {
                 // A plugin failure at end-of-invocation (record construction, transforms, truncation, export/flush,
                 // or optional exporter class linkage) must never disrupt durable execution.
                 logSafely("onInvocationEnd failed", t);
             } finally {
+                // If record construction failed above, the state is still open: close it so a late change hook cannot
+                // schedule into the drain. Idempotent when already closed.
+                if (state != null) {
+                    state.closeAndSchedule(scheduler, null);
+                }
                 // Sampled-out executions never schedule a record, so there is nothing to drain or flush. If the state
                 // lookup itself failed, drain anyway: it is a no-op when idle and otherwise delivers what is pending.
                 if (state == null || state.sampledIn) {
@@ -228,19 +267,17 @@ public final class WorkflowInsight {
             }
         }
 
-        /** Waits for every scheduled record to reach the exporters, then flushes each exporter once. */
+        /** Waits for every scheduled record to reach the exporters, then flushes each exporter once, concurrently. */
         private void drainAndFlush() {
             try {
                 scheduler.drain();
             } catch (Throwable t) {
                 logSafely("failed to drain export scheduler", t);
             }
-            for (InsightExporter exporter : exporters) {
-                try {
-                    exporter.flush();
-                } catch (Throwable t) {
-                    logSafely("exporter flush failed", t);
-                }
+            try {
+                scheduler.flushAll();
+            } catch (Throwable t) {
+                logSafely("exporter flush failed", t);
             }
         }
 

--- a/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/ExportSchedulerTest.java
+++ b/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/ExportSchedulerTest.java
@@ -260,6 +260,108 @@ class ExportSchedulerTest {
         assertEquals(1, exporter.records.size());
     }
 
+    @Test
+    void aDrainThatObservedTheHandleBeforeTheWorkerWasRejectedStillCompletesInline() throws Exception {
+        var submitted = new CountDownLatch(1);
+        var proceed = new CountDownLatch(1);
+        Executor blockingRejector = command -> {
+            submitted.countDown();
+            await(proceed);
+            throw new RejectedExecutionException("no worker");
+        };
+        var failures = new CopyOnWriteArrayList<Throwable>();
+        var exporter = new CapturingExporter();
+        var scheduler = scheduler(blockingRejector, failures, exporter);
+
+        var scheduling = new Thread(() -> scheduler.schedule(record("final")), "scheduling");
+        scheduling.start();
+        assertTrue(submitted.await(5, TimeUnit.SECONDS), "the pump handle is published before execute rejects");
+
+        var drained = new CountDownLatch(1);
+        var drainer = new Thread(
+                () -> {
+                    scheduler.drain();
+                    drained.countDown();
+                },
+                "drainer");
+        drainer.start();
+        Thread.sleep(100); // let the drainer observe the in-flight handle and block on it
+
+        proceed.countDown();
+        scheduling.join(5_000);
+        assertTrue(drained.await(5, TimeUnit.SECONDS), "the rejected handle is completed, so the drainer wakes up");
+        assertEquals(List.of("final"), statuses(exporter));
+        assertEquals("drainer", exporter.threads.get(0).getName(), "the drainer exports the pending record inline");
+        assertEquals(1, failures.size());
+    }
+
+    @Test
+    void flushAllRunsExporterFlushesConcurrentlySoASlowFlushDoesNotDelayTheOthers() throws Exception {
+        var release = new CountDownLatch(1);
+        var fastFlushed = new CountDownLatch(1);
+        var slow = new InsightExporter() {
+            @Override
+            public void export(WorkflowInsightRecord record) {}
+
+            @Override
+            public void flush() {
+                await(release);
+            }
+        };
+        var fast = new InsightExporter() {
+            @Override
+            public void export(WorkflowInsightRecord record) {}
+
+            @Override
+            public void flush() {
+                fastFlushed.countDown();
+            }
+        };
+        var scheduler = scheduler(sharedWorkers(), new ArrayList<>(), slow, fast);
+
+        var flushed = new CountDownLatch(1);
+        new Thread(() -> {
+                    scheduler.flushAll();
+                    flushed.countDown();
+                })
+                .start();
+
+        assertTrue(fastFlushed.await(5, TimeUnit.SECONDS), "fast exporter flushed while the slow one is blocked");
+        assertFalse(flushed.await(100, TimeUnit.MILLISECONDS), "flushAll waits for every exporter");
+        release.countDown();
+        assertTrue(flushed.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void flushAllIsolatesAFailingFlush() {
+        var failures = new CopyOnWriteArrayList<Throwable>();
+        var flushed = new CountDownLatch(1);
+        var bad = new InsightExporter() {
+            @Override
+            public void export(WorkflowInsightRecord record) {}
+
+            @Override
+            public void flush() {
+                throw new IllegalStateException("flush failed");
+            }
+        };
+        var good = new InsightExporter() {
+            @Override
+            public void export(WorkflowInsightRecord record) {}
+
+            @Override
+            public void flush() {
+                flushed.countDown();
+            }
+        };
+        var scheduler = scheduler(sharedWorkers(), failures, bad, good);
+
+        scheduler.flushAll();
+
+        assertEquals(0, flushed.getCount(), "the healthy exporter still flushed");
+        assertEquals(1, failures.size());
+    }
+
     private static List<String> statuses(CapturingExporter exporter) {
         List<String> out = new ArrayList<>();
         for (WorkflowInsightRecord r : exporter.records) {

--- a/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/ExportSchedulerTest.java
+++ b/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/ExportSchedulerTest.java
@@ -1,0 +1,285 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.lambda.durable.insight;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/** Contract tests for {@link ExportScheduler}: serial exports, latest-wins coalescing, drain, and exporter fan-out. */
+class ExportSchedulerTest {
+
+    /** Runs submitted tasks only when the test asks, so pump timing is fully controlled. */
+    private static final class ManualExecutor implements Executor {
+        final Deque<Runnable> tasks = new ArrayDeque<>();
+        int submissions;
+        boolean reject;
+
+        @Override
+        public void execute(Runnable command) {
+            if (reject) {
+                throw new RejectedExecutionException("no worker");
+            }
+            submissions++;
+            tasks.add(command);
+        }
+
+        void runAll() {
+            Runnable task;
+            while ((task = tasks.poll()) != null) {
+                task.run();
+            }
+        }
+    }
+
+    private static class CapturingExporter implements InsightExporter {
+        final List<WorkflowInsightRecord> records = new CopyOnWriteArrayList<>();
+        final List<Thread> threads = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void export(WorkflowInsightRecord record) {
+            records.add(record);
+            threads.add(Thread.currentThread());
+        }
+    }
+
+    private static WorkflowInsightRecord record(String status) {
+        var r = new WorkflowInsightRecord();
+        r.status = status;
+        return r;
+    }
+
+    private static ExportScheduler scheduler(
+            Executor executor, List<Throwable> failures, InsightExporter... exporters) {
+        return new ExportScheduler(List.of(exporters), (rec, exp) -> exp.export(rec), failures::add, executor);
+    }
+
+    @Test
+    void scheduleHandsTheRecordToAWorkerRatherThanExportingOnTheCallingThread() {
+        var executor = new ManualExecutor();
+        var exporter = new CapturingExporter();
+        var scheduler = scheduler(executor, new ArrayList<>(), exporter);
+
+        scheduler.schedule(record("RUNNING"));
+        assertTrue(exporter.records.isEmpty(), "nothing exported until a worker runs");
+
+        executor.runAll();
+        assertEquals(1, exporter.records.size());
+        assertEquals("RUNNING", exporter.records.get(0).status());
+    }
+
+    @Test
+    void updatesScheduledBeforeTheWorkerRunsCollapseIntoTheLatestRecord() {
+        var executor = new ManualExecutor();
+        var exporter = new CapturingExporter();
+        var scheduler = scheduler(executor, new ArrayList<>(), exporter);
+
+        scheduler.schedule(record("r1"));
+        scheduler.schedule(record("r2"));
+        scheduler.schedule(record("r3"));
+        executor.runAll();
+
+        assertEquals(1, exporter.records.size(), "one pump, one latest record");
+        assertEquals("r3", exporter.records.get(0).status());
+        assertEquals(1, executor.submissions, "only one worker was ever requested");
+    }
+
+    @Test
+    void recordScheduledAfterAPumpFinishesStartsANewPump() {
+        var executor = new ManualExecutor();
+        var exporter = new CapturingExporter();
+        var scheduler = scheduler(executor, new ArrayList<>(), exporter);
+
+        scheduler.schedule(record("first"));
+        executor.runAll();
+        scheduler.schedule(record("second"));
+        executor.runAll();
+
+        assertEquals(List.of("first", "second"), statuses(exporter));
+    }
+
+    @Test
+    void updatesArrivingWhileAnExportIsInFlightAreCoalescedAndExportedAfterIt() throws Exception {
+        var entered = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        var exporter = new CapturingExporter() {
+            @Override
+            public void export(WorkflowInsightRecord record) {
+                super.export(record);
+                if (records.size() == 1) {
+                    entered.countDown();
+                    await(release);
+                }
+            }
+        };
+        var scheduler = scheduler(sharedWorkers(), new ArrayList<>(), exporter);
+
+        scheduler.schedule(record("first"));
+        assertTrue(entered.await(5, TimeUnit.SECONDS), "first export is in flight");
+        scheduler.schedule(record("dropped-1"));
+        scheduler.schedule(record("dropped-2"));
+        scheduler.schedule(record("final"));
+        release.countDown();
+        scheduler.drain();
+
+        assertEquals(List.of("first", "final"), statuses(exporter));
+    }
+
+    @Test
+    void drainReturnsImmediatelyWhenIdle() {
+        var scheduler = scheduler(new ManualExecutor(), new ArrayList<>(), new CapturingExporter());
+        scheduler.drain();
+        scheduler.drain();
+    }
+
+    @Test
+    void drainWaitsForTheInFlightExportAndEveryPendingRecord() throws Exception {
+        var entered = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        var exporter = new CapturingExporter() {
+            @Override
+            public void export(WorkflowInsightRecord record) {
+                super.export(record);
+                if (records.size() == 1) {
+                    entered.countDown();
+                    await(release);
+                }
+            }
+        };
+        var scheduler = scheduler(sharedWorkers(), new ArrayList<>(), exporter);
+
+        scheduler.schedule(record("slow"));
+        assertTrue(entered.await(5, TimeUnit.SECONDS));
+        scheduler.schedule(record("final"));
+
+        var drained = new CountDownLatch(1);
+        var drainer = new Thread(() -> {
+            scheduler.drain();
+            drained.countDown();
+        });
+        drainer.start();
+        assertFalse(drained.await(200, TimeUnit.MILLISECONDS), "drain blocks while an export is in flight");
+
+        release.countDown();
+        assertTrue(drained.await(5, TimeUnit.SECONDS), "drain completes once the queue is empty");
+        assertEquals(List.of("slow", "final"), statuses(exporter));
+    }
+
+    @Test
+    void exportersRunOffTheSchedulingThread() {
+        var exporter = new CapturingExporter();
+        var scheduler = scheduler(sharedWorkers(), new ArrayList<>(), exporter);
+
+        scheduler.schedule(record("RUNNING"));
+        scheduler.drain();
+
+        assertEquals(1, exporter.threads.size());
+        assertNotSame(Thread.currentThread(), exporter.threads.get(0));
+    }
+
+    @Test
+    void aFailingExporterNeverBlocksTheOthersForTheSameRecord() {
+        var failures = new CopyOnWriteArrayList<Throwable>();
+        var good = new CapturingExporter();
+        InsightExporter bad = record -> {
+            throw new AssertionError("exporter blew up");
+        };
+        var scheduler = scheduler(sharedWorkers(), failures, bad, good);
+
+        scheduler.schedule(record("RUNNING"));
+        scheduler.drain();
+
+        assertEquals(1, good.records.size());
+        assertEquals(1, failures.size());
+        assertTrue(failures.get(0) instanceof AssertionError);
+    }
+
+    @Test
+    void exportersForOneRecordRunConcurrentlySoASlowExporterDoesNotDelayTheOthers() throws Exception {
+        var release = new CountDownLatch(1);
+        var fast = new CapturingExporter();
+        InsightExporter slow = record -> await(release);
+        var scheduler = scheduler(sharedWorkers(), new ArrayList<>(), slow, fast);
+
+        scheduler.schedule(record("RUNNING"));
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (fast.records.isEmpty() && System.nanoTime() < deadline) {
+            Thread.sleep(5);
+        }
+        assertEquals(1, fast.records.size(), "fast exporter received the record while the slow one is still blocked");
+
+        release.countDown();
+        scheduler.drain();
+    }
+
+    @Test
+    void drainExportsThePendingRecordInlineWhenNoWorkerCouldBeStarted() {
+        var executor = new ManualExecutor();
+        executor.reject = true;
+        var failures = new ArrayList<Throwable>();
+        var exporter = new CapturingExporter();
+        var scheduler = scheduler(executor, failures, exporter);
+
+        scheduler.schedule(record("final"));
+        assertTrue(exporter.records.isEmpty(), "the hook thread does not export");
+        assertEquals(1, failures.size(), "the worker failure is reported");
+
+        scheduler.drain();
+
+        assertEquals(List.of("final"), statuses(exporter));
+        assertSame(Thread.currentThread(), exporter.threads.get(0), "the invocation boundary delivers it");
+    }
+
+    @Test
+    void aLaterScheduleRetriesTheWorkerAfterARejection() {
+        var executor = new ManualExecutor();
+        executor.reject = true;
+        var exporter = new CapturingExporter();
+        var scheduler = scheduler(executor, new ArrayList<>(), exporter);
+
+        scheduler.schedule(record("older"));
+        executor.reject = false;
+        scheduler.schedule(record("newer"));
+        executor.runAll();
+
+        assertEquals(List.of("newer"), statuses(exporter), "the retry exports the latest record");
+        scheduler.drain();
+        assertEquals(1, exporter.records.size());
+    }
+
+    private static List<String> statuses(CapturingExporter exporter) {
+        List<String> out = new ArrayList<>();
+        for (WorkflowInsightRecord r : exporter.records) {
+            out.add(r.status());
+        }
+        return out;
+    }
+
+    private static Executor sharedWorkers() {
+        return command -> new Thread(command, "test-export-worker").start();
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                throw new AssertionError("latch not released");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/ExporterIsolationTest.java
+++ b/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/ExporterIsolationTest.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
-import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
 import software.amazon.lambda.durable.plugin.InvocationInfo;
 import software.amazon.lambda.durable.plugin.OperationChangeItemInfo;
 
@@ -70,7 +69,7 @@ class ExporterIsolationTest {
     void firstExporterMutationsDoNotLeakIntoLaterExporter() {
         var mutating = new MutatingExporter();
         var good = new CapturingExporter();
-        DurableExecutionPlugin plugin = WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
+        var plugin = (WorkflowInsight.InsightPlugin) WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
                 .emitMode(WorkflowInsightConfig.EmitMode.ON_CHANGE)
                 .content(ContentConfig.builder()
                         .addOverride(OperationOverride.withResult("compute", r -> r))
@@ -99,6 +98,7 @@ class ExporterIsolationTest {
                         null,
                         "{\"x\":1}"));
         plugin.onInvocationStart(new InvocationInfo("req", ARN, true, START, input, ops, Map.of()));
+        plugin.drainExports();
 
         assertEquals(1, good.records.size());
         var rec = good.records.get(0);

--- a/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/InputSnapshotTest.java
+++ b/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/InputSnapshotTest.java
@@ -99,7 +99,7 @@ class InputSnapshotTest {
             return v;
         };
         var exporter = new CapturingExporter();
-        DurableExecutionPlugin plugin = WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
+        var plugin = (WorkflowInsight.InsightPlugin) WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
                 .emitMode(WorkflowInsightConfig.EmitMode.ON_CHANGE)
                 .content(ContentConfig.builder()
                         .inputTransform(mutatingTransform)
@@ -113,7 +113,9 @@ class InputSnapshotTest {
         input.put("items", items);
 
         plugin.onInvocationStart(new InvocationInfo("req", ARN, true, START, input, ops(), Map.of()));
+        plugin.drainExports();
         plugin.onOperationChange(new OperationChangeInfo("req", ARN, ops(), ops()));
+        plugin.drainExports();
         plugin.onInvocationEnd(
                 new InvocationEndInfo("req", ARN, true, START, ops(), InvocationStatus.SUCCEEDED, null, input, "out"));
 

--- a/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/JsonJavaTimeTest.java
+++ b/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/JsonJavaTimeTest.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
-import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
 import software.amazon.lambda.durable.plugin.InvocationInfo;
 import software.amazon.lambda.durable.plugin.OperationChangeItemInfo;
 
@@ -56,7 +55,7 @@ class JsonJavaTimeTest {
     @Test
     void pluginOutputWithInstantInInputSerializesInsteadOfDropping() {
         var exporter = new CapturingExporter();
-        DurableExecutionPlugin plugin = WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
+        var plugin = (WorkflowInsight.InsightPlugin) WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
                 .emitMode(WorkflowInsightConfig.EmitMode.ON_CHANGE)
                 .addExporter(exporter)
                 .build());
@@ -80,6 +79,7 @@ class JsonJavaTimeTest {
                         null,
                         null));
         plugin.onInvocationStart(new InvocationInfo("req", ARN, true, START, input, ops, Map.of()));
+        plugin.drainExports();
 
         assertEquals(1, exporter.records.size());
         var rec = exporter.records.get(0);

--- a/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/MutableNumberIsolationTest.java
+++ b/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/MutableNumberIsolationTest.java
@@ -17,7 +17,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
-import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
 import software.amazon.lambda.durable.plugin.InvocationInfo;
 import software.amazon.lambda.durable.plugin.OperationChangeItemInfo;
 
@@ -114,7 +113,7 @@ class MutableNumberIsolationTest {
             }
         };
         var good = new CapturingExporter();
-        DurableExecutionPlugin plugin = WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
+        var plugin = (WorkflowInsight.InsightPlugin) WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
                 .emitMode(WorkflowInsightConfig.EmitMode.ON_CHANGE)
                 .addExporter(mutating)
                 .addExporter(good)
@@ -129,6 +128,7 @@ class MutableNumberIsolationTest {
         input.put("custom", new MutableNumber(99));
 
         plugin.onInvocationStart(new InvocationInfo("req", ARN, true, START, input, ops(), Map.of()));
+        plugin.drainExports();
         // Mutate all originals after emission; isolated copies must be unaffected.
         topLevel.set(-1);
         ((AtomicLong) list.get(0)).set(-1L);

--- a/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/OperationOrderingTest.java
+++ b/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/OperationOrderingTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
-import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
 import software.amazon.lambda.durable.plugin.InvocationInfo;
 import software.amazon.lambda.durable.plugin.OperationChangeItemInfo;
 
@@ -45,11 +44,12 @@ class OperationOrderingTest {
 
     private WorkflowInsightRecord emitStart(Map<String, OperationChangeItemInfo> ops) {
         var exporter = new CapturingExporter();
-        DurableExecutionPlugin plugin = WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
+        var plugin = (WorkflowInsight.InsightPlugin) WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
                 .emitMode(WorkflowInsightConfig.EmitMode.ON_CHANGE)
                 .addExporter(exporter)
                 .build());
         plugin.onInvocationStart(new InvocationInfo("req", ARN, true, START, "in", ops, Map.of()));
+        plugin.drainExports();
         return exporter.records.get(0);
     }
 

--- a/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/WorkflowInsightHookTest.java
+++ b/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/WorkflowInsightHookTest.java
@@ -7,10 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
@@ -32,12 +32,14 @@ class WorkflowInsightHookTest {
     private static final Instant START = Instant.parse("2026-08-05T00:00:00Z");
 
     private static final class CapturingExporter implements InsightExporter {
-        final List<WorkflowInsightRecord> records = new ArrayList<>();
-        int flushes;
+        final List<WorkflowInsightRecord> records = new CopyOnWriteArrayList<>();
+        final List<Thread> threads = new CopyOnWriteArrayList<>();
+        volatile int flushes;
 
         @Override
         public void export(WorkflowInsightRecord record) {
             records.add(record);
+            threads.add(Thread.currentThread());
         }
 
         @Override
@@ -67,20 +69,65 @@ class WorkflowInsightHookTest {
     @Test
     void onChangeEmitsAtStartChangeAndEnd() {
         var exporter = new CapturingExporter();
-        DurableExecutionPlugin plugin = WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
+        var plugin = (WorkflowInsight.InsightPlugin) WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
                 .emitMode(WorkflowInsightConfig.EmitMode.ON_CHANGE)
                 .addExporter(exporter)
                 .build());
 
+        // Let each scheduled export land before the next hook so all three snapshots are observable; back-to-back
+        // hooks may otherwise coalesce into the latest record (covered separately below).
         plugin.onInvocationStart(start(true));
+        plugin.drainExports();
         plugin.onOperationChange(new OperationChangeInfo(
                 "req", ARN, ops("greet", OperationStatus.SUCCEEDED), ops("greet", OperationStatus.SUCCEEDED)));
+        plugin.drainExports();
         plugin.onInvocationEnd(end(InvocationStatus.SUCCEEDED, "out", null));
 
         assertEquals(3, exporter.records.size());
         assertEquals("RUNNING", exporter.records.get(0).status());
         assertEquals("RUNNING", exporter.records.get(1).status());
         assertEquals("SUCCEEDED", exporter.records.get(2).status());
+        assertEquals(1, exporter.flushes, "exporters are flushed once, at invocation end");
+    }
+
+    @Test
+    void onChangeExportsOffTheHookThreadAndCoalescesBurstsIntoTheLatestRecord() {
+        var exporter = new CapturingExporter();
+        var plugin = (WorkflowInsight.InsightPlugin) WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
+                .emitMode(WorkflowInsightConfig.EmitMode.ON_CHANGE)
+                .addExporter(exporter)
+                .build());
+
+        plugin.onInvocationStart(start(true));
+        for (int i = 0; i < 20; i++) {
+            plugin.onOperationChange(new OperationChangeInfo(
+                    "req", ARN, ops("greet", OperationStatus.SUCCEEDED), ops("greet", OperationStatus.SUCCEEDED)));
+        }
+        plugin.onInvocationEnd(end(InvocationStatus.SUCCEEDED, "out", null));
+
+        // Intermediate RUNNING snapshots may be superseded while an export is in flight, but the final record is always
+        // delivered, always last, and no export ever ran on the thread that delivered the hooks.
+        assertFalse(exporter.records.isEmpty());
+        assertTrue(exporter.records.size() <= 22, "no duplicate exports");
+        var last = exporter.records.get(exporter.records.size() - 1);
+        assertEquals("SUCCEEDED", last.status());
+        assertTrue(exporter.records.subList(0, exporter.records.size() - 1).stream()
+                .allMatch(r -> "RUNNING".equals(r.status())));
+        assertTrue(exporter.threads.stream().noneMatch(t -> t == Thread.currentThread()));
+        assertEquals(1, exporter.flushes);
+    }
+
+    @Test
+    void invocationEndFlushesExportersEvenWhenNothingWasEmitted() {
+        var exporter = new CapturingExporter();
+        DurableExecutionPlugin plugin = WorkflowInsight.workflowInsight(
+                WorkflowInsightConfig.builder().addExporter(exporter).build());
+
+        plugin.onInvocationStart(start(true));
+        plugin.onInvocationEnd(end(InvocationStatus.PENDING, null, null));
+
+        assertTrue(exporter.records.isEmpty(), "on-complete emits nothing for a suspend");
+        assertEquals(1, exporter.flushes, "the invocation boundary still flushes buffered exporters");
     }
 
     @Test
@@ -107,8 +154,10 @@ class WorkflowInsightHookTest {
                 .build());
 
         plugin.onInvocationStart(start(true)); // first invocation
+        plugin.drainExports();
         plugin.onInvocationEnd(end(InvocationStatus.PENDING, null, null)); // suspend -> state removed
         plugin.onInvocationStart(start(false)); // resume invocation re-seeds state
+        plugin.drainExports();
         plugin.onInvocationEnd(end(InvocationStatus.SUCCEEDED, "out", null)); // resume + terminal
 
         // start(RUNNING) + pending(RUNNING) + resume-start(RUNNING) + terminal(SUCCEEDED); all share the stable

--- a/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/WorkflowInsightHookTest.java
+++ b/insight-plugin/src/test/java/software/amazon/lambda/durable/insight/WorkflowInsightHookTest.java
@@ -11,6 +11,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.lambda.model.OperationStatus;
 import software.amazon.lambda.durable.plugin.DurableExecutionPlugin;
@@ -31,7 +33,7 @@ class WorkflowInsightHookTest {
             "arn:aws:lambda:us-west-2:1:function:f:$LATEST/durable-execution/exec-1/invocation-1";
     private static final Instant START = Instant.parse("2026-08-05T00:00:00Z");
 
-    private static final class CapturingExporter implements InsightExporter {
+    private static class CapturingExporter implements InsightExporter {
         final List<WorkflowInsightRecord> records = new CopyOnWriteArrayList<>();
         final List<Thread> threads = new CopyOnWriteArrayList<>();
         volatile int flushes;
@@ -114,6 +116,49 @@ class WorkflowInsightHookTest {
         assertTrue(exporter.records.subList(0, exporter.records.size() - 1).stream()
                 .allMatch(r -> "RUNNING".equals(r.status())));
         assertTrue(exporter.threads.stream().noneMatch(t -> t == Thread.currentThread()));
+        assertEquals(1, exporter.flushes);
+    }
+
+    @Test
+    void changeHookArrivingWhileTheEndRecordDrainsCannotFollowOrReplaceIt() throws Exception {
+        var exportingFinal = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        var exporter = new CapturingExporter() {
+            @Override
+            public void export(WorkflowInsightRecord record) {
+                super.export(record);
+                if ("SUCCEEDED".equals(record.status())) {
+                    exportingFinal.countDown();
+                    try {
+                        assertTrue(release.await(5, TimeUnit.SECONDS));
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    }
+                }
+            }
+        };
+        var plugin = (WorkflowInsight.InsightPlugin) WorkflowInsight.workflowInsight(WorkflowInsightConfig.builder()
+                .emitMode(WorkflowInsightConfig.EmitMode.ON_CHANGE)
+                .addExporter(exporter)
+                .build());
+
+        plugin.onInvocationStart(start(true));
+        plugin.drainExports();
+
+        // The end hook blocks in its drain while the final record is being exported; the change hook arrives then,
+        // as it does when a checkpoint for an unawaited asynchronous operation completes during invocation end.
+        var ending = new Thread(() -> plugin.onInvocationEnd(end(InvocationStatus.SUCCEEDED, "out", null)));
+        ending.start();
+        assertTrue(exportingFinal.await(5, TimeUnit.SECONDS));
+        plugin.onOperationChange(new OperationChangeInfo(
+                "req", ARN, ops("greet", OperationStatus.SUCCEEDED), ops("greet", OperationStatus.SUCCEEDED)));
+        release.countDown();
+        ending.join(5_000);
+        assertFalse(ending.isAlive());
+
+        assertEquals(2, exporter.records.size(), "start snapshot + final record; the late change is dropped");
+        assertEquals("RUNNING", exporter.records.get(0).status());
+        assertEquals("SUCCEEDED", exporter.records.get(1).status());
         assertEquals(1, exporter.flushes);
     }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

No linked issue. Supersedes the alternative approach in #699, which stays open only for comparison.

### Description

Workflow Insight exporters ran inline inside the plugin hooks. In `ON_CHANGE` mode that put exporter I/O on the SDK threads that deliver checkpoint callbacks, so a slow exporter slowed the execution.

Records are now handed to a background scheduler. It exports at most one record at a time. Each record is a complete snapshot of the execution, so while an export is in flight newer updates coalesce into a single pending slot and only the latest one is exported next. Exporters for one record run concurrently and independently, so one failing or slow exporter never blocks the others.

`onInvocationEnd` is the hook the SDK awaits. It schedules the final record, waits for the scheduler to drain, and then flushes every exporter once. The final record is therefore always delivered before the invocation returns. If no worker can be started, the drain exports the pending record itself at that boundary, so nothing is silently dropped.

Behavior changes visible to exporters:
- `export()` runs on a worker thread, never on a hook thread.
- `flush()` is called once per invocation end (including non-terminal suspends), instead of after every `export()`.
- Intermediate `RUNNING` snapshots may be superseded by a newer snapshot while an export is in flight.

### Demo/Screenshots

N/A. Behavior is covered by unit tests.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Yes. `ExportSchedulerTest` (new, 11 tests) covers: exports run off the scheduling thread; updates arriving before or during an export collapse into the latest record; a record scheduled after a pump finishes starts a new pump; `drain()` is idempotent when idle and blocks until the in-flight and pending records are exported; a failing exporter never blocks the others for the same record; exporters for one record run concurrently; when no worker can be started the pending record is exported inline by `drain()` and a later `schedule()` retries the worker.

`WorkflowInsightHookTest` adds plugin-level coverage: bursts coalesce with the final record always delivered last and never on the hook thread; exporters are flushed once per invocation end even when nothing was emitted. Existing tests that read records right after `onInvocationStart` now drain through a package-private seam.

`mvn clean verify` passes across all modules. The concurrency-sensitive tests were repeated 8 times with no failures.

#### Integration Tests

No new integration tests. The existing `LocalDurableTestRunner`-based tests in `WorkflowInsightPluginTest` and `TransformContractTest` exercise the plugin end to end and still pass.

#### Examples

N/A. No public API change.
